### PR TITLE
UI Fix: Disabled the material3 theme

### DIFF
--- a/lib/app/utils/constants.dart
+++ b/lib/app/utils/constants.dart
@@ -36,6 +36,7 @@ const Color kLightPrimaryDisabledTextColor = Color(0xffACACAB);
 
 // Dark ThemeData
 ThemeData kThemeData = ThemeData(
+  useMaterial3: false,
   textButtonTheme: TextButtonThemeData(
     style: TextButton.styleFrom(foregroundColor: ksecondaryColor),
   ),
@@ -118,6 +119,7 @@ ThemeData kThemeData = ThemeData(
 
 // Light ThemeData
 ThemeData kLightThemeData = ThemeData(
+  useMaterial3: false,
   textButtonTheme: TextButtonThemeData(
     style: TextButton.styleFrom(foregroundColor: kprimaryColor),
   ),


### PR DESCRIPTION
### Description
I've set the `useMaterial3` property in the dark and light `ThemeData` to `false`. It was impacting the overall theme of our application. 

### Proposed Changes
- Set the `useMaterial3` property to `false` in `ThemeData`.

## Fixes #184 

## Screenshots

<img src="https://github.com/CCExtractor/ultimate_alarm_clock/assets/92971894/7162caa7-4866-4fa9-a204-c927429b44df" width="250" height="550">


## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [ ] All tests are passing