### PR TITLE
Deprecation: Replaced the Deprecated WillPopScope with PopScope

### DIFF
--- a/lib/app/modules/addOrUpdateAlarm/views/add_or_update_alarm_view.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/add_or_update_alarm_view.dart
@@ -36,7 +36,85 @@ class AddOrUpdateAlarmView extends GetView<AddOrUpdateAlarmController> {
   Widget build(BuildContext context) {
     var width = Get.width;
     var height = Get.height;
-    return WillPopScope(
+    return PopScope(
+      canPop: false,
+      onPopInvoked: (bool didPop) {
+        if (didPop) {
+          return;
+        }
+
+        Get.defaultDialog(
+          titlePadding: const EdgeInsets.symmetric(
+            vertical: 20,
+          ),
+          backgroundColor: themeController.isLightMode.value
+              ? kLightSecondaryBackgroundColor
+              : ksecondaryBackgroundColor,
+          title: 'Discard Changes?',
+          titleStyle: Theme.of(context).textTheme.displaySmall,
+          content: Column(
+            children: [
+              Text(
+                'You have unsaved changes. Are you sure you want to leave this'
+                ' page?',
+                style: Theme.of(context).textTheme.bodyMedium,
+                textAlign: TextAlign.center,
+              ),
+              Padding(
+                padding: const EdgeInsets.only(
+                  top: 20,
+                ),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: [
+                    TextButton(
+                      onPressed: () {
+                        Get.back();
+                      },
+                      style: ButtonStyle(
+                        backgroundColor:
+                            MaterialStateProperty.all(kprimaryColor),
+                      ),
+                      child: Text(
+                        'Cancel',
+                        style:
+                            Theme.of(context).textTheme.displaySmall!.copyWith(
+                                  color: kprimaryBackgroundColor,
+                                ),
+                      ),
+                    ),
+                    OutlinedButton(
+                      onPressed: () {
+                        Get.offNamedUntil(
+                          '/home',
+                          (route) => route.settings.name == '/splash-screen',
+                        );
+                      },
+                      style: OutlinedButton.styleFrom(
+                        side: BorderSide(
+                          color: themeController.isLightMode.value
+                              ? Colors.red.withOpacity(0.9)
+                              : Colors.red,
+                          width: 1,
+                        ),
+                      ),
+                      child: Text(
+                        'Leave',
+                        style:
+                            Theme.of(context).textTheme.displaySmall!.copyWith(
+                                  color: themeController.isLightMode.value
+                                      ? Colors.red.withOpacity(0.9)
+                                      : Colors.red,
+                                ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        );
+      },
       child: WithForegroundTask(
         child: Scaffold(
           floatingActionButtonLocation:
@@ -633,81 +711,6 @@ class AddOrUpdateAlarmView extends GetView<AddOrUpdateAlarmController> {
                 ),
         ),
       ),
-      onWillPop: () async {
-        Get.defaultDialog(
-          titlePadding: const EdgeInsets.symmetric(
-            vertical: 20,
-          ),
-          backgroundColor: themeController.isLightMode.value
-              ? kLightSecondaryBackgroundColor
-              : ksecondaryBackgroundColor,
-          title: 'Discard Changes?',
-          titleStyle: Theme.of(context).textTheme.displaySmall,
-          content: Column(
-            children: [
-              Text(
-                'You have unsaved changes. Are you sure you want to leave this'
-                ' page?',
-                style: Theme.of(context).textTheme.bodyMedium,
-                textAlign: TextAlign.center,
-              ),
-              Padding(
-                padding: const EdgeInsets.only(
-                  top: 20,
-                ),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                  children: [
-                    TextButton(
-                      onPressed: () {
-                        Get.back();
-                      },
-                      style: ButtonStyle(
-                        backgroundColor:
-                            MaterialStateProperty.all(kprimaryColor),
-                      ),
-                      child: Text(
-                        'Cancel',
-                        style:
-                            Theme.of(context).textTheme.displaySmall!.copyWith(
-                                  color: kprimaryBackgroundColor,
-                                ),
-                      ),
-                    ),
-                    OutlinedButton(
-                      onPressed: () {
-                        Get.offNamedUntil(
-                          '/home',
-                          (route) => route.settings.name == '/splash-screen',
-                        );
-                      },
-                      style: OutlinedButton.styleFrom(
-                        side: BorderSide(
-                          color: themeController.isLightMode.value
-                              ? Colors.red.withOpacity(0.9)
-                              : Colors.red,
-                          width: 1,
-                        ),
-                      ),
-                      child: Text(
-                        'Leave',
-                        style:
-                            Theme.of(context).textTheme.displaySmall!.copyWith(
-                                  color: themeController.isLightMode.value
-                                      ? Colors.red.withOpacity(0.9)
-                                      : Colors.red,
-                                ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-        );
-
-        return false;
-      },
     );
   }
 }

--- a/lib/app/modules/alarmRing/views/alarm_ring_view.dart
+++ b/lib/app/modules/alarmRing/views/alarm_ring_view.dart
@@ -16,7 +16,20 @@ class AlarmControlView extends GetView<AlarmControlController> {
   Widget build(BuildContext context) {
     var width = Get.width;
     var height = Get.height;
-    return WillPopScope(
+    return PopScope(
+      canPop: false,
+      onPopInvoked: (bool didPop) {
+        if (didPop) {
+          return;
+        }
+
+        Get.snackbar(
+          'Note',
+          "You can't go back while the alarm is ringing",
+          backgroundColor: Colors.red,
+          colorText: Colors.white,
+        );
+      },
       child: SafeArea(
         child: Scaffold(
           floatingActionButtonLocation:
@@ -175,15 +188,6 @@ class AlarmControlView extends GetView<AlarmControlController> {
           ),
         ),
       ),
-      onWillPop: () async {
-        Get.snackbar(
-          'Note',
-          "You can't go back while the alarm is ringing",
-          backgroundColor: Colors.red,
-          colorText: Colors.white,
-        );
-        return false;
-      },
     );
   }
 }


### PR DESCRIPTION
### Description
In the newer versions of the Flutter, the `WillPopScope` widget is deprecated. So I've replaced it with the newly included `PopScope` widget. 

### Proposed Changes
- Replaced the `WillPopScope` widget with the `PopScope` widget. 

## Fixes #151 

## Screenshots

https://github.com/CCExtractor/ultimate_alarm_clock/assets/92971894/79699520-e56b-4410-8ebf-bdadfaaa70b9



## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [ ] All tests are passing