### PR TITLE
Add fix: Select all Top navigation bar corrected

### DIFF
--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -446,7 +446,7 @@ class HomeView extends GetView<HomeController> {
                                           ),
                                           Container(
                                             padding: EdgeInsets.symmetric(
-                                              horizontal: 25 *
+                                              horizontal: 15 *
                                                   controller
                                                       .scalingFactor.value,
                                             ),
@@ -534,7 +534,8 @@ class HomeView extends GetView<HomeController> {
                                                     .value = false;
                                                 controller.isAllAlarmsSelected
                                                     .value = false;
-                                                controller.numberOfAlarmsSelected
+                                                controller
+                                                    .numberOfAlarmsSelected
                                                     .value = 0;
                                                 controller.selectedAlarmSet
                                                     .clear();
@@ -554,7 +555,8 @@ class HomeView extends GetView<HomeController> {
                                                       : kprimaryTextColor
                                                           .withOpacity(0.75),
                                               iconSize: 27 *
-                                                  controller.scalingFactor.value,
+                                                  controller
+                                                      .scalingFactor.value,
                                             ),
                                           ),
                                         ],


### PR DESCRIPTION
### Description
Overflowing of the top navigation bar while selecting multiple alarms for deletion in the home screen has been fixed.



## Fixes #172 



## Screenshots


https://github.com/CCExtractor/ultimate_alarm_clock/assets/94671974/15daea17-84ce-426b-af9e-de63dd9778db

