### PR TITLE
Padding added to snooze button in preview alarm.

### DIFF
--- a/lib/app/modules/alarmRing/views/alarm_ring_view.dart
+++ b/lib/app/modules/alarmRing/views/alarm_ring_view.dart
@@ -171,31 +171,38 @@ class AlarmControlView extends GetView<AlarmControlController> {
                 Obx(
                   () => Visibility(
                     visible: !controller.isSnoozing.value,
-                    child: SizedBox(
-                      height: height * 0.07,
-                      width: width * 0.5,
-                      child: TextButton(
-                        style: ButtonStyle(
-                          backgroundColor: MaterialStateProperty.all(
-                            themeController.isLightMode.value
-                                ? kLightSecondaryBackgroundColor
-                                : ksecondaryBackgroundColor,
+                    child: Obx(
+                     () =>  Padding(
+                       padding: Get.arguments != null
+                           ? const EdgeInsets.symmetric(vertical: 90.0)
+                           : EdgeInsets.zero,
+                        child: SizedBox(
+                          height: height * 0.07,
+                          width: width * 0.5,
+                          child: TextButton(
+                            style: ButtonStyle(
+                              backgroundColor: MaterialStateProperty.all(
+                                themeController.isLightMode.value
+                                    ? kLightSecondaryBackgroundColor
+                                    : ksecondaryBackgroundColor,
+                              ),
+                            ),
+                            child: Text(
+                              'Snooze',
+                              style:
+                                  Theme.of(context).textTheme.bodyMedium!.copyWith(
+                                        color: themeController.isLightMode.value
+                                            ? kLightPrimaryTextColor
+                                            : kprimaryTextColor,
+                                        fontWeight: FontWeight.w600,
+                                      ),
+                            ),
+                            onPressed: () {
+                              Utils.hapticFeedback();
+                              controller.startSnooze();
+                            },
                           ),
                         ),
-                        child: Text(
-                          'Snooze',
-                          style:
-                              Theme.of(context).textTheme.bodyMedium!.copyWith(
-                                    color: themeController.isLightMode.value
-                                        ? kLightPrimaryTextColor
-                                        : kprimaryTextColor,
-                                    fontWeight: FontWeight.w600,
-                                  ),
-                        ),
-                        onPressed: () {
-                          Utils.hapticFeedback();
-                          controller.startSnooze();
-                        },
                       ),
                     ),
                   ),


### PR DESCRIPTION
### Description
When we click "preview alarm," the snooze button shows beneath the dismiss button.


### Proposed Changes
Padding added to snooze button in preview alarm.


## Fixes #256

## Screenshots

https://github.com/CCExtractor/ultimate_alarm_clock/assets/88525320/a6404327-f4d2-4557-b335-bcf468b4567f

