### PR TITLE
Bug: Resolved the no ringtone selected bug

### DIFF
--- a/lib/app/modules/settings/views/custom_ringtone.dart
+++ b/lib/app/modules/settings/views/custom_ringtone.dart
@@ -24,160 +24,183 @@ class CustomRingtone extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return InkWell(
-      onTap: () async {
-        Utils.hapticFeedback();
-        RingtoneModel? customRingtone = await IsarDb.getCustomRingtone();
+    return Obx(
+      () => InkWell(
+        onTap: () async {
+          Utils.hapticFeedback();
+          RingtoneModel? customRingtone = await IsarDb.getCustomRingtone();
 
-        if (customRingtone != null) {
-          controller.customRingtoneName.value = customRingtone.ringtoneName;
-        }
+          if (customRingtone != null) {
+            controller.customRingtoneName.value = customRingtone.ringtoneName;
+          }
 
-        controller.customRingtoneStatus.value =
-            await SecureStorageProvider().readCustomRingtoneStatus();
+          controller.customRingtoneStatus.value =
+              await SecureStorageProvider().readCustomRingtoneStatus();
 
-        Get.defaultDialog(
-          titlePadding: const EdgeInsets.symmetric(vertical: 20),
-          backgroundColor: themeController.isLightMode.value
-              ? kLightSecondaryBackgroundColor
-              : ksecondaryBackgroundColor,
-          title: 'Custom Ringtone',
-          titleStyle: Theme.of(context).textTheme.displaySmall,
-          content: Obx(
-            () => Column(
-              children: [
-                RadioListTile.adaptive(
-                  title: Text(
-                    'Disable',
-                    style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                          color: themeController.isLightMode.value
-                              ? kLightPrimaryTextColor
-                              : kprimaryTextColor,
-                        ),
-                  ),
-                  value: CustomRingtoneStatus.disabled,
-                  groupValue: controller.customRingtoneStatus.value,
-                  fillColor: const MaterialStatePropertyAll(kprimaryColor),
-                  onChanged: (value) {
-                    Utils.hapticFeedback();
-                    controller.customRingtoneStatus.value =
-                        CustomRingtoneStatus.disabled;
-                    controller.customRingtoneName.value =
-                        'Custom Ringtone Disabled!';
-                    controller.saveCustomRingtoneStatus();
-                  },
-                ),
-                RadioListTile.adaptive(
-                  title: Text(
-                    'Enable',
-                    style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                          color: themeController.isLightMode.value
-                              ? kLightPrimaryTextColor
-                              : kprimaryTextColor,
-                        ),
-                  ),
-                  value: CustomRingtoneStatus.enabled,
-                  groupValue: controller.customRingtoneStatus.value,
-                  fillColor: const MaterialStatePropertyAll(kprimaryColor),
-                  onChanged: (value) async {
-                    Utils.hapticFeedback();
-                    controller.customRingtoneStatus.value =
-                        CustomRingtoneStatus.enabled;
-                    RingtoneModel? customRingtone =
-                        await IsarDb.getCustomRingtone();
-
-                    if (customRingtone != null) {
+          Get.defaultDialog(
+            titlePadding: const EdgeInsets.symmetric(vertical: 20),
+            backgroundColor: themeController.isLightMode.value
+                ? kLightSecondaryBackgroundColor
+                : ksecondaryBackgroundColor,
+            barrierDismissible: controller.customRingtoneStatus.value ==
+                        CustomRingtoneStatus.enabled &&
+                    controller.customRingtoneName.value ==
+                        'Custom Ringtone Disabled!'
+                ? false
+                : true,
+            onWillPop: () async {
+              return controller.customRingtoneStatus.value ==
+                      CustomRingtoneStatus.enabled &&
+                  controller.customRingtoneName.value ==
+                      'Custom Ringtone Disabled!' ? false : true;
+            },
+            title: 'Custom Ringtone',
+            titleStyle: Theme.of(context).textTheme.displaySmall,
+            content: Obx(
+              () => Column(
+                children: [
+                  RadioListTile.adaptive(
+                    title: Text(
+                      'Disable',
+                      style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                            color: themeController.isLightMode.value
+                                ? kLightPrimaryTextColor
+                                : kprimaryTextColor,
+                          ),
+                    ),
+                    value: CustomRingtoneStatus.disabled,
+                    groupValue: controller.customRingtoneStatus.value,
+                    fillColor: const MaterialStatePropertyAll(kprimaryColor),
+                    onChanged: (value) {
+                      Utils.hapticFeedback();
+                      controller.customRingtoneStatus.value =
+                          CustomRingtoneStatus.disabled;
                       controller.customRingtoneName.value =
-                          customRingtone.ringtoneName;
-                    }
-                    controller.saveCustomRingtoneStatus();
-                  },
-                ),
-                Visibility(
-                  visible: controller.customRingtoneStatus.value ==
-                      CustomRingtoneStatus.enabled,
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: [
-                      OutlinedButton(
-                        onPressed: () async {
-                          Utils.hapticFeedback();
-                          await controller.saveCustomRingtone();
-                        },
-                        child: Obx(() {
-                          bool isRingtoneSelected =
-                              controller.customRingtoneName.value !=
-                                      'Custom Ringtone Disabled!' &&
-                                  controller.customRingtoneStatus.value ==
-                                      CustomRingtoneStatus.enabled;
+                          'Custom Ringtone Disabled!';
+                      controller.saveCustomRingtoneStatus();
+                    },
+                  ),
+                  RadioListTile.adaptive(
+                    title: Text(
+                      'Enable',
+                      style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                            color: themeController.isLightMode.value
+                                ? kLightPrimaryTextColor
+                                : kprimaryTextColor,
+                          ),
+                    ),
+                    value: CustomRingtoneStatus.enabled,
+                    groupValue: controller.customRingtoneStatus.value,
+                    fillColor: const MaterialStatePropertyAll(kprimaryColor),
+                    onChanged: (value) async {
+                      Utils.hapticFeedback();
+                      controller.customRingtoneStatus.value =
+                          CustomRingtoneStatus.enabled;
+                      RingtoneModel? customRingtone =
+                          await IsarDb.getCustomRingtone();
 
-                          return Text(
-                            isRingtoneSelected
-                                ? 'Change Ringtone'
-                                : 'Choose Ringtone',
-                            style: Theme.of(context)
-                                .textTheme
-                                .bodyMedium!
-                                .copyWith(
-                                  color: kprimaryColor,
-                                ),
-                          );
-                        }),
-                      ),
-                      const SizedBox(
-                        height: 10,
-                      ),
-                      Text(controller.customRingtoneName.value),
-                    ],
+                      if (customRingtone != null) {
+                        controller.customRingtoneName.value =
+                            customRingtone.ringtoneName;
+                      }
+                      controller.saveCustomRingtoneStatus();
+                    },
                   ),
-                ),
-                const SizedBox(
-                  height: 30,
-                ),
-                ElevatedButton(
-                  onPressed: () {
-                    Utils.hapticFeedback();
-                    Get.back();
-                  },
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: kprimaryColor,
-                  ),
-                  child: Text(
-                    'Done',
-                    style: Theme.of(context).textTheme.displaySmall!.copyWith(
-                          color: themeController.isLightMode.value
-                              ? kLightPrimaryTextColor
-                              : ksecondaryTextColor,
+                  Visibility(
+                    visible: controller.customRingtoneStatus.value ==
+                        CustomRingtoneStatus.enabled,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        OutlinedButton(
+                          onPressed: () async {
+                            Utils.hapticFeedback();
+                            await controller.saveCustomRingtone();
+                          },
+                          child: Obx(() {
+                            bool isRingtoneSelected =
+                                controller.customRingtoneName.value !=
+                                        'Custom Ringtone Disabled!' &&
+                                    controller.customRingtoneStatus.value ==
+                                        CustomRingtoneStatus.enabled;
+
+                            return Text(
+                              isRingtoneSelected
+                                  ? 'Change Ringtone'
+                                  : 'Choose Ringtone',
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .bodyMedium!
+                                  .copyWith(
+                                    color: kprimaryColor,
+                                  ),
+                            );
+                          }),
                         ),
+                        const SizedBox(
+                          height: 10,
+                        ),
+                        Text(controller.customRingtoneName.value),
+                      ],
+                    ),
                   ),
+                  const SizedBox(
+                    height: 30,
+                  ),
+                  ElevatedButton(
+                    onPressed: controller.customRingtoneStatus.value ==
+                                CustomRingtoneStatus.enabled &&
+                            controller.customRingtoneName.value ==
+                                'Custom Ringtone Disabled!'
+                        ? null
+                        : () {
+                            Utils.hapticFeedback();
+                            Get.back();
+                          },
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: kprimaryColor,
+                      disabledBackgroundColor: themeController.isLightMode.value
+                          ? kLightPrimaryDisabledTextColor
+                          : kprimaryDisabledTextColor,
+                    ),
+                    child: Text(
+                      'Done',
+                      style: Theme.of(context).textTheme.displaySmall!.copyWith(
+                            color: themeController.isLightMode.value
+                                ? kLightPrimaryTextColor
+                                : ksecondaryTextColor,
+                          ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+        child: Container(
+          width: width * 0.91,
+          height: height * 0.1,
+          decoration: Utils.getCustomTileBoxDecoration(
+            isLightMode: themeController.isLightMode.value,
+          ),
+          child: Padding(
+            padding: const EdgeInsets.only(left: 30, right: 30),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  'Custom Ringtone',
+                  style: Theme.of(context).textTheme.bodyLarge,
+                ),
+                Icon(
+                  Icons.arrow_forward_ios_sharp,
+                  color: themeController.isLightMode.value
+                      ? kLightPrimaryTextColor.withOpacity(0.4)
+                      : kprimaryTextColor.withOpacity(0.2),
                 ),
               ],
             ),
-          ),
-        );
-      },
-      child: Container(
-        width: width * 0.91,
-        height: height * 0.1,
-        decoration: Utils.getCustomTileBoxDecoration(
-          isLightMode: themeController.isLightMode.value,
-        ),
-        child: Padding(
-          padding: const EdgeInsets.only(left: 30, right: 30),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text(
-                'Custom Ringtone',
-                style: Theme.of(context).textTheme.bodyLarge,
-              ),
-              Icon(
-                Icons.arrow_forward_ios_sharp,
-                color: themeController.isLightMode.value
-                    ? kLightPrimaryTextColor.withOpacity(0.4)
-                    : kprimaryTextColor.withOpacity(0.2),
-              ),
-            ],
           ),
         ),
       ),


### PR DESCRIPTION
### Description
Previously when the user had enabled the custom ringtone feature and didn't select any audio file, the dialog would still get dismissed. But I've added the `barrierDismissable` condition, and `onWillPop` method inside the dialog now. So the user will only be able to dismiss the dialog either if they have disabled the feature or enabled the feature and selected a ringtone. 

### Proposed Changes
- Added the `barrierDismissable` condition.
- Added the `onWillPop` method.
- Added the `disabledBackgroundColor`. 

## Fixes #188 

## Screenshots


https://github.com/CCExtractor/ultimate_alarm_clock/assets/92971894/416b32e8-e540-4d00-b363-dd60b36b0464



## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [ ] All tests are passing