### PR TITLE
Feature: Showing flutter toast on creating or updating the alarm

### DIFF
--- a/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
+++ b/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 import 'package:get/get.dart';
 import 'package:fl_location/fl_location.dart';
 import 'package:latlong2/latlong.dart';
@@ -259,6 +260,12 @@ class AddOrUpdateAlarmController extends GetxController {
     } else {
       alarmRecord = await IsarDb.addAlarm(alarmData);
     }
+
+    Future.delayed(const Duration(seconds: 1), () {
+      showToast(
+        alarmRecord: alarmData,
+      );
+    });
   }
 
   showQRDialog() {
@@ -449,6 +456,12 @@ class AddOrUpdateAlarmController extends GetxController {
         createAlarm(alarmData);
       }
     }
+
+    Future.delayed(const Duration(seconds: 1), () {
+      showToast(
+        alarmRecord: alarmData,
+      );
+    });
   }
 
   @override
@@ -782,6 +795,30 @@ class AddOrUpdateAlarmController extends GetxController {
           );
         }
       }
+    } catch (e) {
+      debugPrint(e.toString());
+    }
+  }
+
+  void showToast({
+    required AlarmModel alarmRecord,
+  }) {
+    try {
+      String timeToAlarm = Utils.timeUntilAlarm(
+        Utils.stringToTimeOfDay(alarmRecord.alarmTime),
+        alarmRecord.days,
+      );
+
+      Fluttertoast.showToast(
+        msg: 'Rings in $timeToAlarm',
+        toastLength: Toast.LENGTH_LONG,
+        backgroundColor: themeController.isLightMode.value
+            ? kLightSecondaryBackgroundColor
+            : ksecondaryBackgroundColor,
+        textColor: themeController.isLightMode.value
+            ? kLightPrimaryTextColor
+            : kprimaryTextColor,
+      );
     } catch (e) {
       debugPrint(e.toString());
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_native_splash: ^2.3.8
+  fluttertoast: ^8.2.4
 
 dev_dependencies:
   flutter_lints: ^2.0.3


### PR DESCRIPTION
### Description
Previously, when the user used to create or update an alarm, the app didn't show any confirmation event about it. 

In this PR, I've added the [fluttertoast](https://pub.dev/packages/fluttertoast) dependency to the project and used it to show a toast whenever the user sets/updates an alarm. 

The message of the toast is the difference between the current time and the alarm time. 

_Note: `Get.snackbar` isn't used as a toast because it requires you to provide the title and message. Also if you provide an empty string as a title, the height of the snack bar can't be reduced._

### Proposed Changes
- Added the `fluttertoast`dependency.
- Showing the toast whenever the user sets/updates an alarm. 

## Fixes #229

## Screenshots


https://github.com/CCExtractor/ultimate_alarm_clock/assets/92971894/e0e72c66-23a5-4600-af61-ebf6cef95956



## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [ ] All tests are passing