### PR TITLE
Feature: Restricted the Landscape Mode

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/services.dart';
 
 import 'package:get/get.dart';
 import 'package:ultimate_alarm_clock/app/utils/constants.dart';
@@ -9,6 +10,12 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   await Firebase.initializeApp();
+
+  SystemChrome.setPreferredOrientations([
+    DeviceOrientation.portraitUp,
+    DeviceOrientation.portraitDown,
+  ]);
+
   runApp(
     GetMaterialApp(
       theme: kThemeData,


### PR DESCRIPTION
### Description
I've restricted the landscape mode in this application. So if the user rotates the phone to any horizontal orientation, the app will not rotate and will stay in portrait mode. 

### Proposed Changes
- I've used the SystemChrome services and added those in the `main.dart` file. 

## Fixes #75

## Screenshots

_Please open the image for a better view._

<a href="https://ibb.co/ZMNFb3Z"><img src="https://i.ibb.co/ZMNFb3Z/Whats-App-Image-2023-09-24-at-6-21-13-PM.jpg" alt="Whats-App-Image-2023-09-24-at-6-21-13-PM" border="0"></a>