### PR TITLE
Feature: Persistent Storage for API Key and Weather Key State

### DIFF
--- a/lib/app/data/providers/secure_storage_provider.dart
+++ b/lib/app/data/providers/secure_storage_provider.dart
@@ -48,6 +48,20 @@ class SecureStorageProvider {
     return await _secureStorage.read(key: apiKey);
   }
 
+  Future<void> storeWeatherState(WeatherKeyState val) async {
+    const String key = 'weather_state';
+    final String weatherState = val.toString();
+    await _secureStorage.write(
+      key: key,
+      value: weatherState,
+    );
+  }
+
+  Future<String?> retrieveWeatherState() async {
+    const String key = 'weather_state'; 
+    return await _secureStorage.read(key: key); 
+  }
+
   Future<bool> readHapticFeedbackValue({required String key}) async {
     return await _secureStorage.read(key: key) == 'true';
   }

--- a/lib/app/data/providers/secure_storage_provider.dart
+++ b/lib/app/data/providers/secure_storage_provider.dart
@@ -48,6 +48,7 @@ class SecureStorageProvider {
     return await _secureStorage.read(key: apiKey);
   }
 
+  // Store the weather state in the flutter secure storage
   Future<void> storeWeatherState(String weatherState) async {
     const String key = 'weather_state';
     await _secureStorage.write(
@@ -56,6 +57,7 @@ class SecureStorageProvider {
     );
   }
 
+  // Get the weather state from the flutter secure storage
   Future<String?> retrieveWeatherState() async {
     const String key = 'weather_state';
     return await _secureStorage.read(key: key);

--- a/lib/app/data/providers/secure_storage_provider.dart
+++ b/lib/app/data/providers/secure_storage_provider.dart
@@ -48,9 +48,8 @@ class SecureStorageProvider {
     return await _secureStorage.read(key: apiKey);
   }
 
-  Future<void> storeWeatherState(WeatherKeyState val) async {
+  Future<void> storeWeatherState(String weatherState) async {
     const String key = 'weather_state';
-    final String weatherState = val.toString();
     await _secureStorage.write(
       key: key,
       value: weatherState,
@@ -58,8 +57,8 @@ class SecureStorageProvider {
   }
 
   Future<String?> retrieveWeatherState() async {
-    const String key = 'weather_state'; 
-    return await _secureStorage.read(key: key); 
+    const String key = 'weather_state';
+    return await _secureStorage.read(key: key);
   }
 
   Future<bool> readHapticFeedbackValue({required String key}) async {

--- a/lib/app/modules/settings/controllers/settings_controller.dart
+++ b/lib/app/modules/settings/controllers/settings_controller.dart
@@ -173,6 +173,18 @@ class SettingsController extends GetxController {
 
     isSortedAlarmListEnabled.value = await _secureStorageProvider
         .readSortedAlarmListValue(key: _sortedAlarmListKey);
+
+    String? retrievedAPIKey = await getKey(ApiKeys.openWeatherMap); 
+
+    if(retrievedAPIKey != null) {
+      apiKey.text = retrievedAPIKey;
+    }
+
+    String? retrievedWeatherState = await getWeatherState(); 
+
+    if(retrievedWeatherState != null) {
+      weatherKeyState.value = retrievedWeatherState as WeatherKeyState;
+    }
   }
 
   void _savePreference() async {

--- a/lib/app/modules/settings/controllers/settings_controller.dart
+++ b/lib/app/modules/settings/controllers/settings_controller.dart
@@ -108,6 +108,14 @@ class SettingsController extends GetxController {
     return await _secureStorageProvider.retrieveApiKey(key);
   }
 
+  addWeatherState(WeatherKeyState weatherState) async {
+    await _secureStorageProvider.storeWeatherState(weatherState); 
+  } 
+
+  getWeatherState() async {
+    return await _secureStorageProvider.retrieveWeatherState(); 
+  }
+
   Future<bool> isApiKeyValid(String apiKey) async {
     final weather = WeatherFactory(apiKey);
     try {

--- a/lib/app/modules/settings/controllers/settings_controller.dart
+++ b/lib/app/modules/settings/controllers/settings_controller.dart
@@ -108,10 +108,12 @@ class SettingsController extends GetxController {
     return await _secureStorageProvider.retrieveApiKey(key);
   }
 
+  // Add weather state to the flutter secure storage
   addWeatherState(String weatherState) async {
     await _secureStorageProvider.storeWeatherState(weatherState);
   }
 
+  // Get weather state from the flutter secure storage
   getWeatherState() async {
     return await _secureStorageProvider.retrieveWeatherState();
   }
@@ -174,23 +176,25 @@ class SettingsController extends GetxController {
     isSortedAlarmListEnabled.value = await _secureStorageProvider
         .readSortedAlarmListValue(key: _sortedAlarmListKey);
 
+    // Store the retrieved API key from the flutter secure storage
     String? retrievedAPIKey = await getKey(ApiKeys.openWeatherMap);
 
+    // If the API key has been previously stored there
     if (retrievedAPIKey != null) {
+      // Assign the controller's text to the retrieved API key so that when the user comes to update their API key, they're able to see the previously added API key
       apiKey.text = retrievedAPIKey;
     }
 
+    // Store the retrieved weather state from the flutter secure storage
     String? retrievedWeatherState = await getWeatherState();
 
-    print(retrievedWeatherState);
-
+    // If the weather state has been previously stored there
     if (retrievedWeatherState != null) {
+      // Assign the weatherKeyState to the previously stored weather state, but first convert the stored string to the WeatherKeyState enum
       weatherKeyState.value = WeatherKeyState.values.firstWhereOrNull(
               (weatherState) => weatherState.name == retrievedWeatherState) ??
           WeatherKeyState.add;
     }
-
-    print(weatherKeyState.value);
   }
 
   void _savePreference() async {

--- a/lib/app/modules/settings/controllers/settings_controller.dart
+++ b/lib/app/modules/settings/controllers/settings_controller.dart
@@ -22,7 +22,7 @@ class SettingsController extends GetxController {
   final GoogleSignIn _googleSignIn = GoogleSignIn();
   late GoogleSignInAccount? googleSignInAccount;
   final RxBool isUserLoggedIn = false.obs;
-  final Rx<WeatherKeyState> weatherKeyState = WeatherKeyState.add.obs; 
+  final Rx<WeatherKeyState> weatherKeyState = WeatherKeyState.add.obs;
   final RxBool didWeatherKeyError = false.obs;
   UserModel? userModel;
   @override
@@ -108,12 +108,12 @@ class SettingsController extends GetxController {
     return await _secureStorageProvider.retrieveApiKey(key);
   }
 
-  addWeatherState(WeatherKeyState weatherState) async {
-    await _secureStorageProvider.storeWeatherState(weatherState); 
-  } 
+  addWeatherState(String weatherState) async {
+    await _secureStorageProvider.storeWeatherState(weatherState);
+  }
 
   getWeatherState() async {
-    return await _secureStorageProvider.retrieveWeatherState(); 
+    return await _secureStorageProvider.retrieveWeatherState();
   }
 
   Future<bool> isApiKeyValid(String apiKey) async {
@@ -174,17 +174,23 @@ class SettingsController extends GetxController {
     isSortedAlarmListEnabled.value = await _secureStorageProvider
         .readSortedAlarmListValue(key: _sortedAlarmListKey);
 
-    String? retrievedAPIKey = await getKey(ApiKeys.openWeatherMap); 
+    String? retrievedAPIKey = await getKey(ApiKeys.openWeatherMap);
 
-    if(retrievedAPIKey != null) {
+    if (retrievedAPIKey != null) {
       apiKey.text = retrievedAPIKey;
     }
 
-    String? retrievedWeatherState = await getWeatherState(); 
+    String? retrievedWeatherState = await getWeatherState();
 
-    if(retrievedWeatherState != null) {
-      weatherKeyState.value = retrievedWeatherState as WeatherKeyState;
+    print(retrievedWeatherState);
+
+    if (retrievedWeatherState != null) {
+      weatherKeyState.value = WeatherKeyState.values.firstWhereOrNull(
+              (weatherState) => weatherState.name == retrievedWeatherState) ??
+          WeatherKeyState.add;
     }
+
+    print(weatherKeyState.value);
   }
 
   void _savePreference() async {
@@ -209,6 +215,6 @@ class SettingsController extends GetxController {
   void toggleSortedAlarmList(bool enabled) {
     isSortedAlarmListEnabled.value = enabled;
     homeController.isSortedAlarmListEnabled.value = enabled;
-    _saveSortedAlarmListPreference(); 
+    _saveSortedAlarmListPreference();
   }
 }

--- a/lib/app/modules/settings/views/weather_api.dart
+++ b/lib/app/modules/settings/views/weather_api.dart
@@ -78,8 +78,10 @@ class WeatherApi extends StatelessWidget {
                                               controller.apiKey.text);
                                           if(controller.weatherKeyState.value == WeatherKeyState.add){
                                             controller.weatherKeyState.value = WeatherKeyState.saveAdded;
+                                            controller.addWeatherState('saveAdded');
                                           } else  {
                                             controller.weatherKeyState.value = WeatherKeyState.saveUpdated;
+                                            controller.addWeatherState('saveUpdated');
                                           }
                                         } else {
                                           controller.didWeatherKeyError.value =
@@ -188,6 +190,7 @@ class WeatherApi extends StatelessWidget {
                               Utils.hapticFeedback();
                               controller.weatherKeyState.value =
                                   WeatherKeyState.update;
+                              controller.addWeatherState('update');
                               Get.back();
                             }),
                       ],

--- a/lib/app/modules/settings/views/weather_api.dart
+++ b/lib/app/modules/settings/views/weather_api.dart
@@ -35,7 +35,10 @@ class WeatherApi extends StatelessWidget {
           content: Obx(
             () => Container(
               // If the user hasn't clicked on the 'Save' or 'Update' button of the dialog, or there is no error in the weather key, then show the dialog
-              child: (controller.weatherKeyState.value != WeatherKeyState.saveAdded && controller.weatherKeyState.value != WeatherKeyState.saveUpdated)
+              child: (controller.weatherKeyState.value !=
+                          WeatherKeyState.saveAdded &&
+                      controller.weatherKeyState.value !=
+                          WeatherKeyState.saveUpdated)
                   ? (controller.didWeatherKeyError.value == false)
                       ? Column(
                           children: [
@@ -79,20 +82,25 @@ class WeatherApi extends StatelessWidget {
                                         // If the API key is valid
                                         if (await controller.isApiKeyValid(
                                             controller.apiKey.text)) {
-                                          
                                           // Add the key to the storage
                                           await controller.addKey(
                                               ApiKeys.openWeatherMap,
                                               controller.apiKey.text);
 
                                           // If it is added for the first time
-                                          if(controller.weatherKeyState.value == WeatherKeyState.add){
-                                            controller.weatherKeyState.value = WeatherKeyState.saveAdded;
-                                            controller.addWeatherState('saveAdded');
-                                          } else  {
+                                          if (controller
+                                                  .weatherKeyState.value ==
+                                              WeatherKeyState.add) {
+                                            controller.weatherKeyState.value =
+                                                WeatherKeyState.saveAdded;
+                                            controller
+                                                .addWeatherState('saveAdded');
+                                          } else {
                                             // If it is updated
-                                            controller.weatherKeyState.value = WeatherKeyState.saveUpdated;
-                                            controller.addWeatherState('saveUpdated');
+                                            controller.weatherKeyState.value =
+                                                WeatherKeyState.saveUpdated;
+                                            controller
+                                                .addWeatherState('saveUpdated');
                                           }
                                         } else {
                                           // If the API key is not valid

--- a/lib/app/modules/settings/views/weather_api.dart
+++ b/lib/app/modules/settings/views/weather_api.dart
@@ -34,6 +34,7 @@ class WeatherApi extends StatelessWidget {
           titleStyle: Theme.of(context).textTheme.displaySmall,
           content: Obx(
             () => Container(
+              // If the user hasn't clicked on the 'Save' or 'Update' button of the dialog, or there is no error in the weather key, then show the dialog
               child: (controller.weatherKeyState.value != WeatherKeyState.saveAdded && controller.weatherKeyState.value != WeatherKeyState.saveUpdated)
                   ? (controller.didWeatherKeyError.value == false)
                       ? Column(
@@ -55,6 +56,7 @@ class WeatherApi extends StatelessWidget {
                                                 kprimaryColor),
                                       ),
                                       child: Text(
+                                        // If the weather state is add, then show 'Save' else show 'Update' text on the button
                                         controller.weatherKeyState.value ==
                                                 WeatherKeyState.add
                                             ? 'Save'
@@ -70,20 +72,30 @@ class WeatherApi extends StatelessWidget {
                                       ),
                                       onPressed: () async {
                                         Utils.hapticFeedback();
+
+                                        // Get the user's location
                                         await controller.getLocation();
+
+                                        // If the API key is valid
                                         if (await controller.isApiKeyValid(
                                             controller.apiKey.text)) {
+                                          
+                                          // Add the key to the storage
                                           await controller.addKey(
                                               ApiKeys.openWeatherMap,
                                               controller.apiKey.text);
+
+                                          // If it is added for the first time
                                           if(controller.weatherKeyState.value == WeatherKeyState.add){
                                             controller.weatherKeyState.value = WeatherKeyState.saveAdded;
                                             controller.addWeatherState('saveAdded');
                                           } else  {
+                                            // If it is updated
                                             controller.weatherKeyState.value = WeatherKeyState.saveUpdated;
                                             controller.addWeatherState('saveUpdated');
                                           }
                                         } else {
+                                          // If the API key is not valid
                                           controller.didWeatherKeyError.value =
                                               true;
                                         }
@@ -165,10 +177,11 @@ class WeatherApi extends StatelessWidget {
                         Padding(
                           padding: const EdgeInsets.symmetric(vertical: 15.0),
                           child: Text(
+                            // If the user clicked on the 'Save' button, then
                             controller.weatherKeyState.value ==
                                     WeatherKeyState.saveAdded
-                                ? 'Your API Key is added!'
-                                : 'Your API Key is updated!',
+                                ? 'Your API Key is added!' // show this message
+                                : 'Your API Key is updated!', // else this message
                             style: Theme.of(context).textTheme.displaySmall,
                           ),
                         ),
@@ -188,6 +201,8 @@ class WeatherApi extends StatelessWidget {
                             ),
                             onPressed: () {
                               Utils.hapticFeedback();
+
+                              // Assign the weather state to update, and save it in the local storage
                               controller.weatherKeyState.value =
                                   WeatherKeyState.update;
                               controller.addWeatherState('update');


### PR DESCRIPTION
### Description
Currently, when users save or update their API Key in the app, the data is stored in local storage. However, if the app is hot-restarted, the apiKey TextEditingController is reset, causing users to lose their API Key text. This can lead to confusion and inconvenience for users. Because the API key is being saved in the local storage, they'll be unable to see it. 

To address this issue, I've implemented persistent storage for both the API Key and the Weather Key State. This enhancement will improve the user experience by preserving their API Key and the state of the Weather Key when the app is hot-restarted.

### Proposed Changes
- Wrote new methods in the `secure_storage_provider` and the `settings_controller` for the addition and retrieval of the `WeatherKeyState`.
- When the `SettingsController` is invoked, the app will retrieve the API key and WeatherKeyState from the local storage, and if they're not null, it will assign them to the stored value. 
- Added comments for better understanding.

## Fixes #91 

## Screenshots

https://github.com/CCExtractor/ultimate_alarm_clock/assets/92971894/33df2397-4695-4688-a652-f7790b0c0a91



## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [ ] All tests are passing