### PR TITLE
Prevent Addition of Duplicate Alarms for Same Time #244

### DIFF
--- a/lib/app/data/providers/firestore_provider.dart
+++ b/lib/app/data/providers/firestore_provider.dart
@@ -9,7 +9,7 @@ class FirestoreDb {
       FirebaseFirestore.instance;
 
   static final CollectionReference _usersCollection =
-      FirebaseFirestore.instance.collection('users');
+  FirebaseFirestore.instance.collection('users');
 
   static CollectionReference _alarmsCollection(UserModel? user) {
     if (user == null) {
@@ -38,11 +38,11 @@ class FirestoreDb {
 
   static Future<UserModel?> fetchUserDetails(String userId) async {
     final DocumentSnapshot userSnapshot =
-        await _usersCollection.doc(userId).get();
+    await _usersCollection.doc(userId).get();
 
     if (userSnapshot.exists) {
       final UserModel user =
-          UserModel.fromJson(userSnapshot.data() as Map<String, dynamic>);
+      UserModel.fromJson(userSnapshot.data() as Map<String, dynamic>);
       return user;
     }
 
@@ -57,11 +57,21 @@ class FirestoreDb {
 
     return snapshot.docs.isNotEmpty;
   }
+  static Future<bool> doesAlarmExistTime(UserModel? user, String time) async {
+    if (user == null) return false;
+
+    QuerySnapshot snapshot = await _alarmsCollection(user)
+        .where('isEnabled', isEqualTo: true)
+        .where('alarmTime', isEqualTo: time)
+        .get();
+
+    return snapshot.docs.isNotEmpty;
+  }
 
   static Future<AlarmModel> getTriggeredAlarm(
-    UserModel? user,
-    String time,
-  ) async {
+      UserModel? user,
+      String time,
+      ) async {
     if (user == null) return Utils.genFakeAlarmModel();
     QuerySnapshot snapshot = await _alarmsCollection(user)
         .where('isEnabled', isEqualTo: true)
@@ -79,10 +89,10 @@ class FirestoreDb {
   }
 
   static Future<AlarmModel> getLatestAlarm(
-    UserModel? user,
-    AlarmModel alarmRecord,
-    bool wantNextAlarm,
-  ) async {
+      UserModel? user,
+      AlarmModel alarmRecord,
+      bool wantNextAlarm,
+      ) async {
     if (user == null) {
       alarmRecord.minutesSinceMidnight = -1;
       return alarmRecord;
@@ -109,7 +119,7 @@ class FirestoreDb {
 
     // Get all enabled alarms
     QuerySnapshot snapshot =
-        await _alarmsCollection(user).where('isEnabled', isEqualTo: true).get();
+    await _alarmsCollection(user).where('isEnabled', isEqualTo: true).get();
 
     QuerySnapshot snapshotSharedAlarms = await _firebaseFirestore
         .collectionGroup('alarms')
@@ -258,9 +268,9 @@ class FirestoreDb {
     }
 
     final sharedUserIds =
-        List<String>.from(alarmDoc.data()['sharedUserIds'] ?? []);
+    List<String>.from(alarmDoc.data()['sharedUserIds'] ?? []);
     final offsetDetails =
-        Map<String, dynamic>.from(alarmDoc.data()['offsetDetails'] ?? {});
+    Map<String, dynamic>.from(alarmDoc.data()['offsetDetails'] ?? {});
 
     offsetDetails[userModelId] = {
       'isOffsetBefore': true,
@@ -278,9 +288,9 @@ class FirestoreDb {
   }
 
   static Future<List<String>> removeUserFromAlarmSharedUsers(
-    UserModel? userModel,
-    String alarmID,
-  ) async {
+      UserModel? userModel,
+      String alarmID,
+      ) async {
     String userModelId = userModel!.id;
 
     final alarmQuerySnapshot = await _firebaseFirestore
@@ -294,7 +304,7 @@ class FirestoreDb {
 
     final alarmDoc = alarmQuerySnapshot.docs[0];
     final sharedUserIds =
-        List<String>.from(alarmDoc.data()['sharedUserIds'] ?? []);
+    List<String>.from(alarmDoc.data()['sharedUserIds'] ?? []);
 
     if (sharedUserIds.contains(userModelId)) {
       sharedUserIds.remove(userModelId); // Remove the userId from the list

--- a/lib/app/data/providers/isar_provider.dart
+++ b/lib/app/data/providers/isar_provider.dart
@@ -55,7 +55,7 @@ class IsarDb {
     final isarProvider = IsarDb();
     final db = await isarProvider.db;
     final alarms =
-        await db.alarmModels.where().filter().alarmIDEqualTo(alarmID).findAll();
+    await db.alarmModels.where().filter().alarmIDEqualTo(alarmID).findAll();
 
     return alarms.isNotEmpty;
   }
@@ -73,9 +73,9 @@ class IsarDb {
   }
 
   static Future<AlarmModel> getLatestAlarm(
-    AlarmModel alarmRecord,
-    bool wantNextAlarm,
-  ) async {
+      AlarmModel alarmRecord,
+      bool wantNextAlarm,
+      ) async {
     int nowInMinutes = 0;
     final isarProvider = IsarDb();
     final db = await isarProvider.db;
@@ -100,7 +100,7 @@ class IsarDb {
 
     // Get all enabled alarms
     List<AlarmModel> alarms =
-        await db.alarmModels.where().filter().isEnabledEqualTo(true).findAll();
+    await db.alarmModels.where().filter().isEnabledEqualTo(true).findAll();
 
     if (alarms.isEmpty) {
       alarmRecord.minutesSinceMidnight = -1;
@@ -188,8 +188,8 @@ class IsarDb {
   }
 
   static Future<void> addCustomRingtone(
-    RingtoneModel customRingtone,
-  ) async {
+      RingtoneModel customRingtone,
+      ) async {
     try {
       final isarProvider = IsarDb();
       final db = await isarProvider.db;

--- a/lib/app/data/providers/isar_provider.dart
+++ b/lib/app/data/providers/isar_provider.dart
@@ -59,6 +59,18 @@ class IsarDb {
 
     return alarms.isNotEmpty;
   }
+  static Future<bool> doesAlarmExistTime(String time, bool is_enable) async {
+    final isarProvider = IsarDb();
+    final db = await isarProvider.db;
+    final alarms = await db.alarmModels
+        .where()
+        .filter()
+        .isEnabledEqualTo(is_enable)
+        .and()
+        .alarmTimeEqualTo(time)
+        .findAll();
+    return alarms.isNotEmpty;
+  }
 
   static Future<AlarmModel> getLatestAlarm(
     AlarmModel alarmRecord,

--- a/lib/app/modules/addOrUpdateAlarm/views/add_or_update_alarm_view.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/add_or_update_alarm_view.dart
@@ -4,6 +4,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_time_picker_spinner/flutter_time_picker_spinner.dart';
 
 import 'package:get/get.dart';
+import 'package:ultimate_alarm_clock/app/data/providers/firestore_provider.dart';
 import 'package:ultimate_alarm_clock/app/data/models/alarm_model.dart';
 import 'package:ultimate_alarm_clock/app/modules/addOrUpdateAlarm/controllers/input_time_controller.dart';
 import 'package:ultimate_alarm_clock/app/modules/addOrUpdateAlarm/views/alarm_id_tile.dart';
@@ -25,7 +26,9 @@ import 'package:ultimate_alarm_clock/app/modules/settings/controllers/settings_c
 import 'package:ultimate_alarm_clock/app/modules/settings/controllers/theme_controller.dart';
 import 'package:ultimate_alarm_clock/app/utils/constants.dart';
 import 'package:ultimate_alarm_clock/app/utils/utils.dart';
+import '../../../data/providers/isar_provider.dart';
 import '../controllers/add_or_update_alarm_controller.dart';
+
 
 class AddOrUpdateAlarmView extends GetView<AddOrUpdateAlarmController> {
   AddOrUpdateAlarmView({Key? key}) : super(key: key);
@@ -57,7 +60,7 @@ class AddOrUpdateAlarmView extends GetView<AddOrUpdateAlarmController> {
               children: [
                 Text(
                   'You have unsaved changes. Are you sure you want to leave this'
-                  ' page?',
+                      ' page?',
                   style: Theme.of(context).textTheme.bodyMedium,
                   textAlign: TextAlign.center,
                 ),
@@ -74,7 +77,7 @@ class AddOrUpdateAlarmView extends GetView<AddOrUpdateAlarmController> {
                         },
                         style: ButtonStyle(
                           backgroundColor:
-                              MaterialStateProperty.all(kprimaryColor),
+                          MaterialStateProperty.all(kprimaryColor),
                         ),
                         child: Text(
                           'Cancel',
@@ -82,15 +85,15 @@ class AddOrUpdateAlarmView extends GetView<AddOrUpdateAlarmController> {
                               .textTheme
                               .displaySmall!
                               .copyWith(
-                                color: kprimaryBackgroundColor,
-                              ),
+                            color: kprimaryBackgroundColor,
+                          ),
                         ),
                       ),
                       OutlinedButton(
                         onPressed: () {
                           Get.offNamedUntil(
                             '/home',
-                            (route) => route.settings.name == '/splash-screen',
+                                (route) => route.settings.name == '/splash-screen',
                           );
                         },
                         style: OutlinedButton.styleFrom(
@@ -107,10 +110,10 @@ class AddOrUpdateAlarmView extends GetView<AddOrUpdateAlarmController> {
                               .textTheme
                               .displaySmall!
                               .copyWith(
-                                color: themeController.isLightMode.value
-                                    ? Colors.red.withOpacity(0.9)
-                                    : Colors.red,
-                              ),
+                            color: themeController.isLightMode.value
+                                ? Colors.red.withOpacity(0.9)
+                                : Colors.red,
+                          ),
                         ),
                       ),
                     ],
@@ -122,633 +125,717 @@ class AddOrUpdateAlarmView extends GetView<AddOrUpdateAlarmController> {
         },
         child: Scaffold(
           floatingActionButtonLocation:
-              FloatingActionButtonLocation.centerDocked,
+          FloatingActionButtonLocation.centerDocked,
           floatingActionButton: (controller.alarmRecord != null &&
-                  controller.mutexLock.value == true)
+              controller.mutexLock.value == true)
               ? const SizedBox()
               : Padding(
-                  padding: const EdgeInsets.all(18.0),
-                  child: SizedBox(
-                    height: height * 0.06,
-                    width: width * 0.8,
-                    child: TextButton(
-                      style: ButtonStyle(
-                        backgroundColor:
-                            MaterialStateProperty.all(kprimaryColor),
-                      ),
-                      child: Text(
-                        (controller.alarmRecord == null) ? 'Save' : 'Update',
-                        style:
-                            Theme.of(context).textTheme.displaySmall!.copyWith(
-                                  color: themeController.isLightMode.value
-                                      ? kLightPrimaryTextColor
-                                      : ksecondaryTextColor,
-                                ),
-                      ),
-                      onPressed: () async {
-                        Utils.hapticFeedback();
-                        if (controller.userModel != null) {
-                          controller.offsetDetails[controller.userModel!.id] = {
-                            'offsettedTime': Utils.timeOfDayToString(
-                              TimeOfDay.fromDateTime(
-                                Utils.calculateOffsetAlarmTime(
-                                  controller.selectedTime.value,
-                                  controller.isOffsetBefore.value,
-                                  controller.offsetDuration.value,
-                                ),
-                              ),
-                            ),
-                            'offsetDuration': controller.offsetDuration.value,
-                            'isOffsetBefore': controller.isOffsetBefore.value,
-                          };
-                        } else {
-                          controller.offsetDetails.value = {};
-                        }
-                        AlarmModel alarmRecord = AlarmModel(
-                          snoozeDuration: controller.snoozeDuration.value,
-                          offsetDetails: controller.offsetDetails,
-                          label: controller.label.value,
-                          isOneTime: controller.isOneTime.value,
-                          lastEditedUserId: controller.lastEditedUserId,
-                          mutexLock: controller.mutexLock.value,
-                          alarmID: controller.alarmID,
-                          ownerId: controller.ownerId,
-                          ownerName: controller.ownerName,
-                          activityInterval:
-                              controller.activityInterval.value * 60000,
-                          days: controller.repeatDays.toList(),
-                          alarmTime: Utils.timeOfDayToString(
-                            TimeOfDay.fromDateTime(
-                              controller.selectedTime.value,
-                            ),
-                          ),
-                          mainAlarmTime: Utils.timeOfDayToString(
-                            TimeOfDay.fromDateTime(
-                              controller.selectedTime.value,
-                            ),
-                          ),
-                          intervalToAlarm: Utils.getMillisecondsToAlarm(
-                            DateTime.now(),
-                            controller.selectedTime.value,
-                          ),
-                          isActivityEnabled: controller.isActivityenabled.value,
-                          minutesSinceMidnight: Utils.timeOfDayToInt(
-                            TimeOfDay.fromDateTime(
-                              controller.selectedTime.value,
-                            ),
-                          ),
-                          isLocationEnabled: controller.isLocationEnabled.value,
-                          weatherTypes: Utils.getIntFromWeatherTypes(
-                            controller.selectedWeather.toList(),
-                          ),
-                          isWeatherEnabled: controller.isWeatherEnabled.value,
-                          location: Utils.geoPointToString(
-                            Utils.latLngToGeoPoint(
-                              controller.selectedPoint.value,
-                            ),
-                          ),
-                          isSharedAlarmEnabled:
-                              controller.isSharedAlarmEnabled.value,
-                          isQrEnabled: controller.isQrEnabled.value,
-                          qrValue: controller.qrValue.value,
-                          isMathsEnabled: controller.isMathsEnabled.value,
-                          numMathsQuestions: controller.numMathsQuestions.value,
-                          mathsDifficulty:
-                              controller.mathsDifficulty.value.index,
-                          isShakeEnabled: controller.isShakeEnabled.value,
-                          shakeTimes: controller.shakeTimes.value,
-                          ringtoneName: controller.customRingtoneName.value,
-                        );
-
-                        // Adding offset details to the database if
-                        // its a shared alarm
-                        if (controller.isSharedAlarmEnabled.value) {
-                          alarmRecord.offsetDetails = controller.offsetDetails;
-                          alarmRecord.mainAlarmTime = Utils.timeOfDayToString(
-                            TimeOfDay.fromDateTime(
-                              controller.selectedTime.value,
-                            ),
-                          );
-                        }
-
-                        try {
-                          if (controller.alarmRecord == null) {
-                            await controller.createAlarm(alarmRecord);
-                          } else {
-                            AlarmModel updatedAlarmModel =
-                                controller.updatedAlarmModel();
-                            await controller.updateAlarm(updatedAlarmModel);
-                          }
-                        } catch (e) {
-                          debugPrint(e.toString());
-                        }
-
-                        await controller.checkOverlayPermissionAndNavigate();
-                      },
-                    ),
+            padding: const EdgeInsets.all(18.0),
+            child: SizedBox(
+              height: height * 0.06,
+              width: width * 0.8,
+              child: TextButton(
+                style: ButtonStyle(
+                  backgroundColor:
+                  MaterialStateProperty.all(kprimaryColor),
+                ),
+                child: Text(
+                  (controller.alarmRecord == null) ? 'Save' : 'Update',
+                  style:
+                  Theme.of(context).textTheme.displaySmall!.copyWith(
+                    color: themeController.isLightMode.value
+                        ? kLightPrimaryTextColor
+                        : ksecondaryTextColor,
                   ),
                 ),
+                onPressed: () async {
+                  Utils.hapticFeedback();
+                  if (controller.userModel != null) {
+                    controller.offsetDetails[controller.userModel!.id] = {
+                      'offsettedTime': Utils.timeOfDayToString(
+                        TimeOfDay.fromDateTime(
+                          Utils.calculateOffsetAlarmTime(
+                            controller.selectedTime.value,
+                            controller.isOffsetBefore.value,
+                            controller.offsetDuration.value,
+                          ),
+                        ),
+                      ),
+                      'offsetDuration': controller.offsetDuration.value,
+                      'isOffsetBefore': controller.isOffsetBefore.value,
+                    };
+                  } else {
+                    controller.offsetDetails.value = {};
+                  }
+
+                  String time = Utils.timeOfDayToString(
+                    TimeOfDay.fromDateTime(
+                      controller.selectedTime.value,
+                    ),
+                  );
+                  bool res = await IsarDb.doesAlarmExistTime(time,true);
+                  if (res){
+                    Get.defaultDialog(
+                      titlePadding: const EdgeInsets.symmetric(
+                        vertical: 20,
+                      ),
+                      backgroundColor: themeController.isLightMode.value
+                          ? kLightSecondaryBackgroundColor
+                          : ksecondaryBackgroundColor,
+                      title: 'Alarm already set for $time',
+                      titleStyle: Theme.of(context).textTheme.displaySmall,
+                      content: Column(
+                        children: [
+                          Text(
+                            'You have already set a alarm for $time. Please update existing one or set alarm for another time',
+                            style: Theme.of(context).textTheme.bodyMedium,
+                            textAlign: TextAlign.center,
+                          ),
+                          Padding(
+                            padding: const EdgeInsets.only(
+                              top: 20,
+                            ),
+                            child: Row(
+                              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                              children: [
+                                TextButton(
+                                  onPressed: () {
+                                    Get.back();
+                                  },
+                                  style: ButtonStyle(
+                                    backgroundColor:
+                                    MaterialStateProperty.all(kprimaryColor),
+                                  ),
+                                  child: Text(
+                                    'Cancel',
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .displaySmall!
+                                        .copyWith(
+                                      color: kprimaryBackgroundColor,
+                                    ),
+                                  ),
+                                ),
+                                OutlinedButton(
+                                  onPressed: () {
+                                    Get.offNamedUntil(
+                                      '/home',
+                                          (route) => route.settings.name == '/splash-screen',
+                                    );
+                                  },
+                                  style: OutlinedButton.styleFrom(
+                                    side: BorderSide(
+                                      color: themeController.isLightMode.value
+                                          ? Colors.red.withOpacity(0.9)
+                                          : Colors.red,
+                                      width: 1,
+                                    ),
+                                  ),
+                                  child: Text(
+                                    'Leave',
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .displaySmall!
+                                        .copyWith(
+                                      color: themeController.isLightMode.value
+                                          ? Colors.red.withOpacity(0.9)
+                                          : Colors.red,
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
+                    );
+
+                  }else{
+                    AlarmModel alarmRecord = AlarmModel(
+                      snoozeDuration: controller.snoozeDuration.value,
+                      offsetDetails: controller.offsetDetails,
+                      label: controller.label.value,
+                      isOneTime: controller.isOneTime.value,
+                      lastEditedUserId: controller.lastEditedUserId,
+                      mutexLock: controller.mutexLock.value,
+                      alarmID: controller.alarmID,
+                      ownerId: controller.ownerId,
+                      ownerName: controller.ownerName,
+                      activityInterval:
+                      controller.activityInterval.value * 60000,
+                      days: controller.repeatDays.toList(),
+                      alarmTime: Utils.timeOfDayToString(
+                        TimeOfDay.fromDateTime(
+                          controller.selectedTime.value,
+                        ),
+                      ),
+                      mainAlarmTime: Utils.timeOfDayToString(
+                        TimeOfDay.fromDateTime(
+                          controller.selectedTime.value,
+                        ),
+                      ),
+                      intervalToAlarm: Utils.getMillisecondsToAlarm(
+                        DateTime.now(),
+                        controller.selectedTime.value,
+                      ),
+                      isActivityEnabled: controller.isActivityenabled.value,
+                      minutesSinceMidnight: Utils.timeOfDayToInt(
+                        TimeOfDay.fromDateTime(
+                          controller.selectedTime.value,
+                        ),
+                      ),
+                      isLocationEnabled: controller.isLocationEnabled.value,
+                      weatherTypes: Utils.getIntFromWeatherTypes(
+                        controller.selectedWeather.toList(),
+                      ),
+                      isWeatherEnabled: controller.isWeatherEnabled.value,
+                      location: Utils.geoPointToString(
+                        Utils.latLngToGeoPoint(
+                          controller.selectedPoint.value,
+                        ),
+                      ),
+                      isSharedAlarmEnabled:
+                      controller.isSharedAlarmEnabled.value,
+                      isQrEnabled: controller.isQrEnabled.value,
+                      qrValue: controller.qrValue.value,
+                      isMathsEnabled: controller.isMathsEnabled.value,
+                      numMathsQuestions: controller.numMathsQuestions.value,
+                      mathsDifficulty:
+                      controller.mathsDifficulty.value.index,
+                      isShakeEnabled: controller.isShakeEnabled.value,
+                      shakeTimes: controller.shakeTimes.value,
+                      ringtoneName: controller.customRingtoneName.value,
+                    );
+
+                    // Adding offset details to the database if
+                    // its a shared alarm
+                    if (controller.isSharedAlarmEnabled.value) {
+                      alarmRecord.offsetDetails = controller.offsetDetails;
+                      alarmRecord.mainAlarmTime = Utils.timeOfDayToString(
+                        TimeOfDay.fromDateTime(
+                          controller.selectedTime.value,
+                        ),
+                      );
+                    }
+
+                    try {
+                      if (controller.alarmRecord == null) {
+                        await controller.createAlarm(alarmRecord);
+                      } else {
+                        AlarmModel updatedAlarmModel =
+                        controller.updatedAlarmModel();
+                        await controller.updateAlarm(updatedAlarmModel);
+                      }
+                    } catch (e) {
+                      debugPrint(e.toString());
+                    }
+                    await controller.checkOverlayPermissionAndNavigate();
+                  }
+                },
+              ),
+            ),
+          ),
           appBar: AppBar(
             backgroundColor: (controller.alarmRecord != null &&
-                    controller.mutexLock.value == true)
+                controller.mutexLock.value == true)
                 ? themeController.isLightMode.value
-                    ? kLightPrimaryBackgroundColor
-                    : kprimaryBackgroundColor
+                ? kLightPrimaryBackgroundColor
+                : kprimaryBackgroundColor
                 : themeController.isLightMode.value
-                    ? kLightSecondaryBackgroundColor
-                    : ksecondaryBackgroundColor,
+                ? kLightSecondaryBackgroundColor
+                : ksecondaryBackgroundColor,
             elevation: 0.0,
             centerTitle: true,
             iconTheme: Theme.of(context).iconTheme,
             title: (controller.alarmRecord != null &&
-                    controller.mutexLock.value == true)
+                controller.mutexLock.value == true)
                 ? const Text('')
                 : Obx(
-                    () => Text(
-                      'Rings in ${controller.timeToAlarm.value}',
-                      style: Theme.of(context).textTheme.titleSmall,
-                    ),
-                  ),
+                  () => Text(
+                'Rings in ${controller.timeToAlarm.value}',
+                style: Theme.of(context).textTheme.titleSmall,
+              ),
+            ),
           ),
           body: (controller.alarmRecord != null &&
-                  controller.mutexLock.value == true)
+              controller.mutexLock.value == true)
               ? Center(
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                    children: [
-                      Padding(
-                        padding: const EdgeInsets.all(20.0),
-                        child: Text(
-                          'Uh-oh!',
-                          style: Theme.of(context)
-                              .textTheme
-                              .displayMedium!
-                              .copyWith(
-                                color: themeController.isLightMode.value
-                                    ? kLightPrimaryDisabledTextColor
-                                    : kprimaryDisabledTextColor,
-                              ),
-                        ),
-                      ),
-                      SvgPicture.asset(
-                        'assets/images/locked.svg',
-                        height: height * 0.24,
-                        width: width * 0.5,
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.all(20.0),
-                        child: Text(
-                          'This alarm is currently being edited!',
-                          style: Theme.of(context)
-                              .textTheme
-                              .displaySmall!
-                              .copyWith(
-                                color: themeController.isLightMode.value
-                                    ? kLightPrimaryDisabledTextColor
-                                    : kprimaryDisabledTextColor,
-                              ),
-                        ),
-                      ),
-                      TextButton(
-                        style: ButtonStyle(
-                          backgroundColor:
-                              MaterialStateProperty.all(kprimaryColor),
-                        ),
-                        child: Text(
-                          'Go back',
-                          style: Theme.of(context)
-                              .textTheme
-                              .displaySmall!
-                              .copyWith(
-                                color: themeController.isLightMode.value
-                                    ? kLightSecondaryTextColor
-                                    : ksecondaryTextColor,
-                              ),
-                        ),
-                        onPressed: () {
-                          Utils.hapticFeedback();
-                          Get.back();
-                        },
-                      ),
-                    ],
-                  ),
-                )
-              : ListView(
-                  children: [
-                    Container(
-                        color: themeController.isLightMode.value
-                            ? kLightSecondaryBackgroundColor
-                            : ksecondaryBackgroundColor,
-                        height: height * 0.32,
-                        width: width,
-                        child: Obx(() {
-                          return InkWell(
-                            onTap: () {
-                              Utils.hapticFeedback();
-                              inputTimeController.changeDatePicker();
-                            },
-                            child: inputTimeController.isTimePicker.value
-                                ? TimePickerSpinner(
-                                    time: controller.selectedTime.value,
-                                    isForce2Digits: true,
-                                    alignment: Alignment.center,
-                                    is24HourMode:
-                                        settingsController.is24HrsEnabled.value,
-                                    normalTextStyle: Theme.of(context)
-                                        .textTheme
-                                        .displayMedium!
-                                        .copyWith(
-                                          fontWeight: FontWeight.normal,
-                                          color: themeController
-                                                  .isLightMode.value
-                                              ? kLightPrimaryDisabledTextColor
-                                              : kprimaryDisabledTextColor,
-                                        ),
-                                    highlightedTextStyle: Theme.of(context)
-                                        .textTheme
-                                        .displayMedium,
-                                    onTimeChange: (dateTime) {
-                                      Utils.hapticFeedback();
-                                      controller.selectedTime.value = dateTime;
-                                      inputTimeController.inputHrsController
-                                          .text = settingsController
-                                              .is24HrsEnabled.value
-                                          ? dateTime.hour.toString()
-                                          : (dateTime.hour == 0
-                                              ? 12.toString()
-                                              : (dateTime.hour > 12
-                                                  ? (dateTime.hour - 12)
-                                                      .toString()
-                                                  : dateTime.hour.toString()));
-                                      inputTimeController.inputMinutesController
-                                          .text = dateTime.minute.toString();
-                                      inputTimeController.changePeriod(
-                                          dateTime.hour >= 12 ? 'PM' : 'AM');
-                                    },
-                                  )
-                                : Row(
-                                    mainAxisAlignment: MainAxisAlignment.center,
-                                    children: [
-                                      SizedBox(
-                                        width: 80,
-                                        child: TextField(
-                                          onChanged: (_) {
-                                            inputTimeController.setTime();
-                                          },
-                                          decoration: const InputDecoration(
-                                              hintText: 'HH',
-                                              border: InputBorder.none),
-                                          textAlign: TextAlign.center,
-                                          controller: inputTimeController
-                                              .inputHrsController,
-                                          keyboardType: TextInputType.number,
-                                          inputFormatters: [
-                                            FilteringTextInputFormatter.allow(
-                                                RegExp(
-                                                    '[1,2,3,4,5,6,7,8,9,0]')),
-                                            LengthLimitingTextInputFormatter(2),
-                                            LimitRange(
-                                                0,
-                                                settingsController
-                                                        .is24HrsEnabled.value
-                                                    ? 23
-                                                    : 12)
-                                          ],
-                                        ),
-                                      ),
-                                      SizedBox(
-                                        width: 16,
-                                        child: Text(
-                                          ':',
-                                          textAlign: TextAlign.center,
-                                          style: Theme.of(context)
-                                              .textTheme
-                                              .titleMedium,
-                                        ),
-                                      ),
-                                      SizedBox(
-                                        width: 80,
-                                        child: TextField(
-                                          onChanged: (_) {
-                                            inputTimeController.setTime();
-                                          },
-                                          decoration: const InputDecoration(
-                                              hintText: 'MM',
-                                              border: InputBorder.none),
-                                          textAlign: TextAlign.center,
-                                          controller: inputTimeController
-                                              .inputMinutesController,
-                                          keyboardType: TextInputType.number,
-                                          inputFormatters: [
-                                            FilteringTextInputFormatter.allow(
-                                                RegExp(
-                                                    '[1,2,3,4,5,6,7,8,9,0]')),
-                                            LengthLimitingTextInputFormatter(2),
-                                            LimitRange(00, 59)
-                                          ],
-                                        ),
-                                      ),
-                                      const SizedBox(
-                                        width: 16,
-                                      ),
-                                      Visibility(
-                                        visible: !settingsController
-                                            .is24HrsEnabled.value,
-                                        child: DropdownButton(
-                                          underline: Container(),
-                                          value: inputTimeController.isAM.value
-                                              ? 'AM'
-                                              : 'PM',
-                                          dropdownColor:
-                                              themeController.isLightMode.value
-                                                  ? kLightPrimaryBackgroundColor
-                                                  : kprimaryBackgroundColor,
-                                          items:
-                                              ['AM', 'PM'].map((String period) {
-                                            return DropdownMenuItem<String>(
-                                              value: period,
-                                              child: Text(period),
-                                            );
-                                          }).toList(),
-                                          onChanged: (getPeriod) {
-                                            inputTimeController
-                                                .changePeriod(getPeriod!);
-
-                                            inputTimeController.setTime();
-                                          },
-                                        ),
-                                      )
-                                    ],
-                                  ),
-                          );
-                        })),
-                    RepeatTile(
-                      controller: controller,
-                      themeController: themeController,
-                    ),
-                    Container(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.all(20.0),
+                  child: Text(
+                    'Uh-oh!',
+                    style: Theme.of(context)
+                        .textTheme
+                        .displayMedium!
+                        .copyWith(
                       color: themeController.isLightMode.value
-                          ? kLightSecondaryBackgroundColor
-                          : ksecondaryBackgroundColor,
-                      child: Divider(
-                        color: themeController.isLightMode.value
-                            ? kLightPrimaryDisabledTextColor
-                            : kprimaryDisabledTextColor,
-                      ),
+                          ? kLightPrimaryDisabledTextColor
+                          : kprimaryDisabledTextColor,
                     ),
-                    Obx(() => (!controller.repeatDays
-                            .every((element) => element == false))
-                        ? RepeatOnceTile(
-                            controller: controller,
-                            themeController: themeController,
-                          )
-                        : const SizedBox()),
-                    Obx(() => (!controller.repeatDays
-                            .every((element) => element == false))
-                        ? Container(
-                            color: themeController.isLightMode.value
-                                ? kLightSecondaryBackgroundColor
-                                : ksecondaryBackgroundColor,
-                            child: Divider(
-                              color: themeController.isLightMode.value
-                                  ? kLightPrimaryDisabledTextColor
-                                  : kprimaryDisabledTextColor,
+                  ),
+                ),
+                SvgPicture.asset(
+                  'assets/images/locked.svg',
+                  height: height * 0.24,
+                  width: width * 0.5,
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(20.0),
+                  child: Text(
+                    'This alarm is currently being edited!',
+                    style: Theme.of(context)
+                        .textTheme
+                        .displaySmall!
+                        .copyWith(
+                      color: themeController.isLightMode.value
+                          ? kLightPrimaryDisabledTextColor
+                          : kprimaryDisabledTextColor,
+                    ),
+                  ),
+                ),
+                TextButton(
+                  style: ButtonStyle(
+                    backgroundColor:
+                    MaterialStateProperty.all(kprimaryColor),
+                  ),
+                  child: Text(
+                    'Go back',
+                    style: Theme.of(context)
+                        .textTheme
+                        .displaySmall!
+                        .copyWith(
+                      color: themeController.isLightMode.value
+                          ? kLightSecondaryTextColor
+                          : ksecondaryTextColor,
+                    ),
+                  ),
+                  onPressed: () {
+                    Utils.hapticFeedback();
+                    Get.back();
+                  },
+                ),
+              ],
+            ),
+          )
+              : ListView(
+            children: [
+              Container(
+                  color: themeController.isLightMode.value
+                      ? kLightSecondaryBackgroundColor
+                      : ksecondaryBackgroundColor,
+                  height: height * 0.32,
+                  width: width,
+                  child: Obx(() {
+                    return InkWell(
+                      onTap: () {
+                        Utils.hapticFeedback();
+                        inputTimeController.changeDatePicker();
+                      },
+                      child: inputTimeController.isTimePicker.value
+                          ? TimePickerSpinner(
+                        time: controller.selectedTime.value,
+                        isForce2Digits: true,
+                        alignment: Alignment.center,
+                        is24HourMode:
+                        settingsController.is24HrsEnabled.value,
+                        normalTextStyle: Theme.of(context)
+                            .textTheme
+                            .displayMedium!
+                            .copyWith(
+                          fontWeight: FontWeight.normal,
+                          color: themeController
+                              .isLightMode.value
+                              ? kLightPrimaryDisabledTextColor
+                              : kprimaryDisabledTextColor,
+                        ),
+                        highlightedTextStyle: Theme.of(context)
+                            .textTheme
+                            .displayMedium,
+                        onTimeChange: (dateTime) {
+                          Utils.hapticFeedback();
+                          controller.selectedTime.value = dateTime;
+                          inputTimeController.inputHrsController
+                              .text = settingsController
+                              .is24HrsEnabled.value
+                              ? dateTime.hour.toString()
+                              : (dateTime.hour == 0
+                              ? 12.toString()
+                              : (dateTime.hour > 12
+                              ? (dateTime.hour - 12)
+                              .toString()
+                              : dateTime.hour.toString()));
+                          inputTimeController.inputMinutesController
+                              .text = dateTime.minute.toString();
+                          inputTimeController.changePeriod(
+                              dateTime.hour >= 12 ? 'PM' : 'AM');
+                        },
+                      )
+                          : Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          SizedBox(
+                            width: 80,
+                            child: TextField(
+                              onChanged: (_) {
+                                inputTimeController.setTime();
+                              },
+                              decoration: const InputDecoration(
+                                  hintText: 'HH',
+                                  border: InputBorder.none),
+                              textAlign: TextAlign.center,
+                              controller: inputTimeController
+                                  .inputHrsController,
+                              keyboardType: TextInputType.number,
+                              inputFormatters: [
+                                FilteringTextInputFormatter.allow(
+                                    RegExp(
+                                        '[1,2,3,4,5,6,7,8,9,0]')),
+                                LengthLimitingTextInputFormatter(2),
+                                LimitRange(
+                                    0,
+                                    settingsController
+                                        .is24HrsEnabled.value
+                                        ? 23
+                                        : 12)
+                              ],
+                            ),
+                          ),
+                          SizedBox(
+                            width: 16,
+                            child: Text(
+                              ':',
+                              textAlign: TextAlign.center,
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .titleMedium,
+                            ),
+                          ),
+                          SizedBox(
+                            width: 80,
+                            child: TextField(
+                              onChanged: (_) {
+                                inputTimeController.setTime();
+                              },
+                              decoration: const InputDecoration(
+                                  hintText: 'MM',
+                                  border: InputBorder.none),
+                              textAlign: TextAlign.center,
+                              controller: inputTimeController
+                                  .inputMinutesController,
+                              keyboardType: TextInputType.number,
+                              inputFormatters: [
+                                FilteringTextInputFormatter.allow(
+                                    RegExp(
+                                        '[1,2,3,4,5,6,7,8,9,0]')),
+                                LengthLimitingTextInputFormatter(2),
+                                LimitRange(00, 59)
+                              ],
+                            ),
+                          ),
+                          const SizedBox(
+                            width: 16,
+                          ),
+                          Visibility(
+                            visible: !settingsController
+                                .is24HrsEnabled.value,
+                            child: DropdownButton(
+                              underline: Container(),
+                              value: inputTimeController.isAM.value
+                                  ? 'AM'
+                                  : 'PM',
+                              dropdownColor:
+                              themeController.isLightMode.value
+                                  ? kLightPrimaryBackgroundColor
+                                  : kprimaryBackgroundColor,
+                              items:
+                              ['AM', 'PM'].map((String period) {
+                                return DropdownMenuItem<String>(
+                                  value: period,
+                                  child: Text(period),
+                                );
+                              }).toList(),
+                              onChanged: (getPeriod) {
+                                inputTimeController
+                                    .changePeriod(getPeriod!);
+
+                                inputTimeController.setTime();
+                              },
                             ),
                           )
-                        : const SizedBox()),
-                    SnoozeDurationTile(
-                      controller: controller,
-                      themeController: themeController,
-                    ),
-                    Container(
-                      color: themeController.isLightMode.value
-                          ? kLightSecondaryBackgroundColor
-                          : ksecondaryBackgroundColor,
-                      child: Divider(
-                        color: themeController.isLightMode.value
-                            ? kLightPrimaryDisabledTextColor
-                            : kprimaryDisabledTextColor,
+                        ],
+                      ),
+                    );
+                  })),
+              RepeatTile(
+                controller: controller,
+                themeController: themeController,
+              ),
+              Container(
+                color: themeController.isLightMode.value
+                    ? kLightSecondaryBackgroundColor
+                    : ksecondaryBackgroundColor,
+                child: Divider(
+                  color: themeController.isLightMode.value
+                      ? kLightPrimaryDisabledTextColor
+                      : kprimaryDisabledTextColor,
+                ),
+              ),
+              Obx(() => (!controller.repeatDays
+                  .every((element) => element == false))
+                  ? RepeatOnceTile(
+                controller: controller,
+                themeController: themeController,
+              )
+                  : const SizedBox()),
+              Obx(() => (!controller.repeatDays
+                  .every((element) => element == false))
+                  ? Container(
+                color: themeController.isLightMode.value
+                    ? kLightSecondaryBackgroundColor
+                    : ksecondaryBackgroundColor,
+                child: Divider(
+                  color: themeController.isLightMode.value
+                      ? kLightPrimaryDisabledTextColor
+                      : kprimaryDisabledTextColor,
+                ),
+              )
+                  : const SizedBox()),
+              SnoozeDurationTile(
+                controller: controller,
+                themeController: themeController,
+              ),
+              Container(
+                color: themeController.isLightMode.value
+                    ? kLightSecondaryBackgroundColor
+                    : ksecondaryBackgroundColor,
+                child: Divider(
+                  color: themeController.isLightMode.value
+                      ? kLightPrimaryDisabledTextColor
+                      : kprimaryDisabledTextColor,
+                ),
+              ),
+              LabelTile(
+                controller: controller,
+                themeController: themeController,
+              ),
+              Container(
+                color: themeController.isLightMode.value
+                    ? kLightSecondaryBackgroundColor
+                    : ksecondaryBackgroundColor,
+                child: Divider(
+                  color: themeController.isLightMode.value
+                      ? kLightPrimaryDisabledTextColor
+                      : kprimaryDisabledTextColor,
+                ),
+              ),
+              ChooseRingtoneTile(
+                controller: controller,
+                themeController: themeController,
+                height: height,
+                width: width,
+              ),
+              Container(
+                color: themeController.isLightMode.value
+                    ? kLightPrimaryBackgroundColor
+                    : ksecondaryTextColor,
+                height: 10,
+                width: width,
+              ),
+              Container(
+                color: themeController.isLightMode.value
+                    ? kLightSecondaryBackgroundColor
+                    : ksecondaryBackgroundColor,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Center(
+                      child: Padding(
+                        padding: const EdgeInsets.only(top: 10.0),
+                        child: Text(
+                          'Automatic Cancellation',
+                          style: Theme.of(context)
+                              .textTheme
+                              .titleMedium!
+                              .copyWith(
+                            fontWeight: FontWeight.w500,
+                            color: themeController.isLightMode.value
+                                ? kLightPrimaryTextColor
+                                .withOpacity(0.85)
+                                : kprimaryTextColor.withOpacity(0.85),
+                          ),
+                        ),
                       ),
                     ),
-                    LabelTile(
+                    ScreenActivityTile(
                       controller: controller,
                       themeController: themeController,
                     ),
-                    Container(
+                    Divider(
                       color: themeController.isLightMode.value
-                          ? kLightSecondaryBackgroundColor
-                          : ksecondaryBackgroundColor,
-                      child: Divider(
-                        color: themeController.isLightMode.value
-                            ? kLightPrimaryDisabledTextColor
-                            : kprimaryDisabledTextColor,
-                      ),
+                          ? kLightPrimaryDisabledTextColor
+                          : kprimaryDisabledTextColor,
                     ),
-                    ChooseRingtoneTile(
+                    WeatherTile(
                       controller: controller,
                       themeController: themeController,
+                    ),
+                    Divider(
+                      color: themeController.isLightMode.value
+                          ? kLightPrimaryDisabledTextColor
+                          : kprimaryDisabledTextColor,
+                    ),
+                    LocationTile(
+                      controller: controller,
                       height: height,
                       width: width,
-                    ),
-                    Container(
-                      color: themeController.isLightMode.value
-                          ? kLightPrimaryBackgroundColor
-                          : ksecondaryTextColor,
-                      height: 10,
-                      width: width,
-                    ),
-                    Container(
-                      color: themeController.isLightMode.value
-                          ? kLightSecondaryBackgroundColor
-                          : ksecondaryBackgroundColor,
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Center(
-                            child: Padding(
-                              padding: const EdgeInsets.only(top: 10.0),
-                              child: Text(
-                                'Automatic Cancellation',
-                                style: Theme.of(context)
-                                    .textTheme
-                                    .titleMedium!
-                                    .copyWith(
-                                      fontWeight: FontWeight.w500,
-                                      color: themeController.isLightMode.value
-                                          ? kLightPrimaryTextColor
-                                              .withOpacity(0.85)
-                                          : kprimaryTextColor.withOpacity(0.85),
-                                    ),
-                              ),
-                            ),
-                          ),
-                          ScreenActivityTile(
-                            controller: controller,
-                            themeController: themeController,
-                          ),
-                          Divider(
-                            color: themeController.isLightMode.value
-                                ? kLightPrimaryDisabledTextColor
-                                : kprimaryDisabledTextColor,
-                          ),
-                          WeatherTile(
-                            controller: controller,
-                            themeController: themeController,
-                          ),
-                          Divider(
-                            color: themeController.isLightMode.value
-                                ? kLightPrimaryDisabledTextColor
-                                : kprimaryDisabledTextColor,
-                          ),
-                          LocationTile(
-                            controller: controller,
-                            height: height,
-                            width: width,
-                            themeController: themeController,
-                          ),
-                        ],
-                      ),
-                    ),
-                    Container(
-                      color: themeController.isLightMode.value
-                          ? kLightPrimaryBackgroundColor
-                          : ksecondaryTextColor,
-                      height: 10,
-                      width: width,
-                    ),
-                    Container(
-                      color: themeController.isLightMode.value
-                          ? kLightSecondaryBackgroundColor
-                          : ksecondaryBackgroundColor,
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Center(
-                            child: Padding(
-                              padding: const EdgeInsets.only(top: 10.0),
-                              child: Text(
-                                'Challenges',
-                                style: Theme.of(
-                                  context,
-                                ).textTheme.titleMedium!.copyWith(
-                                      fontWeight: FontWeight.w500,
-                                      color: themeController.isLightMode.value
-                                          ? kLightPrimaryTextColor
-                                              .withOpacity(0.85)
-                                          : kprimaryTextColor.withOpacity(0.85),
-                                    ),
-                              ),
-                            ),
-                          ),
-                          ShakeToDismiss(
-                            controller: controller,
-                            themeController: themeController,
-                          ),
-                          Divider(
-                            color: themeController.isLightMode.value
-                                ? kLightPrimaryDisabledTextColor
-                                : kprimaryDisabledTextColor,
-                          ),
-                          QrBarCode(
-                            controller: controller,
-                            themeController: themeController,
-                          ),
-                          Divider(
-                            color: themeController.isLightMode.value
-                                ? kLightPrimaryDisabledTextColor
-                                : kprimaryDisabledTextColor,
-                          ),
-                          MathsChallenge(
-                            controller: controller,
-                            themeController: themeController,
-                          ),
-                        ],
-                      ),
-                    ),
-                    Container(
-                      color: themeController.isLightMode.value
-                          ? kLightPrimaryBackgroundColor
-                          : ksecondaryTextColor,
-                      height: 10,
-                      width: width,
-                    ),
-                    Container(
-                      color: themeController.isLightMode.value
-                          ? kLightSecondaryBackgroundColor
-                          : ksecondaryBackgroundColor,
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Center(
-                            child: Padding(
-                              padding: const EdgeInsets.only(top: 10.0),
-                              child: Text(
-                                'Shared Alarm',
-                                style: Theme.of(
-                                  context,
-                                ).textTheme.titleMedium!.copyWith(
-                                      fontWeight: FontWeight.w500,
-                                      color: themeController.isLightMode.value
-                                          ? kLightPrimaryTextColor
-                                              .withOpacity(0.85)
-                                          : kprimaryTextColor.withOpacity(0.85),
-                                    ),
-                              ),
-                            ),
-                          ),
-                          SharedAlarm(
-                            controller: controller,
-                            themeController: themeController,
-                          ),
-                          Divider(
-                            color: themeController.isLightMode.value
-                                ? kLightPrimaryDisabledTextColor
-                                : kprimaryDisabledTextColor,
-                          ),
-                          AlarmIDTile(
-                            controller: controller,
-                            width: width,
-                            themeController: themeController,
-                          ),
-                          Obx(
-                            () => Container(
-                              child: (controller.isSharedAlarmEnabled.value)
-                                  ? Divider(
-                                      color: themeController.isLightMode.value
-                                          ? kLightPrimaryDisabledTextColor
-                                          : kprimaryDisabledTextColor,
-                                    )
-                                  : const SizedBox(),
-                            ),
-                          ),
-                          AlarmOffset(
-                            controller: controller,
-                            themeController: themeController,
-                          ),
-                          Obx(
-                            () => Container(
-                              child: (controller.isSharedAlarmEnabled.value &&
-                                      controller.alarmRecord != null)
-                                  ? Divider(
-                                      color: themeController.isLightMode.value
-                                          ? kLightPrimaryDisabledTextColor
-                                          : kprimaryDisabledTextColor,
-                                    )
-                                  : const SizedBox(),
-                            ),
-                          ),
-                          SharedUsers(
-                            controller: controller,
-                            themeController: themeController,
-                          ),
-                        ],
-                      ),
-                    ),
-                    SizedBox(
-                      height: height * 0.15,
+                      themeController: themeController,
                     ),
                   ],
                 ),
+              ),
+              Container(
+                color: themeController.isLightMode.value
+                    ? kLightPrimaryBackgroundColor
+                    : ksecondaryTextColor,
+                height: 10,
+                width: width,
+              ),
+              Container(
+                color: themeController.isLightMode.value
+                    ? kLightSecondaryBackgroundColor
+                    : ksecondaryBackgroundColor,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Center(
+                      child: Padding(
+                        padding: const EdgeInsets.only(top: 10.0),
+                        child: Text(
+                          'Challenges',
+                          style: Theme.of(
+                            context,
+                          ).textTheme.titleMedium!.copyWith(
+                            fontWeight: FontWeight.w500,
+                            color: themeController.isLightMode.value
+                                ? kLightPrimaryTextColor
+                                .withOpacity(0.85)
+                                : kprimaryTextColor.withOpacity(0.85),
+                          ),
+                        ),
+                      ),
+                    ),
+                    ShakeToDismiss(
+                      controller: controller,
+                      themeController: themeController,
+                    ),
+                    Divider(
+                      color: themeController.isLightMode.value
+                          ? kLightPrimaryDisabledTextColor
+                          : kprimaryDisabledTextColor,
+                    ),
+                    QrBarCode(
+                      controller: controller,
+                      themeController: themeController,
+                    ),
+                    Divider(
+                      color: themeController.isLightMode.value
+                          ? kLightPrimaryDisabledTextColor
+                          : kprimaryDisabledTextColor,
+                    ),
+                    MathsChallenge(
+                      controller: controller,
+                      themeController: themeController,
+                    ),
+                  ],
+                ),
+              ),
+              Container(
+                color: themeController.isLightMode.value
+                    ? kLightPrimaryBackgroundColor
+                    : ksecondaryTextColor,
+                height: 10,
+                width: width,
+              ),
+              Container(
+                color: themeController.isLightMode.value
+                    ? kLightSecondaryBackgroundColor
+                    : ksecondaryBackgroundColor,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Center(
+                      child: Padding(
+                        padding: const EdgeInsets.only(top: 10.0),
+                        child: Text(
+                          'Shared Alarm',
+                          style: Theme.of(
+                            context,
+                          ).textTheme.titleMedium!.copyWith(
+                            fontWeight: FontWeight.w500,
+                            color: themeController.isLightMode.value
+                                ? kLightPrimaryTextColor
+                                .withOpacity(0.85)
+                                : kprimaryTextColor.withOpacity(0.85),
+                          ),
+                        ),
+                      ),
+                    ),
+                    SharedAlarm(
+                      controller: controller,
+                      themeController: themeController,
+                    ),
+                    Divider(
+                      color: themeController.isLightMode.value
+                          ? kLightPrimaryDisabledTextColor
+                          : kprimaryDisabledTextColor,
+                    ),
+                    AlarmIDTile(
+                      controller: controller,
+                      width: width,
+                      themeController: themeController,
+                    ),
+                    Obx(
+                          () => Container(
+                        child: (controller.isSharedAlarmEnabled.value)
+                            ? Divider(
+                          color: themeController.isLightMode.value
+                              ? kLightPrimaryDisabledTextColor
+                              : kprimaryDisabledTextColor,
+                        )
+                            : const SizedBox(),
+                      ),
+                    ),
+                    AlarmOffset(
+                      controller: controller,
+                      themeController: themeController,
+                    ),
+                    Obx(
+                          () => Container(
+                        child: (controller.isSharedAlarmEnabled.value &&
+                            controller.alarmRecord != null)
+                            ? Divider(
+                          color: themeController.isLightMode.value
+                              ? kLightPrimaryDisabledTextColor
+                              : kprimaryDisabledTextColor,
+                        )
+                            : const SizedBox(),
+                      ),
+                    ),
+                    SharedUsers(
+                      controller: controller,
+                      themeController: themeController,
+                    ),
+                  ],
+                ),
+              ),
+              SizedBox(
+                height: height * 0.15,
+              ),
+            ],
+          ),
         ));
   }
 }

--- a/lib/app/modules/addOrUpdateAlarm/views/add_or_update_alarm_view.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/add_or_update_alarm_view.dart
@@ -173,163 +173,97 @@ class AddOrUpdateAlarmView extends GetView<AddOrUpdateAlarmController> {
                       controller.selectedTime.value,
                     ),
                   );
-                  bool res = await IsarDb.doesAlarmExistTime(time,true);
-                  if (res){
-                    Get.defaultDialog(
-                      titlePadding: const EdgeInsets.symmetric(
-                        vertical: 20,
-                      ),
-                      backgroundColor: themeController.isLightMode.value
-                          ? kLightSecondaryBackgroundColor
-                          : ksecondaryBackgroundColor,
-                      title: 'Alarm already set for $time',
-                      titleStyle: Theme.of(context).textTheme.displaySmall,
-                      content: Column(
-                        children: [
-                          Text(
-                            'You have already set a alarm for $time. Please update existing one or set alarm for another time',
-                            style: Theme.of(context).textTheme.bodyMedium,
-                            textAlign: TextAlign.center,
-                          ),
-                          Padding(
-                            padding: const EdgeInsets.only(
-                              top: 20,
-                            ),
-                            child: Row(
-                              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                              children: [
-                                TextButton(
-                                  onPressed: () {
-                                    Get.back();
-                                  },
-                                  style: ButtonStyle(
-                                    backgroundColor:
-                                    MaterialStateProperty.all(kprimaryColor),
-                                  ),
-                                  child: Text(
-                                    'Cancel',
-                                    style: Theme.of(context)
-                                        .textTheme
-                                        .displaySmall!
-                                        .copyWith(
-                                      color: kprimaryBackgroundColor,
-                                    ),
-                                  ),
-                                ),
-                                OutlinedButton(
-                                  onPressed: () {
-                                    Get.offNamedUntil(
-                                      '/home',
-                                          (route) => route.settings.name == '/splash-screen',
-                                    );
-                                  },
-                                  style: OutlinedButton.styleFrom(
-                                    side: BorderSide(
-                                      color: themeController.isLightMode.value
-                                          ? Colors.red.withOpacity(0.9)
-                                          : Colors.red,
-                                      width: 1,
-                                    ),
-                                  ),
-                                  child: Text(
-                                    'Leave',
-                                    style: Theme.of(context)
-                                        .textTheme
-                                        .displaySmall!
-                                        .copyWith(
-                                      color: themeController.isLightMode.value
-                                          ? Colors.red.withOpacity(0.9)
-                                          : Colors.red,
-                                    ),
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-                        ],
-                      ),
-                    );
-
+                  if(controller.alarmRecord != null){
+                    addAlarm();
                   }else{
-                    AlarmModel alarmRecord = AlarmModel(
-                      snoozeDuration: controller.snoozeDuration.value,
-                      offsetDetails: controller.offsetDetails,
-                      label: controller.label.value,
-                      isOneTime: controller.isOneTime.value,
-                      lastEditedUserId: controller.lastEditedUserId,
-                      mutexLock: controller.mutexLock.value,
-                      alarmID: controller.alarmID,
-                      ownerId: controller.ownerId,
-                      ownerName: controller.ownerName,
-                      activityInterval:
-                      controller.activityInterval.value * 60000,
-                      days: controller.repeatDays.toList(),
-                      alarmTime: Utils.timeOfDayToString(
-                        TimeOfDay.fromDateTime(
-                          controller.selectedTime.value,
+                    bool resFirestore = await FirestoreDb.doesAlarmExistTime(controller.userModel, time);
+                    bool resIsardb = await IsarDb.doesAlarmExistTime(time,true);
+                    if (resIsardb || resFirestore){
+                      Get.defaultDialog(
+                        titlePadding: const EdgeInsets.symmetric(
+                          vertical: 20,
                         ),
-                      ),
-                      mainAlarmTime: Utils.timeOfDayToString(
-                        TimeOfDay.fromDateTime(
-                          controller.selectedTime.value,
-                        ),
-                      ),
-                      intervalToAlarm: Utils.getMillisecondsToAlarm(
-                        DateTime.now(),
-                        controller.selectedTime.value,
-                      ),
-                      isActivityEnabled: controller.isActivityenabled.value,
-                      minutesSinceMidnight: Utils.timeOfDayToInt(
-                        TimeOfDay.fromDateTime(
-                          controller.selectedTime.value,
-                        ),
-                      ),
-                      isLocationEnabled: controller.isLocationEnabled.value,
-                      weatherTypes: Utils.getIntFromWeatherTypes(
-                        controller.selectedWeather.toList(),
-                      ),
-                      isWeatherEnabled: controller.isWeatherEnabled.value,
-                      location: Utils.geoPointToString(
-                        Utils.latLngToGeoPoint(
-                          controller.selectedPoint.value,
-                        ),
-                      ),
-                      isSharedAlarmEnabled:
-                      controller.isSharedAlarmEnabled.value,
-                      isQrEnabled: controller.isQrEnabled.value,
-                      qrValue: controller.qrValue.value,
-                      isMathsEnabled: controller.isMathsEnabled.value,
-                      numMathsQuestions: controller.numMathsQuestions.value,
-                      mathsDifficulty:
-                      controller.mathsDifficulty.value.index,
-                      isShakeEnabled: controller.isShakeEnabled.value,
-                      shakeTimes: controller.shakeTimes.value,
-                      ringtoneName: controller.customRingtoneName.value,
-                    );
-
-                    // Adding offset details to the database if
-                    // its a shared alarm
-                    if (controller.isSharedAlarmEnabled.value) {
-                      alarmRecord.offsetDetails = controller.offsetDetails;
-                      alarmRecord.mainAlarmTime = Utils.timeOfDayToString(
-                        TimeOfDay.fromDateTime(
-                          controller.selectedTime.value,
+                        backgroundColor: themeController.isLightMode.value
+                            ? kLightSecondaryBackgroundColor
+                            : ksecondaryBackgroundColor,
+                        title: 'Alarm already set for $time',
+                        titleStyle: Theme.of(context).textTheme.displaySmall,
+                        content: Column(
+                          children: [
+                            Text(
+                              'To overwrite the alarm, select Overwrite, or choose Cancel',
+                              style: Theme.of(context).textTheme.bodyMedium,
+                              textAlign: TextAlign.center,
+                            ),
+                            Padding(
+                              padding: const EdgeInsets.only(
+                                top: 20,
+                              ),
+                              child: Row(
+                                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                                children: [
+                                  TextButton(
+                                    onPressed: () {
+                                      Get.back();
+                                    },
+                                    style: ButtonStyle(
+                                      backgroundColor:
+                                      MaterialStateProperty.all(kprimaryColor),
+                                    ),
+                                    child: Text(
+                                      'Cancel',
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .displaySmall!
+                                          .copyWith(
+                                        color: kprimaryBackgroundColor,
+                                      ),
+                                    ),
+                                  ),
+                                  OutlinedButton(
+                                    onPressed: () async {
+                                      if(resIsardb){
+                                        AlarmModel alarm = await IsarDb.getTriggeredAlarm(time);
+                                        await IsarDb.deleteAlarm(alarm.isarId);
+                                        addAlarm();
+                                        await controller.checkOverlayPermissionAndNavigate();
+                                      }
+                                      if(resFirestore){
+                                        AlarmModel alarm = await FirestoreDb.getTriggeredAlarm(controller.userModel, time);
+                                        await FirestoreDb.deleteAlarm(controller.userModel,alarm.firestoreId!);
+                                        addAlarm();
+                                        await controller.checkOverlayPermissionAndNavigate();
+                                      }
+                                    },
+                                    style: OutlinedButton.styleFrom(
+                                      side: BorderSide(
+                                        color: themeController.isLightMode.value
+                                            ? Colors.red.withOpacity(0.9)
+                                            : Colors.red,
+                                        width: 1,
+                                      ),
+                                    ),
+                                    child: Text(
+                                      'Overwrite',
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .displaySmall!
+                                          .copyWith(
+                                        color: themeController.isLightMode.value
+                                            ? Colors.red.withOpacity(0.9)
+                                            : Colors.red,
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ],
                         ),
                       );
+                    }else{
+                      addAlarm();
                     }
-
-                    try {
-                      if (controller.alarmRecord == null) {
-                        await controller.createAlarm(alarmRecord);
-                      } else {
-                        AlarmModel updatedAlarmModel =
-                        controller.updatedAlarmModel();
-                        await controller.updateAlarm(updatedAlarmModel);
-                      }
-                    } catch (e) {
-                      debugPrint(e.toString());
-                    }
-                    await controller.checkOverlayPermissionAndNavigate();
                   }
                 },
               ),
@@ -837,5 +771,89 @@ class AddOrUpdateAlarmView extends GetView<AddOrUpdateAlarmController> {
             ],
           ),
         ));
+  }
+
+  Future<void> addAlarm() async {
+    AlarmModel alarmRecord = AlarmModel(
+      snoozeDuration: controller.snoozeDuration.value,
+      offsetDetails: controller.offsetDetails,
+      label: controller.label.value,
+      isOneTime: controller.isOneTime.value,
+      lastEditedUserId: controller.lastEditedUserId,
+      mutexLock: controller.mutexLock.value,
+      alarmID: controller.alarmID,
+      ownerId: controller.ownerId,
+      ownerName: controller.ownerName,
+      activityInterval:
+      controller.activityInterval.value * 60000,
+      days: controller.repeatDays.toList(),
+      alarmTime: Utils.timeOfDayToString(
+        TimeOfDay.fromDateTime(
+          controller.selectedTime.value,
+        ),
+      ),
+      mainAlarmTime: Utils.timeOfDayToString(
+        TimeOfDay.fromDateTime(
+          controller.selectedTime.value,
+        ),
+      ),
+      intervalToAlarm: Utils.getMillisecondsToAlarm(
+        DateTime.now(),
+        controller.selectedTime.value,
+      ),
+      isActivityEnabled: controller.isActivityenabled.value,
+      minutesSinceMidnight: Utils.timeOfDayToInt(
+        TimeOfDay.fromDateTime(
+          controller.selectedTime.value,
+        ),
+      ),
+      isLocationEnabled: controller.isLocationEnabled.value,
+      weatherTypes: Utils.getIntFromWeatherTypes(
+        controller.selectedWeather.toList(),
+      ),
+      isWeatherEnabled: controller.isWeatherEnabled.value,
+      location: Utils.geoPointToString(
+        Utils.latLngToGeoPoint(
+          controller.selectedPoint.value,
+        ),
+      ),
+      isSharedAlarmEnabled:
+      controller.isSharedAlarmEnabled.value,
+      isQrEnabled: controller.isQrEnabled.value,
+      qrValue: controller.qrValue.value,
+      isMathsEnabled: controller.isMathsEnabled.value,
+      numMathsQuestions: controller.numMathsQuestions.value,
+      mathsDifficulty:
+      controller.mathsDifficulty.value.index,
+      isShakeEnabled: controller.isShakeEnabled.value,
+      shakeTimes: controller.shakeTimes.value,
+      ringtoneName: controller.customRingtoneName.value,
+    );
+
+    // Adding offset details to the database if
+    // its a shared alarm
+    if (controller.isSharedAlarmEnabled.value) {
+      alarmRecord.offsetDetails = controller.offsetDetails;
+      alarmRecord.mainAlarmTime = Utils.timeOfDayToString(
+        TimeOfDay.fromDateTime(
+          controller.selectedTime.value,
+        ),
+      );
+    }
+
+    try {
+
+      if (controller.alarmRecord == null) {
+        await controller.createAlarm(alarmRecord);
+      } else {
+        AlarmModel updatedAlarmModel =
+        controller.updatedAlarmModel();
+        await controller.updateAlarm(updatedAlarmModel);
+      }
+    } catch (e) {
+      debugPrint(e.toString());
+    }
+    await controller.checkOverlayPermissionAndNavigate();
+
   }
 }


### PR DESCRIPTION
### Description
When users attempt to set multiple alarms for the same time (e.g., 6:00 AM) within the app, the observed behavior is that only the latest alarm among them triggers, while the other alarms are scheduled for the next day

### Proposed Changes
if attempting to set multiple alarms for the same time, the app should display an alert message indicating that an alarm for that specific time is already set, preventing the addition of duplicate alarms at that time

## Fixes #244 

#244 with the issue number which is fixed in this PR
## Screenshots

<!-- If applicable, add screenshots or images demonstrating the changes made -->
![WhatsApp Image 2023-12-18 at 5 52 36 PM](https://github.com/CCExtractor/ultimate_alarm_clock/assets/91874023/aa6191a3-402e-42ac-897c-457943f0113b)

![WhatsApp Image 2023-12-18 at 5 52 42 PM](https://github.com/CCExtractor/ultimate_alarm_clock/assets/91874023/ea0b8d3c-a311-4c0f-83f2-0b8adecf43e0)


## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing