### PR TITLE
Feature: Turned autofocus on, and applied hint text to weather API textfield

### DIFF
--- a/lib/app/modules/settings/views/weather_api.dart
+++ b/lib/app/modules/settings/views/weather_api.dart
@@ -43,8 +43,12 @@ class WeatherApi extends StatelessWidget {
                       ? Column(
                           children: [
                             TextField(
+                              autofocus: true,
                               obscureText: false,
                               controller: controller.apiKey,
+                              decoration: const InputDecoration(
+                                hintText: 'Enter API Key...',
+                              ),
                             ),
                             Padding(
                               padding: const EdgeInsets.only(top: 20.0),

--- a/lib/app/utils/constants.dart
+++ b/lib/app/utils/constants.dart
@@ -76,7 +76,7 @@ ThemeData kThemeData = ThemeData(
       background: kprimaryBackgroundColor,
       onPrimaryContainer: ksecondaryBackgroundColor),
   inputDecorationTheme: InputDecorationTheme(
-      hintStyle: const TextStyle(color: kprimaryTextColor),
+      hintStyle: TextStyle(color: kprimaryTextColor.withOpacity(0.5)),
       labelStyle: const TextStyle(color: kprimaryTextColor),
       focusColor: kprimaryTextColor,
       enabledBorder: OutlineInputBorder(
@@ -143,7 +143,7 @@ ThemeData kLightThemeData = ThemeData(
       background: kLightPrimaryBackgroundColor,
       onPrimaryContainer: kLightSecondaryBackgroundColor),
   inputDecorationTheme: InputDecorationTheme(
-      hintStyle: const TextStyle(color: kLightPrimaryTextColor),
+      hintStyle: TextStyle(color: kLightPrimaryTextColor.withOpacity(0.5)),
       labelStyle: const TextStyle(color: kLightPrimaryTextColor),
       focusColor: kLightPrimaryTextColor,
       enabledBorder: OutlineInputBorder(


### PR DESCRIPTION
### Description
Previously, when the user wanted to add/update their Weather API Key, they needed to tap on the Weather API key tile, and a dialog would appear there. However since the autofocus was off by default, the user needed to tap on the text field to enter their API Key.

In this PR, I've turned the autofocus on, so that user can now directly enter their API key. 

Also, I've provided a hint text `Enter API Key...` for a better user experience. 

### Proposed Changes
- Turned the autofocus on inside the `TextField`.
- Provided a `hintText` inside the `TextField`.
- Changed the `hintStyle` inside the `InputDecorationTheme`.

## Fixes #102 

## Screenshots


https://github.com/CCExtractor/ultimate_alarm_clock/assets/92971894/c6973031-68cb-4688-8ee7-b547245804d8



## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [ ] All tests are passing