### PR TITLE
Fixes Bug: Label Text with whitespace doesn't show "Off" and stays empty

### DIFF
--- a/lib/app/modules/addOrUpdateAlarm/views/label_tile.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/label_tile.dart
@@ -82,12 +82,12 @@ class LabelTile extends StatelessWidget {
                   width: 100,
                   alignment: Alignment.centerRight,
                   child: Text(
-                    (controller.label.value.length > 0)
+                    (controller.label.value.trim().isNotEmpty)
                         ? controller.label.value
                         : 'Off',
                     overflow: TextOverflow.ellipsis,
                     style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                          color: (controller.label.value.isEmpty)
+                          color: (controller.label.value.trim().isEmpty)
                               ? kprimaryDisabledTextColor
                               : kprimaryTextColor,
                         ),
@@ -95,7 +95,7 @@ class LabelTile extends StatelessWidget {
                 )),
             Icon(
               Icons.chevron_right,
-              color: (controller.label.value.isEmpty)
+              color: (controller.label.value.trim().isEmpty)
                   ? kprimaryDisabledTextColor
                   : kprimaryTextColor,
             )


### PR DESCRIPTION
### Description
So first of all the issue was that whenever the user is not entering any character then the label tile is showing `Off`, but when the user is entering any whitespace character then the label tile is showing nothing there. It must show `Off` at that time too. 

So instead of using `controller.label.value.count`, I'm trimming the `label text` on the go while checking. It will remove the whitespace at the front and back of the `label text`. 

### Proposed Changes
- Changed the implementation of checking for empty `label text`.

## Fixes #51 

## Screenshots

https://github.com/CCExtractor/ultimate_alarm_clock/assets/92971894/f8dad149-73ac-4b5a-9c7a-837edd031b7a


