### PR TITLE
Feature: Implemented Select Multiple Alarms to Delete on Holding an Alarm

### DIFF
--- a/lib/app/data/models/alarm_model.dart
+++ b/lib/app/data/models/alarm_model.dart
@@ -41,8 +41,6 @@ class AlarmModel {
   late String label;
   late bool isOneTime;
   late int snoozeDuration;
-  late bool isHolded;
-  late bool isSelected;
   @ignore
   Map? offsetDetails;
 
@@ -77,8 +75,6 @@ class AlarmModel {
     required this.label,
     required this.isOneTime,
     required this.snoozeDuration,
-    this.isHolded = false,
-    this.isSelected = false,
   });
 
   AlarmModel.fromDocumentSnapshot(

--- a/lib/app/data/models/alarm_model.dart
+++ b/lib/app/data/models/alarm_model.dart
@@ -41,40 +41,45 @@ class AlarmModel {
   late String label;
   late bool isOneTime;
   late int snoozeDuration;
+  late bool isHolded;
+  late bool isSelected;
   @ignore
   Map? offsetDetails;
 
-  AlarmModel(
-      {required this.alarmTime,
-      required this.alarmID,
-      this.sharedUserIds = const [],
-      required this.ownerId,
-      required this.ownerName,
-      required this.lastEditedUserId,
-      required this.mutexLock,
-      this.isEnabled = true,
-      required this.days,
-      required this.intervalToAlarm,
-      required this.isActivityEnabled,
-      required this.minutesSinceMidnight,
-      required this.isLocationEnabled,
-      required this.isSharedAlarmEnabled,
-      required this.isWeatherEnabled,
-      required this.location,
-      required this.weatherTypes,
-      required this.isMathsEnabled,
-      required this.mathsDifficulty,
-      required this.numMathsQuestions,
-      required this.isShakeEnabled,
-      required this.shakeTimes,
-      required this.isQrEnabled,
-      required this.qrValue,
-      required this.activityInterval,
-      this.offsetDetails = const {},
-      required this.mainAlarmTime,
-      required this.label,
-      required this.isOneTime,
-      required this.snoozeDuration});
+  AlarmModel({
+    required this.alarmTime,
+    required this.alarmID,
+    this.sharedUserIds = const [],
+    required this.ownerId,
+    required this.ownerName,
+    required this.lastEditedUserId,
+    required this.mutexLock,
+    this.isEnabled = true,
+    required this.days,
+    required this.intervalToAlarm,
+    required this.isActivityEnabled,
+    required this.minutesSinceMidnight,
+    required this.isLocationEnabled,
+    required this.isSharedAlarmEnabled,
+    required this.isWeatherEnabled,
+    required this.location,
+    required this.weatherTypes,
+    required this.isMathsEnabled,
+    required this.mathsDifficulty,
+    required this.numMathsQuestions,
+    required this.isShakeEnabled,
+    required this.shakeTimes,
+    required this.isQrEnabled,
+    required this.qrValue,
+    required this.activityInterval,
+    this.offsetDetails = const {},
+    required this.mainAlarmTime,
+    required this.label,
+    required this.isOneTime,
+    required this.snoozeDuration,
+    this.isHolded = false,
+    this.isSelected = false,
+  });
 
   AlarmModel.fromDocumentSnapshot(
       {required DocumentSnapshot documentSnapshot, required UserModel? user}) {

--- a/lib/app/modules/home/controllers/home_controller.dart
+++ b/lib/app/modules/home/controllers/home_controller.dart
@@ -16,6 +16,13 @@ import 'package:ultimate_alarm_clock/app/data/providers/secure_storage_provider.
 import 'package:ultimate_alarm_clock/app/modules/settings/controllers/settings_controller.dart';
 import 'package:ultimate_alarm_clock/app/utils/utils.dart';
 
+class Pair<T, U> {
+  final T first;
+  final U second;
+
+  Pair(this.first, this.second);
+}
+
 class HomeController extends GetxController with AlarmHandlerSetupModel {
   Stream<QuerySnapshot>? firestoreStreamAlarms;
   Stream<QuerySnapshot>? sharedAlarmsStream;
@@ -43,6 +50,9 @@ class HomeController extends GetxController with AlarmHandlerSetupModel {
   RxDouble scalingFactor = 1.0.obs;
 
   RxBool isSortedAlarmListEnabled = true.obs;
+  RxBool inMultipleSelectMode = false.obs;
+
+  Set<Pair<dynamic, bool>> selectedAlarmSet = {};
 
   loginWithGoogle() async {
     // Logging in again to ensure right details if User has linked account
@@ -189,7 +199,8 @@ class HomeController extends GetxController with AlarmHandlerSetupModel {
     super.onInit();
     if (!isUserSignedIn.value) await loginWithGoogle();
 
-    isSortedAlarmListEnabled.value = await SecureStorageProvider().readSortedAlarmListValue(key: 'sorted_alarm_list');
+    isSortedAlarmListEnabled.value = await SecureStorageProvider()
+        .readSortedAlarmListValue(key: 'sorted_alarm_list');
 
     scrollController.addListener(() {
       final offset = scrollController.offset;

--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -20,6 +20,8 @@ class HomeView extends GetView<HomeController> {
 
   ThemeController themeController = Get.find<ThemeController>();
 
+  RxBool isHolded = false.obs;
+
   @override
   Widget build(BuildContext context) {
     var width = Get.width;
@@ -442,131 +444,127 @@ class HomeView extends GetView<HomeController> {
                                                 Utils.getRepeatDays(alarm.days);
                                             // Main card
                                             return Obx(
-                                              () => InkWell(
+                                              () => GestureDetector(
                                                 onTap: () {
                                                   Utils.hapticFeedback();
                                                   Get.toNamed(
                                                       '/add-update-alarm',
                                                       arguments: alarm);
                                                 },
-                                                child: Center(
-                                                  child: Padding(
-                                                    padding: const EdgeInsets
-                                                            .symmetric(
-                                                        horizontal: 10.0),
-                                                    child: Card(
-                                                      color: themeController
-                                                              .isLightMode.value
-                                                          ? kLightSecondaryBackgroundColor
-                                                          : ksecondaryBackgroundColor,
-                                                      shape:
-                                                          RoundedRectangleBorder(
-                                                        borderRadius:
-                                                            BorderRadius
-                                                                .circular(18),
-                                                      ),
-                                                      child: Center(
-                                                        child: Padding(
-                                                          padding:
-                                                              EdgeInsets.only(
-                                                            left: 25.0,
-                                                            top: Utils.isChallengeEnabled(
-                                                                        alarm) ||
-                                                                    Utils.isAutoDismissalEnabled(
-                                                                        alarm)
-                                                                ? 8.0
-                                                                : 0.0,
-                                                            bottom: Utils.isChallengeEnabled(
-                                                                        alarm) ||
-                                                                    Utils.isAutoDismissalEnabled(
-                                                                        alarm)
-                                                                ? 8.0
-                                                                : 0.0,
-                                                          ),
-                                                          child: Row(
-                                                            mainAxisAlignment:
-                                                                MainAxisAlignment
-                                                                    .start,
-                                                            children: [
-                                                              Expanded(
-                                                                flex: 3,
-                                                                child: Column(
-                                                                  mainAxisAlignment:
-                                                                      MainAxisAlignment
-                                                                          .center,
-                                                                  crossAxisAlignment:
-                                                                      CrossAxisAlignment
-                                                                          .start,
-                                                                  children: [
-                                                                    IntrinsicHeight(
-                                                                      child: Row(
-                                                                          children: [
-                                                                            Text(
-                                                                              repeatDays.replaceAll("Never", "One Time"),
-                                                                              style: Theme.of(context).textTheme.bodySmall!.copyWith(
-                                                                                    fontWeight: FontWeight.w500,
-                                                                                    color: alarm.isEnabled == true
-                                                                                        ? kprimaryColor
-                                                                                        : themeController.isLightMode.value
-                                                                                            ? kLightPrimaryDisabledTextColor
-                                                                                            : kprimaryDisabledTextColor,
-                                                                                  ),
-                                                                            ),
-                                                                            if (alarm.label!.isNotEmpty)
-                                                                              VerticalDivider(
-                                                                                color: alarm.isEnabled == true
-                                                                                    ? kprimaryColor
-                                                                                    : themeController.isLightMode.value
-                                                                                        ? kLightPrimaryDisabledTextColor
-                                                                                        : kprimaryDisabledTextColor,
-                                                                                thickness: 1.4,
-                                                                                width: 6,
-                                                                                indent: 3.1,
-                                                                                endIndent: 3.1,
-                                                                              ),
-                                                                            Expanded(
-                                                                              child: Container(
-                                                                                child: Text(
-                                                                                  alarm.label,
-                                                                                  overflow: TextOverflow.ellipsis, // Set overflow property here
-                                                                                  style: Theme.of(context).textTheme.bodySmall!.copyWith(
-                                                                                        fontWeight: FontWeight.w500,
-                                                                                        color: alarm.isEnabled == true
-                                                                                            ? kprimaryColor
-                                                                                            : themeController.isLightMode.value
-                                                                                                ? kLightPrimaryDisabledTextColor
-                                                                                                : kprimaryDisabledTextColor,
-                                                                                      ),
-                                                                                ),
-                                                                              ),
-                                                                            )
-                                                                          ]),
-                                                                    ),
-                                                                    Row(
-                                                                      children: [
-                                                                        Text(
-                                                                          time12[
-                                                                              0],
-                                                                          style: Theme.of(context)
-                                                                              .textTheme
-                                                                              .displayLarge!
-                                                                              .copyWith(
-                                                                                color: alarm.isEnabled == true
-                                                                                    ? themeController.isLightMode.value
-                                                                                        ? kLightPrimaryTextColor
-                                                                                        : kprimaryTextColor
-                                                                                    : themeController.isLightMode.value
-                                                                                        ? kLightPrimaryDisabledTextColor
-                                                                                        : kprimaryDisabledTextColor,
-                                                                              ),
-                                                                        ),
-                                                                        Padding(
-                                                                          padding:
-                                                                              const EdgeInsets.symmetric(horizontal: 3.0),
-                                                                          child:
+                                                onLongPress: () {
+                                                  isHolded.value = true;
+                                                  Utils.hapticFeedback();
+                                                },
+                                                onLongPressEnd: (details) {
+                                                  isHolded.value = false;
+                                                },
+                                                child: AnimatedContainer(
+                                                  duration: const Duration(
+                                                    milliseconds: 300,
+                                                  ),
+                                                  curve: Curves.easeInOut,
+                                                  margin: EdgeInsets.all(
+                                                    isHolded.value ? 8 : 0,
+                                                  ),
+                                                  child: Center(
+                                                    child: Padding(
+                                                      padding: const EdgeInsets
+                                                              .symmetric(
+                                                          horizontal: 10.0),
+                                                      child: Card(
+                                                        color: themeController
+                                                                .isLightMode
+                                                                .value
+                                                            ? kLightSecondaryBackgroundColor
+                                                            : ksecondaryBackgroundColor,
+                                                        shape:
+                                                            RoundedRectangleBorder(
+                                                          borderRadius:
+                                                              BorderRadius
+                                                                  .circular(18),
+                                                        ),
+                                                        child: Center(
+                                                          child: Padding(
+                                                            padding:
+                                                                EdgeInsets.only(
+                                                              left: 25.0,
+                                                              top: Utils.isChallengeEnabled(
+                                                                          alarm) ||
+                                                                      Utils.isAutoDismissalEnabled(
+                                                                          alarm)
+                                                                  ? 8.0
+                                                                  : 0.0,
+                                                              bottom: Utils.isChallengeEnabled(
+                                                                          alarm) ||
+                                                                      Utils.isAutoDismissalEnabled(
+                                                                          alarm)
+                                                                  ? 8.0
+                                                                  : 0.0,
+                                                            ),
+                                                            child: Row(
+                                                              mainAxisAlignment:
+                                                                  MainAxisAlignment
+                                                                      .start,
+                                                              children: [
+                                                                Expanded(
+                                                                  flex: 3,
+                                                                  child: Column(
+                                                                    mainAxisAlignment:
+                                                                        MainAxisAlignment
+                                                                            .center,
+                                                                    crossAxisAlignment:
+                                                                        CrossAxisAlignment
+                                                                            .start,
+                                                                    children: [
+                                                                      IntrinsicHeight(
+                                                                        child: Row(
+                                                                            children: [
                                                                               Text(
-                                                                            time12[1],
-                                                                            style: Theme.of(context).textTheme.displayMedium!.copyWith(
+                                                                                repeatDays.replaceAll("Never", "One Time"),
+                                                                                style: Theme.of(context).textTheme.bodySmall!.copyWith(
+                                                                                      fontWeight: FontWeight.w500,
+                                                                                      color: alarm.isEnabled == true
+                                                                                          ? kprimaryColor
+                                                                                          : themeController.isLightMode.value
+                                                                                              ? kLightPrimaryDisabledTextColor
+                                                                                              : kprimaryDisabledTextColor,
+                                                                                    ),
+                                                                              ),
+                                                                              if (alarm.label!.isNotEmpty)
+                                                                                VerticalDivider(
+                                                                                  color: alarm.isEnabled == true
+                                                                                      ? kprimaryColor
+                                                                                      : themeController.isLightMode.value
+                                                                                          ? kLightPrimaryDisabledTextColor
+                                                                                          : kprimaryDisabledTextColor,
+                                                                                  thickness: 1.4,
+                                                                                  width: 6,
+                                                                                  indent: 3.1,
+                                                                                  endIndent: 3.1,
+                                                                                ),
+                                                                              Expanded(
+                                                                                child: Container(
+                                                                                  child: Text(
+                                                                                    alarm.label,
+                                                                                    overflow: TextOverflow.ellipsis, // Set overflow property here
+                                                                                    style: Theme.of(context).textTheme.bodySmall!.copyWith(
+                                                                                          fontWeight: FontWeight.w500,
+                                                                                          color: alarm.isEnabled == true
+                                                                                              ? kprimaryColor
+                                                                                              : themeController.isLightMode.value
+                                                                                                  ? kLightPrimaryDisabledTextColor
+                                                                                                  : kprimaryDisabledTextColor,
+                                                                                        ),
+                                                                                  ),
+                                                                                ),
+                                                                              )
+                                                                            ]),
+                                                                      ),
+                                                                      Row(
+                                                                        children: [
+                                                                          Text(
+                                                                            time12[0],
+                                                                            style: Theme.of(context).textTheme.displayLarge!.copyWith(
                                                                                   color: alarm.isEnabled == true
                                                                                       ? themeController.isLightMode.value
                                                                                           ? kLightPrimaryTextColor
@@ -576,248 +574,248 @@ class HomeView extends GetView<HomeController> {
                                                                                           : kprimaryDisabledTextColor,
                                                                                 ),
                                                                           ),
-                                                                        ),
-                                                                      ],
-                                                                    ),
-                                                                    if (Utils.isChallengeEnabled(alarm) ||
-                                                                        Utils.isAutoDismissalEnabled(
-                                                                            alarm) ||
-                                                                        alarm
-                                                                            .isSharedAlarmEnabled)
-                                                                      Row(
-                                                                        mainAxisAlignment:
-                                                                            MainAxisAlignment.start,
-                                                                        children: [
-                                                                          if (alarm
-                                                                              .isSharedAlarmEnabled)
-                                                                            Padding(
-                                                                              padding: const EdgeInsets.symmetric(horizontal: 3.0),
-                                                                              child: Icon(
-                                                                                Icons.share_arrival_time,
-                                                                                size: 24,
-                                                                                color: alarm.isEnabled == true
-                                                                                    ? themeController.isLightMode.value
-                                                                                        ? kLightPrimaryTextColor.withOpacity(0.5)
-                                                                                        : kprimaryTextColor.withOpacity(0.5)
-                                                                                    : themeController.isLightMode.value
-                                                                                        ? kLightPrimaryDisabledTextColor
-                                                                                        : kprimaryDisabledTextColor,
-                                                                              ),
+                                                                          Padding(
+                                                                            padding:
+                                                                                const EdgeInsets.symmetric(horizontal: 3.0),
+                                                                            child:
+                                                                                Text(
+                                                                              time12[1],
+                                                                              style: Theme.of(context).textTheme.displayMedium!.copyWith(
+                                                                                    color: alarm.isEnabled == true
+                                                                                        ? themeController.isLightMode.value
+                                                                                            ? kLightPrimaryTextColor
+                                                                                            : kprimaryTextColor
+                                                                                        : themeController.isLightMode.value
+                                                                                            ? kLightPrimaryDisabledTextColor
+                                                                                            : kprimaryDisabledTextColor,
+                                                                                  ),
                                                                             ),
-                                                                          if (alarm
-                                                                              .isLocationEnabled)
-                                                                            Padding(
-                                                                              padding: const EdgeInsets.symmetric(horizontal: 3.0),
-                                                                              child: Icon(
-                                                                                Icons.location_pin,
-                                                                                size: 24,
-                                                                                color: alarm.isEnabled == true
-                                                                                    ? themeController.isLightMode.value
-                                                                                        ? kLightPrimaryTextColor.withOpacity(0.5)
-                                                                                        : kprimaryTextColor.withOpacity(0.5)
-                                                                                    : themeController.isLightMode.value
-                                                                                        ? kLightPrimaryDisabledTextColor
-                                                                                        : kprimaryDisabledTextColor,
-                                                                              ),
-                                                                            ),
-                                                                          if (alarm
-                                                                              .isActivityEnabled)
-                                                                            Padding(
-                                                                              padding: const EdgeInsets.symmetric(horizontal: 3.0),
-                                                                              child: Icon(
-                                                                                Icons.screen_lock_portrait,
-                                                                                size: 24,
-                                                                                color: alarm.isEnabled == true
-                                                                                    ? themeController.isLightMode.value
-                                                                                        ? kLightPrimaryTextColor.withOpacity(0.5)
-                                                                                        : kprimaryTextColor.withOpacity(0.5)
-                                                                                    : themeController.isLightMode.value
-                                                                                        ? kLightPrimaryDisabledTextColor
-                                                                                        : kprimaryDisabledTextColor,
-                                                                              ),
-                                                                            ),
-                                                                          if (alarm
-                                                                              .isWeatherEnabled)
-                                                                            Padding(
-                                                                              padding: const EdgeInsets.symmetric(horizontal: 3.0),
-                                                                              child: Icon(
-                                                                                Icons.cloudy_snowing,
-                                                                                size: 24,
-                                                                                color: alarm.isEnabled == true
-                                                                                    ? themeController.isLightMode.value
-                                                                                        ? kLightPrimaryTextColor.withOpacity(0.5)
-                                                                                        : kprimaryTextColor.withOpacity(0.5)
-                                                                                    : themeController.isLightMode.value
-                                                                                        ? kLightPrimaryDisabledTextColor
-                                                                                        : kprimaryDisabledTextColor,
-                                                                              ),
-                                                                            ),
-                                                                          if (alarm
-                                                                              .isQrEnabled)
-                                                                            Padding(
-                                                                              padding: const EdgeInsets.symmetric(horizontal: 3.0),
-                                                                              child: Icon(
-                                                                                Icons.qr_code_scanner,
-                                                                                size: 24,
-                                                                                color: alarm.isEnabled == true
-                                                                                    ? themeController.isLightMode.value
-                                                                                        ? kLightPrimaryTextColor.withOpacity(0.5)
-                                                                                        : kprimaryTextColor.withOpacity(0.5)
-                                                                                    : themeController.isLightMode.value
-                                                                                        ? kLightPrimaryDisabledTextColor
-                                                                                        : kprimaryDisabledTextColor,
-                                                                              ),
-                                                                            ),
-                                                                          if (alarm
-                                                                              .isShakeEnabled)
-                                                                            Padding(
-                                                                              padding: const EdgeInsets.symmetric(horizontal: 3.0),
-                                                                              child: Icon(
-                                                                                Icons.vibration,
-                                                                                size: 24,
-                                                                                color: alarm.isEnabled == true
-                                                                                    ? themeController.isLightMode.value
-                                                                                        ? kLightPrimaryTextColor.withOpacity(0.5)
-                                                                                        : kprimaryTextColor.withOpacity(0.5)
-                                                                                    : themeController.isLightMode.value
-                                                                                        ? kLightPrimaryDisabledTextColor
-                                                                                        : kprimaryDisabledTextColor,
-                                                                              ),
-                                                                            ),
-                                                                          if (alarm
-                                                                              .isMathsEnabled)
-                                                                            Padding(
-                                                                              padding: const EdgeInsets.symmetric(horizontal: 3.0),
-                                                                              child: Icon(
-                                                                                Icons.calculate,
-                                                                                size: 24,
-                                                                                color: alarm.isEnabled == true
-                                                                                    ? themeController.isLightMode.value
-                                                                                        ? kLightPrimaryTextColor.withOpacity(0.5)
-                                                                                        : kprimaryTextColor.withOpacity(0.5)
-                                                                                    : themeController.isLightMode.value
-                                                                                        ? kLightPrimaryDisabledTextColor
-                                                                                        : kprimaryDisabledTextColor,
-                                                                              ),
-                                                                            ),
+                                                                          ),
                                                                         ],
                                                                       ),
-                                                                  ],
+                                                                      if (Utils.isChallengeEnabled(alarm) ||
+                                                                          Utils.isAutoDismissalEnabled(
+                                                                              alarm) ||
+                                                                          alarm
+                                                                              .isSharedAlarmEnabled)
+                                                                        Row(
+                                                                          mainAxisAlignment:
+                                                                              MainAxisAlignment.start,
+                                                                          children: [
+                                                                            if (alarm.isSharedAlarmEnabled)
+                                                                              Padding(
+                                                                                padding: const EdgeInsets.symmetric(horizontal: 3.0),
+                                                                                child: Icon(
+                                                                                  Icons.share_arrival_time,
+                                                                                  size: 24,
+                                                                                  color: alarm.isEnabled == true
+                                                                                      ? themeController.isLightMode.value
+                                                                                          ? kLightPrimaryTextColor.withOpacity(0.5)
+                                                                                          : kprimaryTextColor.withOpacity(0.5)
+                                                                                      : themeController.isLightMode.value
+                                                                                          ? kLightPrimaryDisabledTextColor
+                                                                                          : kprimaryDisabledTextColor,
+                                                                                ),
+                                                                              ),
+                                                                            if (alarm.isLocationEnabled)
+                                                                              Padding(
+                                                                                padding: const EdgeInsets.symmetric(horizontal: 3.0),
+                                                                                child: Icon(
+                                                                                  Icons.location_pin,
+                                                                                  size: 24,
+                                                                                  color: alarm.isEnabled == true
+                                                                                      ? themeController.isLightMode.value
+                                                                                          ? kLightPrimaryTextColor.withOpacity(0.5)
+                                                                                          : kprimaryTextColor.withOpacity(0.5)
+                                                                                      : themeController.isLightMode.value
+                                                                                          ? kLightPrimaryDisabledTextColor
+                                                                                          : kprimaryDisabledTextColor,
+                                                                                ),
+                                                                              ),
+                                                                            if (alarm.isActivityEnabled)
+                                                                              Padding(
+                                                                                padding: const EdgeInsets.symmetric(horizontal: 3.0),
+                                                                                child: Icon(
+                                                                                  Icons.screen_lock_portrait,
+                                                                                  size: 24,
+                                                                                  color: alarm.isEnabled == true
+                                                                                      ? themeController.isLightMode.value
+                                                                                          ? kLightPrimaryTextColor.withOpacity(0.5)
+                                                                                          : kprimaryTextColor.withOpacity(0.5)
+                                                                                      : themeController.isLightMode.value
+                                                                                          ? kLightPrimaryDisabledTextColor
+                                                                                          : kprimaryDisabledTextColor,
+                                                                                ),
+                                                                              ),
+                                                                            if (alarm.isWeatherEnabled)
+                                                                              Padding(
+                                                                                padding: const EdgeInsets.symmetric(horizontal: 3.0),
+                                                                                child: Icon(
+                                                                                  Icons.cloudy_snowing,
+                                                                                  size: 24,
+                                                                                  color: alarm.isEnabled == true
+                                                                                      ? themeController.isLightMode.value
+                                                                                          ? kLightPrimaryTextColor.withOpacity(0.5)
+                                                                                          : kprimaryTextColor.withOpacity(0.5)
+                                                                                      : themeController.isLightMode.value
+                                                                                          ? kLightPrimaryDisabledTextColor
+                                                                                          : kprimaryDisabledTextColor,
+                                                                                ),
+                                                                              ),
+                                                                            if (alarm.isQrEnabled)
+                                                                              Padding(
+                                                                                padding: const EdgeInsets.symmetric(horizontal: 3.0),
+                                                                                child: Icon(
+                                                                                  Icons.qr_code_scanner,
+                                                                                  size: 24,
+                                                                                  color: alarm.isEnabled == true
+                                                                                      ? themeController.isLightMode.value
+                                                                                          ? kLightPrimaryTextColor.withOpacity(0.5)
+                                                                                          : kprimaryTextColor.withOpacity(0.5)
+                                                                                      : themeController.isLightMode.value
+                                                                                          ? kLightPrimaryDisabledTextColor
+                                                                                          : kprimaryDisabledTextColor,
+                                                                                ),
+                                                                              ),
+                                                                            if (alarm.isShakeEnabled)
+                                                                              Padding(
+                                                                                padding: const EdgeInsets.symmetric(horizontal: 3.0),
+                                                                                child: Icon(
+                                                                                  Icons.vibration,
+                                                                                  size: 24,
+                                                                                  color: alarm.isEnabled == true
+                                                                                      ? themeController.isLightMode.value
+                                                                                          ? kLightPrimaryTextColor.withOpacity(0.5)
+                                                                                          : kprimaryTextColor.withOpacity(0.5)
+                                                                                      : themeController.isLightMode.value
+                                                                                          ? kLightPrimaryDisabledTextColor
+                                                                                          : kprimaryDisabledTextColor,
+                                                                                ),
+                                                                              ),
+                                                                            if (alarm.isMathsEnabled)
+                                                                              Padding(
+                                                                                padding: const EdgeInsets.symmetric(horizontal: 3.0),
+                                                                                child: Icon(
+                                                                                  Icons.calculate,
+                                                                                  size: 24,
+                                                                                  color: alarm.isEnabled == true
+                                                                                      ? themeController.isLightMode.value
+                                                                                          ? kLightPrimaryTextColor.withOpacity(0.5)
+                                                                                          : kprimaryTextColor.withOpacity(0.5)
+                                                                                      : themeController.isLightMode.value
+                                                                                          ? kLightPrimaryDisabledTextColor
+                                                                                          : kprimaryDisabledTextColor,
+                                                                                ),
+                                                                              ),
+                                                                          ],
+                                                                        ),
+                                                                    ],
+                                                                  ),
                                                                 ),
-                                                              ),
-                                                              Padding(
-                                                                padding: const EdgeInsets
-                                                                        .symmetric(
-                                                                    horizontal:
-                                                                        10.0),
-                                                                child: Column(
-                                                                  mainAxisAlignment:
-                                                                      MainAxisAlignment
-                                                                          .center,
-                                                                  children: [
-                                                                    Expanded(
-                                                                      flex: 0,
-                                                                      child: Switch
-                                                                          .adaptive(
-                                                                        activeColor:
-                                                                            ksecondaryColor,
-                                                                        value: alarm
-                                                                            .isEnabled,
-                                                                        onChanged:
-                                                                            (bool
-                                                                                value) async {
-                                                                          Utils
-                                                                              .hapticFeedback();
-                                                                          alarm.isEnabled =
-                                                                              value;
-
-                                                                          if (alarm.isSharedAlarmEnabled ==
-                                                                              true) {
-                                                                            await FirestoreDb.updateAlarm(alarm.ownerId,
-                                                                                alarm);
-                                                                          } else {
-                                                                            await IsarDb.updateAlarm(alarm);
-                                                                          }
-                                                                          controller.refreshTimer =
-                                                                              true;
-                                                                          controller
-                                                                              .refreshUpcomingAlarms();
-                                                                        },
-                                                                      ),
-                                                                    ),
-                                                                    Expanded(
-                                                                      flex: 0,
-                                                                      child:
-                                                                          PopupMenuButton(
-                                                                        onSelected:
-                                                                            (value) async {
-                                                                          Utils
-                                                                              .hapticFeedback();
-                                                                          if (value ==
-                                                                              0) {
-                                                                            Get.back();
-                                                                            Get.offNamed('/alarm-ring',
-                                                                                arguments: alarm);
-                                                                          } else if (value ==
-                                                                              1) {
-                                                                            print(alarm.isSharedAlarmEnabled);
+                                                                Padding(
+                                                                  padding: const EdgeInsets
+                                                                          .symmetric(
+                                                                      horizontal:
+                                                                          10.0),
+                                                                  child: Column(
+                                                                    mainAxisAlignment:
+                                                                        MainAxisAlignment
+                                                                            .center,
+                                                                    children: [
+                                                                      Expanded(
+                                                                        flex: 0,
+                                                                        child: Switch
+                                                                            .adaptive(
+                                                                          activeColor:
+                                                                              ksecondaryColor,
+                                                                          value:
+                                                                              alarm.isEnabled,
+                                                                          onChanged:
+                                                                              (bool value) async {
+                                                                            Utils.hapticFeedback();
+                                                                            alarm.isEnabled =
+                                                                                value;
 
                                                                             if (alarm.isSharedAlarmEnabled ==
                                                                                 true) {
-                                                                              await FirestoreDb.deleteAlarm(controller.userModel.value, alarm.firestoreId!);
+                                                                              await FirestoreDb.updateAlarm(alarm.ownerId, alarm);
                                                                             } else {
-                                                                              await IsarDb.deleteAlarm(alarm.isarId);
+                                                                              await IsarDb.updateAlarm(alarm);
                                                                             }
-
                                                                             controller.refreshTimer =
                                                                                 true;
                                                                             controller.refreshUpcomingAlarms();
-                                                                          }
-                                                                        },
-                                                                        color: themeController.isLightMode.value
-                                                                            ? kLightPrimaryBackgroundColor
-                                                                            : kprimaryBackgroundColor,
-                                                                        icon:
-                                                                            Icon(
-                                                                          Icons
-                                                                              .more_vert,
-                                                                          color: alarm.isEnabled == true
-                                                                              ? themeController.isLightMode.value
-                                                                                  ? kLightPrimaryTextColor
-                                                                                  : kprimaryTextColor
-                                                                              : themeController.isLightMode.value
-                                                                                  ? kLightPrimaryDisabledTextColor
-                                                                                  : kprimaryDisabledTextColor,
+                                                                          },
                                                                         ),
-                                                                        itemBuilder:
-                                                                            (context) {
-                                                                          return [
-                                                                            PopupMenuItem<int>(
-                                                                              value: 0,
-                                                                              child: Text(
-                                                                                "Preview Alarm",
-                                                                                style: Theme.of(context).textTheme.bodyMedium,
-                                                                              ),
-                                                                            ),
-                                                                            if (alarm.isSharedAlarmEnabled == false ||
-                                                                                (alarm.isSharedAlarmEnabled == true && alarm.ownerId == controller.userModel.value!.id))
+                                                                      ),
+                                                                      Expanded(
+                                                                        flex: 0,
+                                                                        child:
+                                                                            PopupMenuButton(
+                                                                          onSelected:
+                                                                              (value) async {
+                                                                            Utils.hapticFeedback();
+                                                                            if (value ==
+                                                                                0) {
+                                                                              Get.back();
+                                                                              Get.offNamed('/alarm-ring', arguments: alarm);
+                                                                            } else if (value ==
+                                                                                1) {
+                                                                              print(alarm.isSharedAlarmEnabled);
+
+                                                                              if (alarm.isSharedAlarmEnabled == true) {
+                                                                                await FirestoreDb.deleteAlarm(controller.userModel.value, alarm.firestoreId!);
+                                                                              } else {
+                                                                                await IsarDb.deleteAlarm(alarm.isarId);
+                                                                              }
+
+                                                                              controller.refreshTimer = true;
+                                                                              controller.refreshUpcomingAlarms();
+                                                                            }
+                                                                          },
+                                                                          color: themeController.isLightMode.value
+                                                                              ? kLightPrimaryBackgroundColor
+                                                                              : kprimaryBackgroundColor,
+                                                                          icon:
+                                                                              Icon(
+                                                                            Icons.more_vert,
+                                                                            color: alarm.isEnabled == true
+                                                                                ? themeController.isLightMode.value
+                                                                                    ? kLightPrimaryTextColor
+                                                                                    : kprimaryTextColor
+                                                                                : themeController.isLightMode.value
+                                                                                    ? kLightPrimaryDisabledTextColor
+                                                                                    : kprimaryDisabledTextColor,
+                                                                          ),
+                                                                          itemBuilder:
+                                                                              (context) {
+                                                                            return [
                                                                               PopupMenuItem<int>(
-                                                                                value: 1,
+                                                                                value: 0,
                                                                                 child: Text(
-                                                                                  "Delete Alarm",
-                                                                                  style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                                                                                        color: Colors.red,
-                                                                                      ),
+                                                                                  "Preview Alarm",
+                                                                                  style: Theme.of(context).textTheme.bodyMedium,
                                                                                 ),
                                                                               ),
-                                                                          ];
-                                                                        },
+                                                                              if (alarm.isSharedAlarmEnabled == false || (alarm.isSharedAlarmEnabled == true && alarm.ownerId == controller.userModel.value!.id))
+                                                                                PopupMenuItem<int>(
+                                                                                  value: 1,
+                                                                                  child: Text(
+                                                                                    "Delete Alarm",
+                                                                                    style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                                                                                          color: Colors.red,
+                                                                                        ),
+                                                                                  ),
+                                                                                ),
+                                                                            ];
+                                                                          },
+                                                                        ),
                                                                       ),
-                                                                    ),
-                                                                  ],
+                                                                    ],
+                                                                  ),
                                                                 ),
-                                                              ),
-                                                            ],
+                                                              ],
+                                                            ),
                                                           ),
                                                         ),
                                                       ),

--- a/lib/app/modules/home/views/toggle_button.dart
+++ b/lib/app/modules/home/views/toggle_button.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:ultimate_alarm_clock/app/data/models/alarm_model.dart';
 import 'package:ultimate_alarm_clock/app/modules/home/controllers/home_controller.dart';
 
 class ToggleButton extends StatefulWidget {
   const ToggleButton(
-      {super.key, required this.controller, required this.isSelected});
+      {super.key, required this.controller, this.alarmIndex, this.isSelected});
   final HomeController controller;
-  final RxBool isSelected;
+  final int? alarmIndex;
+  final RxBool? isSelected;
 
   @override
   State<ToggleButton> createState() => _ToggleButtonState();
@@ -17,8 +19,89 @@ class _ToggleButtonState extends State<ToggleButton> {
   Widget build(BuildContext context) {
     return Obx(
       () => GestureDetector(
-        onTap: () {
-          widget.isSelected.value = !widget.isSelected.value;
+        onTap: () async {
+          // If individual toggle button is pressed
+          if (widget.isSelected == null) {
+
+            // Toggle the value of that particular alarm
+            widget.controller.alarmListPairs.second[widget.alarmIndex!].value =
+                !widget
+                    .controller.alarmListPairs.second[widget.alarmIndex!].value;
+
+            // Storing the value of the toggle button for that particular alarm
+            var buttonValue = widget
+                .controller.alarmListPairs.second[widget.alarmIndex!].value;
+
+            // Storing the alarm model 
+            AlarmModel alarm =
+                widget.controller.alarmListPairs.first[widget.alarmIndex!];
+
+            // If the alarm is selected
+            if (buttonValue) {
+
+              // Increase the number of alarms selected
+              widget.controller.numberOfAlarmsSelected.value++;
+
+              // Add this alarm to selected alarm set
+              widget.controller.selectedAlarmSet.add(
+
+                // If the isSharedAlarmEnabled is true, then add firestore id and isSharedAlarmEnabled, else add isar id and isSharedAlarmEnabled
+                alarm.isSharedAlarmEnabled
+                    ? Pair(
+                        alarm.firestoreId,
+                        true,
+                      )
+                    : Pair(
+                        alarm.isarId,
+                        false,
+                      ),
+              );
+
+              // If all the alarms are selected
+              if(widget.controller.numberOfAlarmsSelected.value == widget.controller.alarmListPairs.first.length) {
+                widget.controller.isAllAlarmsSelected.value = true;
+              } 
+            } else {
+              // Reduce the number of alarms selected
+              widget.controller.numberOfAlarmsSelected.value--;
+
+              // If isSharedAlarmEnabled is true, then remove the alarm with the firestore id, else with the isar id
+              alarm.isSharedAlarmEnabled
+                  ? widget.controller.selectedAlarmSet.removeWhere(
+                      (element) => alarm.firestoreId == element.first,
+                    )
+                  : widget.controller.selectedAlarmSet.removeWhere(
+                      (element) => alarm.isarId == element.first,
+                    );
+
+              // If all alarms are not selected, then set all alarm select button at the top to false
+              if(widget.controller.numberOfAlarmsSelected.value < widget.controller.alarmListPairs.first.length) {
+                widget.controller.isAllAlarmsSelected.value = false;
+              }
+            }
+          } else {
+            // Toggle the all alarm select button
+            widget.controller.isAllAlarmsSelected.value =
+                !widget.controller.isAllAlarmsSelected.value;
+
+            // Store the all alarm select button's value
+            var buttonValue = widget.controller.isAllAlarmsSelected.value;
+
+            // If it is selected
+            if (buttonValue) {
+              // Add all alarms to the selected alarm set
+              widget.controller.addAllAlarmsToSelectedAlarmSet();
+
+              // Set the number of alarms selected to number of alarms
+              widget.controller.numberOfAlarmsSelected.value = widget.controller.alarmListPairs.first.length;
+            } else {
+              // Remove all alarms from the selected alarm set
+              widget.controller.removeAllAlarmsFromSelectedAlarmSet();
+
+              // Set the number of alarms selected to zero
+              widget.controller.numberOfAlarmsSelected.value = 0;
+            }
+          }
         },
         child: Container(
           height: 20 * widget.controller.scalingFactor.value,
@@ -30,22 +113,31 @@ class _ToggleButtonState extends State<ToggleButton> {
               width: 1,
             ),
           ),
-          child: widget.isSelected.value
-              ? Center(
-                  child: AnimatedContainer(
-                    duration: const Duration(
-                      milliseconds: 300,
-                    ),
-                    curve: Curves.bounceIn,
-                    height: 10 * widget.controller.scalingFactor.value,
-                    width: 10 * widget.controller.scalingFactor.value,
-                    decoration: const BoxDecoration(
-                      shape: BoxShape.circle,
-                      color: Colors.white,
-                    ),
-                  ),
-                )
-              : const SizedBox(),
+          child: widget.isSelected == null // If single toggle button is changed
+              ? widget.controller.alarmListPairs.second[widget.alarmIndex!]
+                      .value // If it is selected, show a circle at the middle with an animation
+                  ? _animatedCircle()
+                  : const SizedBox()
+              : widget.isSelected!.value // If all alarm select button is selected
+                  ? _animatedCircle()
+                  : const SizedBox(),
+        ),
+      ),
+    );
+  }
+
+  Widget _animatedCircle() {
+    return Center(
+      child: AnimatedContainer(
+        duration: const Duration(
+          milliseconds: 300,
+        ),
+        curve: Curves.bounceIn,
+        height: 10 * widget.controller.scalingFactor.value,
+        width: 10 * widget.controller.scalingFactor.value,
+        decoration: const BoxDecoration(
+          shape: BoxShape.circle,
+          color: Colors.white,
         ),
       ),
     );

--- a/lib/app/modules/home/views/toggle_button.dart
+++ b/lib/app/modules/home/views/toggle_button.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:ultimate_alarm_clock/app/modules/home/controllers/home_controller.dart';
+
+class ToggleButton extends StatefulWidget {
+  const ToggleButton(
+      {super.key, required this.controller, required this.isSelected});
+  final HomeController controller;
+  final RxBool isSelected;
+
+  @override
+  State<ToggleButton> createState() => _ToggleButtonState();
+}
+
+class _ToggleButtonState extends State<ToggleButton> {
+  @override
+  Widget build(BuildContext context) {
+    return Obx(
+      () => GestureDetector(
+        onTap: () {
+          widget.isSelected.value = !widget.isSelected.value;
+        },
+        child: Container(
+          height: 20 * widget.controller.scalingFactor.value,
+          width: 20 * widget.controller.scalingFactor.value,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            border: Border.all(
+              color: Colors.white,
+              width: 1,
+            ),
+          ),
+          child: widget.isSelected.value
+              ? Center(
+                  child: AnimatedContainer(
+                    duration: const Duration(
+                      milliseconds: 300,
+                    ),
+                    curve: Curves.bounceIn,
+                    height: 10 * widget.controller.scalingFactor.value,
+                    width: 10 * widget.controller.scalingFactor.value,
+                    decoration: const BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: Colors.white,
+                    ),
+                  ),
+                )
+              : const SizedBox(),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
### Description
This PR adds a new feature to the alarm app that allows users to select and delete multiple alarms simultaneously. Users can now long-press on any alarm to activate multi-select mode, and then choose one or more alarms for deletion.

### Proposed Changes
- Added a long-press gesture detection to each alarm card.
- Implemented a multi-select mode that allows users to select and deselect alarms
- Added a new `AppBar` when user is in multi-select mode that allows user to 
  - close the multi-select mode
  - select all alarms at once
  - delete alarms
- New toggle button in the alarm card when the user is in multi-select mode
- Animation when the user holds any alarm card

## Fixes #86

## Screenshots

https://github.com/CCExtractor/ultimate_alarm_clock/assets/92971894/ad69a4c2-a543-4b93-baf4-d3c50e4ff3e9



## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [ ] All tests are passing