### PR TITLE
Feature: Changed the checbox fill color

### DIFF
--- a/lib/app/utils/constants.dart
+++ b/lib/app/utils/constants.dart
@@ -42,7 +42,7 @@ ThemeData kThemeData = ThemeData(
   fontFamily: 'poppins',
   checkboxTheme: CheckboxThemeData(
     checkColor: MaterialStateProperty.all(kprimaryTextColor),
-    fillColor: MaterialStateProperty.all(kprimaryColor.withOpacity(0.8)),
+    fillColor: MaterialStateProperty.all(kprimaryBackgroundColor),
   ),
   textTheme: const TextTheme(
       titleSmall: TextStyle(color: kprimaryTextColor, letterSpacing: 0.15),
@@ -108,7 +108,7 @@ ThemeData kLightThemeData = ThemeData(
   fontFamily: 'poppins',
   checkboxTheme: CheckboxThemeData(
     checkColor: MaterialStateProperty.all(kprimaryTextColor),
-    fillColor: MaterialStateProperty.all(kLightSecondaryColor.withOpacity(0.8)),
+    fillColor: MaterialStateProperty.all(kLightPrimaryBackgroundColor),
   ),
   textTheme: const TextTheme(
       titleSmall: TextStyle(color: kLightPrimaryTextColor, letterSpacing: 0.15),


### PR DESCRIPTION
### Description
Previously, the `CheckBox fillColor` was looking weird for both light and dark modes. It was affecting the overall UX of the app. Therefore, I've changed the `CheckBox fillColor` for both light and dark modes. Now it's certainly looking better. 

### Proposed Changes
- Changed the `CheckBox fillColor` to the primary background color of the respective light and dark modes.

## Fixes #101 

## Screenshots

### Dark Mode

**Before**
<img src="https://github.com/CCExtractor/ultimate_alarm_clock/assets/92971894/72dd3b49-552a-4a80-b219-6d446a8ec98a" width="250" height="550">

**After**
<img src="https://github.com/CCExtractor/ultimate_alarm_clock/assets/92971894/f7e188e7-adca-4f97-96ad-77f724745a94" width="250" height="550">

---

### Light Mode

**Before**
<img src="https://github.com/CCExtractor/ultimate_alarm_clock/assets/92971894/f96cd408-e17e-4e9d-b371-048023447908" width="250" height="550">

**After**
<img src="https://github.com/CCExtractor/ultimate_alarm_clock/assets/92971894/8951ed79-e8f1-47fe-9ee6-b5408679444a" width="250" height="550">


## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [ ] All tests are passing