### PR TITLE
Bug: Added the bug title to the bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,5 +1,6 @@
 name: 🐛 Bug
 description: Report an issue to help improve the project.
+title: 'Bug: '
 labels: ['bug']
 body:
   - type: textarea


### PR DESCRIPTION
### Description
Previously, when the contributor tried to create an issue of type bug, the title "Bug: " wasn't there. So I've added the title "Bug: " to the bug issue template.

### Proposed Changes
- Added the title "Bug: " to the bug issue template.

## Fixes #192 

## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [ ] All tests are passing