### PR TITLE
Refactor: Removed the app's dependency on flutter_ringtone_player

### DIFF
--- a/android/app/src/main/kotlin/com/example/ultimate_alarm_clock/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/ultimate_alarm_clock/MainActivity.kt
@@ -19,14 +19,18 @@ import android.widget.Toast
 import android.os.PowerManager
 import android.util.Log
 import android.view.WindowManager
+import android.media.Ringtone
+import android.media.RingtoneManager
+import android.net.Uri
 
 class MainActivity : FlutterActivity() {
 
     companion object {
         const val CHANNEL = "ulticlock"
         const val ACTION_START_FLUTTER_APP = "com.example.ultimate_alarm_clock"
-const val EXTRA_KEY = "alarmRing"
-val alarmConfig = hashMapOf("shouldAlarmRing" to false, "alarmIgnore" to false)
+        const val EXTRA_KEY = "alarmRing"
+        val alarmConfig = hashMapOf("shouldAlarmRing" to false, "alarmIgnore" to false)
+        private var ringtone: Ringtone? = null
     }
 
 
@@ -34,7 +38,7 @@ val alarmConfig = hashMapOf("shouldAlarmRing" to false, "alarmIgnore" to false)
     override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON or WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED or WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON)
-        var  methodChannel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL)
+        var methodChannel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL)
 
         val intent = intent
         if (intent != null && intent.hasExtra(EXTRA_KEY)) {
@@ -51,35 +55,41 @@ val alarmConfig = hashMapOf("shouldAlarmRing" to false, "alarmIgnore" to false)
         methodChannel.setMethodCallHandler { call, result ->
             if (call.method == "scheduleAlarm") {
                 val seconds = call.argument<Int>("milliSeconds")
-               println("FLUTTER CALLED SCHEDULE")
+                println("FLUTTER CALLED SCHEDULE")
                 scheduleAlarm(seconds ?: 0)
                 result.success(null)
             } else if (call.method == "cancelAllScheduledAlarms") {
-               println("FLUTTER CALLED CANCEL ALARMS")
-               cancelAllScheduledAlarms()
+                println("FLUTTER CALLED CANCEL ALARMS")
+                cancelAllScheduledAlarms()
                 result.success(null)
-            }else if(call.method == "bringAppToForeground"){
+            } else if (call.method == "bringAppToForeground") {
                 bringAppToForeground(this)
                 result.success(null)
-            }else if (call.method == "minimizeApp" ){
+            } else if (call.method == "minimizeApp" ) {
                 minimizeApp()
                 result.success(null)   
+            } else if (call.method == "playDefaultAlarm") {
+                playDefaultAlarm(this)
+                result.success(null)
+            } else if (call.method == "stopDefaultAlarm") {
+                stopDefaultAlarm()
+                result.success(null)
             } else {
                 result.notImplemented()
             }
         }
     }
 
-        fun bringAppToForeground(context: Context) {
-            val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager?
-            val appTasks = activityManager?.appTasks
-            appTasks?.forEach { task ->
-                if (task.taskInfo.baseIntent.component?.packageName == context.packageName) {
-                    task.moveToFront()
-                    return@forEach
-                }
+    fun bringAppToForeground(context: Context) {
+        val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager?
+        val appTasks = activityManager?.appTasks
+        appTasks?.forEach { task ->
+            if (task.taskInfo.baseIntent.component?.packageName == context.packageName) {
+                task.moveToFront()
+                return@forEach
             }
         }
+    }
 
 
     private fun minimizeApp() {
@@ -87,35 +97,43 @@ val alarmConfig = hashMapOf("shouldAlarmRing" to false, "alarmIgnore" to false)
     }
 
 
-private fun scheduleAlarm(milliSeconds: Int) {
-    val alarmManager = getSystemService(Context.ALARM_SERVICE) as AlarmManager
-    val intent = Intent(this, AlarmReceiver::class.java)
-    val pendingIntent = PendingIntent.getBroadcast(
-        this,
-        0,
-        intent,
-        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
-    )
+    private fun scheduleAlarm(milliSeconds: Int) {
+        val alarmManager = getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        val intent = Intent(this, AlarmReceiver::class.java)
+        val pendingIntent = PendingIntent.getBroadcast(
+            this,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+        )
 
-    // Schedule the alarm
-    val triggerTime = SystemClock.elapsedRealtime() + milliSeconds
-    alarmManager.setExact(AlarmManager.ELAPSED_REALTIME_WAKEUP, triggerTime, pendingIntent)
-}
+        // Schedule the alarm
+        val triggerTime = SystemClock.elapsedRealtime() + milliSeconds
+        alarmManager.setExact(AlarmManager.ELAPSED_REALTIME_WAKEUP, triggerTime, pendingIntent)
+    }
 
-private fun cancelAllScheduledAlarms() {
-    val alarmManager = getSystemService(Context.ALARM_SERVICE) as AlarmManager
-    val intent = Intent(this, AlarmReceiver::class.java)
-    val pendingIntent = PendingIntent.getBroadcast(
-        this,
-        0,
-        intent,
-        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
-    )
+    private fun cancelAllScheduledAlarms() {
+        val alarmManager = getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        val intent = Intent(this, AlarmReceiver::class.java)
+        val pendingIntent = PendingIntent.getBroadcast(
+            this,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+        )
 
-    // Cancel any existing alarms by providing the same pending intent
-    alarmManager.cancel(pendingIntent)
-    pendingIntent.cancel()
-}
+        // Cancel any existing alarms by providing the same pending intent
+        alarmManager.cancel(pendingIntent)
+        pendingIntent.cancel()
+    }
 
+    private fun playDefaultAlarm(context: Context) {
+        val alarmUri: Uri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM)
+        ringtone = RingtoneManager.getRingtone(context, alarmUri)
+        ringtone?.play()
+    }
 
+    private fun stopDefaultAlarm() {
+        ringtone?.stop()
+    }
 }

