### PR TITLE
Delete Custom Ringtone fixed

### DIFF
--- a/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
+++ b/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
@@ -766,6 +766,16 @@ class AddOrUpdateAlarmController extends GetxController {
   }) async {
     try {
       int customRingtoneId = AudioUtils.fastHash(ringtoneName);
+      RingtoneModel? previousRingtone = await IsarDb.getCustomRingtone(customRingtoneId: customRingtoneId);
+
+    if (previousRingtone != null) {
+      int previousCounterOfUsage = previousRingtone.currentCounterOfUsage;
+
+      if (previousCounterOfUsage > 0) {
+        previousRingtone.currentCounterOfUsage--;
+        await IsarDb.addCustomRingtone(previousRingtone);
+      }
+    }
       RingtoneModel? customRingtone =
           await IsarDb.getCustomRingtone(customRingtoneId: customRingtoneId);
 
@@ -782,23 +792,8 @@ class AddOrUpdateAlarmController extends GetxController {
 
           if (await File(ringtoneFilePath).exists()) {
             await File(ringtoneFilePath).delete();
-            Get.snackbar(
-              'Ringtone Deleted',
-              'The selected ringtone has been successfully deleted.',
-            );
-          } else {
-            Get.snackbar(
-              'Ringtone Not Found',
-              'The selected ringtone does not exist and cannot be deleted.',
-            );
-          }
-        } else {
-          Get.snackbar(
-            'Ringtone in Use',
-            'This ringtone cannot be deleted as it is currently assigned'
-                ' to one or more alarms.',
-          );
-        }
+          } 
+        } 
       }
     } catch (e) {
       debugPrint(e.toString());


### PR DESCRIPTION
### Description
Previously, the application faced issues with inaccurate counter values, resulting in the failure to delete custom ringtones under certain conditions.

### Proposed Changes
The modifications ensure that when a custom ringtone is deleted, the counter for the previously selected ringtone is decremented, providing accurate tracking of ringtone usage. Additionally, the removal of Snackbars simplifies the user interface by eliminating potentially redundant or non-critical notifications, leading to a cleaner and more straightforward user experience.


## Fixes #262

Before fix:

https://github.com/tushar11kh/ultimate_alarm_clock/assets/144731286/7a7d20c4-b906-4aa4-ac00-c8b119c759d8

After fix:


https://github.com/tushar11kh/ultimate_alarm_clock/assets/144731286/96d2b7e1-c4ad-46f3-a18f-ade99e9351ef