### PR TITLE
Label tile's snackbar bg color changed to red and text color changed to white

### DIFF
--- a/lib/app/modules/addOrUpdateAlarm/views/label_tile.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/label_tile.dart
@@ -82,8 +82,8 @@ class LabelTile extends StatelessWidget {
                   Get.snackbar(
                     "Note",
                     "Please don't enter whitespace as first character!",
-                    backgroundColor: Colors.white,
-                    colorText: Colors.black,
+                    backgroundColor: Colors.red,
+                    colorText: Colors.white,
                   );
                 }
               }


### PR DESCRIPTION
Fixes #93

https://github.com/CCExtractor/ultimate_alarm_clock/assets/88525320/32d7b99f-6efc-465a-aac3-5c5014c46d2e


 