### PR TITLE
Done Button added in the "add_Or_Update_alarm" in timePickerSpinner when enter the time manually.

### DIFF
--- a/lib/app/modules/addOrUpdateAlarm/controllers/input_time_controller.dart
+++ b/lib/app/modules/addOrUpdateAlarm/controllers/input_time_controller.dart
@@ -12,6 +12,13 @@ class InputTimeController extends GetxController {
   TextEditingController inputHrsController = TextEditingController();
   TextEditingController inputMinutesController = TextEditingController();
   final selectedDateTime = DateTime.now().obs;
+  bool isInputtingTime = false;
+
+  void confirmTimeInput() {
+    setTime();
+    changeDatePicker(); 
+  }
+
   @override
   void onInit() {
     isTimePicker.value = true;

--- a/lib/app/modules/addOrUpdateAlarm/views/add_or_update_alarm_view.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/add_or_update_alarm_view.dart
@@ -479,7 +479,35 @@ class AddOrUpdateAlarmView extends GetView<AddOrUpdateAlarmController> {
                                             inputTimeController.setTime();
                                           },
                                         ),
-                                      )
+                                      ),
+                                      const SizedBox(
+                                        width: 12,
+                                      ),
+                                      Visibility(
+                                        visible: inputTimeController
+                                            .isTimePicker.isFalse,
+                                        child: InkWell(
+                                          onTap: () {
+                                            Utils.hapticFeedback();
+                                            inputTimeController
+                                                .confirmTimeInput();
+                                          },
+                                          child: Container(
+                                            decoration: BoxDecoration(
+                                                borderRadius:
+                                                    BorderRadius.circular(50.0),
+                                                border: Border.all(
+                                                  color: kprimaryColor,
+                                                  width: 1.0,
+                                                )),
+                                            padding: EdgeInsets.all(5.0),
+                                            child: Icon(
+                                              Icons.done,
+                                              color: kprimaryColor,
+                                            ),
+                                          ),
+                                        ),
+                                      ),
                                     ],
                                   ),
                           );


### PR DESCRIPTION
### Description
When we manually enter the time in a text field and want to complete the task, we have two options. Firstly, we can click anywhere on the screen to exit the text field. Secondly, we can click on the "done" button located on the soft keyboard.

To improve the app's user experience, I suggest adding a dedicated "Tick" or "Done" button. This button should only be visible when the user clicks on the timePickerSpinner to enter the time manually. This will make it more convenient for the user to confirm their selection and provide a better overall experience.

### Proposed Changes
Done Button added in the "add_Or_Update_alarm" in timePickerSpinner when entering the time manually.

## Fixes #201 

## Screenshots

https://github.com/CCExtractor/ultimate_alarm_clock/assets/88525320/136f1b77-19bd-47d2-be09-b4db33cfb72d


