### PR TITLE
num of math question updates

### DIFF
--- a/lib/app/modules/alarmChallenge/controllers/alarm_challenge_controller.dart
+++ b/lib/app/modules/alarmChallenge/controllers/alarm_challenge_controller.dart
@@ -30,6 +30,7 @@ class AlarmChallengeController extends GetxController {
   int mathsAnswer = 0;
 
   bool isTimerEnabled = true;
+  bool isNumMathQuestionsSet = false;
 
   void onButtonPressed(String buttonText) {
     displayValue.value += buttonText;
@@ -45,7 +46,10 @@ class AlarmChallengeController extends GetxController {
   }
 
   newMathsQuestion() {
-    numMathsQuestions.value = alarmRecord.numMathsQuestions;
+    if (!isNumMathQuestionsSet){
+      numMathsQuestions.value = alarmRecord.numMathsQuestions;
+      isNumMathQuestionsSet = true;
+    }
     List mathsProblemDetails = Utils.generateMathProblem(
       Difficulty.values[alarmRecord.mathsDifficulty],
     );
@@ -155,6 +159,7 @@ class AlarmChallengeController extends GetxController {
 
   isChallengesComplete() {
     if (!Utils.isChallengeEnabled(alarmRecord)) {
+      isNumMathQuestionsSet = false;
       isTimerEnabled = false;
       Get.offAllNamed('/home');
     }


### PR DESCRIPTION
### Description
I have set up the maths challenge on easy mode for two questions , But even after solving the two questions the alarm doesn't turn off. After completion of the time period, the alarm restarts and the maths challenge has to be done again. This feature is not working properly.

### Proposed Changes
Every time the 'newMathQuestion' function is called, it resets the number of math questions. Therefore, I created a boolean variable that assigns the value of 'numMathQuestions' only for the first time. This way, the code will function as expected, and the number of math questions will change as the user completes questions.

## Fixes #170 


## Screenshots


https://github.com/CCExtractor/ultimate_alarm_clock/assets/91874023/d861276d-52fc-4493-a216-816a3c2c5344



## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [ ] All tests are passing