### PR TITLE
Controller added to Repeat tile Font Weight.

### DIFF
--- a/lib/app/modules/addOrUpdateAlarm/views/repeat_tile.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/repeat_tile.dart
@@ -17,6 +17,8 @@ class RepeatTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    bool anyDaySelected = controller.repeatDays.any((daySelected) => daySelected);
+
     return InkWell(
       onTap: () {
         Utils.hapticFeedback();
@@ -82,14 +84,21 @@ class RepeatTile extends StatelessWidget {
         tileColor: themeController.isLightMode.value
             ? kLightSecondaryBackgroundColor
             : ksecondaryBackgroundColor,
-        title: Text(
-          'Repeat',
-          style: TextStyle(
-            color: themeController.isLightMode.value
-                ? kLightPrimaryTextColor
-                : kprimaryTextColor,
-            fontWeight: FontWeight.w500,
-          ),
+        title: Obx(
+              () {
+            bool anyDaySelected =
+            controller.repeatDays.any((daySelected) => daySelected);
+
+            return Text(
+              'Repeat',
+              style: TextStyle(
+                color: themeController.isLightMode.value
+                    ? kLightPrimaryTextColor
+                    : kprimaryTextColor,
+                fontWeight: anyDaySelected ? FontWeight.w500 : FontWeight.normal,
+              ),
+            );
+          },
         ),
         trailing: Wrap(
           crossAxisAlignment: WrapCrossAlignment.center,


### PR DESCRIPTION
### Description
Currently, the Repeat tile has a fontweight that does not go with it when the repeat tile is set to Never.
I think adding a controller to it provides a better User Interface.
This means when it is set to never its font weight should be normal like all,
After selecting any particular day or days make the Repeat tile show like it is active now.



## Fixes #149
Controller has been added to Repeat tile Font Weight
