### PR TITLE
Exit preview button (color and text) Now working properly according to whatever was defined in ThemeController

### DIFF
--- a/lib/app/modules/alarmRing/views/alarm_ring_view.dart
+++ b/lib/app/modules/alarmRing/views/alarm_ring_view.dart
@@ -74,32 +74,34 @@ class AlarmControlView extends GetView<AlarmControlController> {
               (Get.arguments != null)
                   ? Padding(
                       padding: const EdgeInsets.all(8.0),
-                      child: SizedBox(
-                        height: height * 0.06,
-                        width: width,
-                        child: TextButton(
-                          style: ButtonStyle(
-                            backgroundColor: MaterialStateProperty.all(
-                              themeController.isLightMode.value
-                                  ? kLightPrimaryTextColor.withOpacity(0.7)
-                                  : kprimaryTextColor.withOpacity(0.7),
+                      child: Obx(
+                        () => SizedBox(
+                          height: height * 0.06,
+                          width: width,
+                          child: TextButton(
+                            style: ButtonStyle(
+                              backgroundColor: MaterialStateProperty.all(
+                                themeController.isLightMode.value
+                                    ? kLightPrimaryTextColor.withOpacity(0.7)
+                                    : kprimaryTextColor.withOpacity(0.7),
+                              ),
                             ),
+                            child: Text(
+                              'Exit Preview',
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .displaySmall!
+                                  .copyWith(
+                                    color: themeController.isLightMode.value
+                                        ? kLightPrimaryTextColor
+                                        : ksecondaryTextColor,
+                                  ),
+                            ),
+                            onPressed: () {
+                              Utils.hapticFeedback();
+                              Get.offNamed('/home');
+                            },
                           ),
-                          child: Text(
-                            'Exit Preview',
-                            style: Theme.of(context)
-                                .textTheme
-                                .displaySmall!
-                                .copyWith(
-                                  color: themeController.isLightMode.value
-                                      ? kLightPrimaryTextColor
-                                      : ksecondaryTextColor,
-                                ),
-                          ),
-                          onPressed: () {
-                            Utils.hapticFeedback();
-                            Get.offNamed('/home');
-                          },
                         ),
                       ),
                     )


### PR DESCRIPTION
Fixes #118 
Description:-

In the preview alarm, the Exit Preview button color and text Do not change according to the theme controller( error occurs when dark Mode is enabled).

How to Produce the issue:-

https://github.com/CCExtractor/ultimate_alarm_clock/assets/88525320/ac094151-2588-4acd-90fb-1a5ec2a65d25

After fixes:-
This issue mainly occurs when Dark mode is enabled.

https://github.com/CCExtractor/ultimate_alarm_clock/assets/88525320/557cf961-e3df-4bdf-b25d-4e67aed45488



https://github.com/CCExtractor/ultimate_alarm_clock/assets/88525320/13bd94a4-06cd-4d37-9f39-0ce00868d928


