### PR TITLE
Fix: Alarm Tile will not allow take whitespaces  #65

### DIFF
--- a/lib/app/modules/addOrUpdateAlarm/views/label_tile.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/label_tile.dart
@@ -21,7 +21,7 @@ class LabelTile extends StatelessWidget {
         style: TextStyle(color: kprimaryTextColor),
       ),
       onTap: () {
-       Utils.hapticFeedback();
+        Utils.hapticFeedback();
         Get.defaultDialog(
           title: "Enter a name",
           titlePadding: const EdgeInsets.fromLTRB(0, 21, 0, 0),
@@ -54,6 +54,11 @@ class LabelTile extends StatelessWidget {
                     .textTheme
                     .bodyLarge!
                     .copyWith(color: kprimaryDisabledTextColor)),
+            onChanged: (text) {
+              if (text.trim().isEmpty) {
+                controller.labelController.text = "";
+              }
+            },
           ),
           buttonColor: ksecondaryBackgroundColor,
           confirm: TextButton(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -181,10 +181,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.17.2"
   convert:
     dependency: transitive
     description:
@@ -652,18 +652,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
@@ -1033,10 +1033,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
@@ -1081,10 +1081,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.6.0"
   time:
     dependency: transitive
     description:
@@ -1253,6 +1253,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
   web_socket_channel:
     dependency: transitive
     description:
@@ -1318,5 +1326,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.0.0-0 <4.0.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
   flutter: ">=3.7.0"


### PR DESCRIPTION
### Description
when user gives space it will ignore whitespace

### Proposed Changes
some puspec.yaml files version got updated and the fix of wihtespace is in alarm tile is set when user will press space it automaticall ignore the space and accept it has some word

## Fixes #65 



## Screenshots

<!-- If applicable, add screenshots or images demonstrating the changes made -->
![Screenshot_1694473801](https://github.com/CCExtractor/ultimate_alarm_clock/assets/63517775/7f2a4273-38e8-4b92-aa16-e8c24c12607d)
![Screenshot_1694473937](https://github.com/CCExtractor/ultimate_alarm_clock/assets/63517775/77d3f60d-c6d0-46b4-8f0e-b019b0a21008)

## Checklist

<!-- Mark the completed tasks with [x] -->
- [x ] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [ x] Code follows the established coding style guidelines
- [x ] All tests are passing