--- a/lib/app/utils/utils.dart
+++ b/lib/app/utils/utils.dart
@@ -2,7 +2,6 @@ import 'package:audioplayers/audioplayers.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_ringtone_player/flutter_ringtone_player.dart';
 import 'package:get/get.dart';
 import 'package:intl/intl.dart';
 import 'package:latlong2/latlong.dart';
@@ -18,6 +17,8 @@ import 'constants.dart';
 
 class Utils {
   static final audioPlayer = AudioPlayer();
+
+  static MethodChannel alarmChannel = const MethodChannel('ulticlock');
 
   static String timeOfDayToString(TimeOfDay time) {
     final hours = time.hour.toString().padLeft(2, '0');
@@ -583,7 +584,7 @@ class Utils {
       String ringtoneName = alarmRecord.ringtoneName;
 
       if (ringtoneName == 'Default') {
-        FlutterRingtonePlayer.playAlarm();
+        await alarmChannel.invokeMethod('playDefaultAlarm');
       } else {
         int customRingtoneId = fastHash(ringtoneName);
         RingtoneModel? customRingtone = await IsarDb.getCustomRingtone(
@@ -594,7 +595,7 @@ class Utils {
           String customRingtonePath = customRingtone.ringtonePath;
           await playCustomSound(customRingtonePath);
         } else {
-          FlutterRingtonePlayer.playAlarm();
+          await alarmChannel.invokeMethod('playDefaultAlarm');
           
           bool isSharedAlarmEnabled = alarmRecord.isSharedAlarmEnabled;
 
@@ -617,7 +618,7 @@ class Utils {
   }) async {
     try {
       if (ringtoneName == 'Default') {
-        FlutterRingtonePlayer.stop();
+        await alarmChannel.invokeMethod('stopDefaultAlarm');
       } else {
         await audioPlayer.stop();
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ version: 0.5.0
 publish_to: none
 description: A new Flutter project.
 environment:
-  sdk: '>=3.2.0 <4.0.0'
+  sdk: ">=3.2.0 <4.0.0"
   flutter: 3.16.0
 
 dependencies:
@@ -11,7 +11,6 @@ dependencies:
   screen_state: ^2.0.0
   cupertino_icons: ^1.0.2
   get: 4.6.5
-  flutter_ringtone_player: ^3.2.0
   flutter_time_picker_spinner: ^2.0.0
   cloud_firestore: ^4.4.5
   intl: ^0.18.0


### PR DESCRIPTION
### Description
Previously, the app was using the `flutter_ringtone_player` package for playing the device's default alarm ringtone. But the `audioplayers` package is also being utilized in the `Custom Ringtone` feature. 

But obviously, it's not feasible to have two packages contributing to just a ringtone-playing feature, and especially to have the `flutter_ringtone_player` package just to play the device's default alarm ringtone. 

So I've removed the app's dependency on the `flutter_ringtone_player` package by using the `MethodChannel` and invoking the native methods for playing and stopping the device's default alarm ringtone. 

I've written two methods named `playDefaultAlarm`, and `stopDefaultAlarm` for playing and stopping the alarm ringtone respectively. 

### Proposed Changes
- Removed the `flutter_ringtone_player` package from `pubspec.yaml` file.
- Added two methods named `playDefaultAlarm`, and `stopDefaultAlarm` to the `MainActivity`.
- Invoked these methods in the `utils.dart` file.

## Fixes #223

## Screenshots


https://github.com/CCExtractor/ultimate_alarm_clock/assets/92971894/ae173e2d-b5dd-425f-9061-0769cf5c6a0b



## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [ ] All tests are passing