### PR TITLE
Fixed #275 on Render overflow in home_view.dart drawer

### DIFF
--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -2,7 +2,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:gap/gap.dart';
+
 import 'package:get/get.dart';
 import 'package:flutter_expandable_fab/flutter_expandable_fab.dart';
 import 'package:ultimate_alarm_clock/app/data/models/alarm_model.dart';
@@ -322,7 +322,9 @@ class HomeView extends GetView<HomeController> {
                           ),
                         ),
                       ),
-                      const Gap(10),
+                      const SizedBox(
+                        width: 10,
+                      ),
                       Flexible(
                         flex: 3,
                         child: Column(

--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -2,6 +2,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:gap/gap.dart';
 import 'package:get/get.dart';
 import 'package:flutter_expandable_fab/flutter_expandable_fab.dart';
 import 'package:ultimate_alarm_clock/app/data/models/alarm_model.dart';
@@ -21,6 +22,7 @@ class HomeView extends GetView<HomeController> {
   HomeView({Key? key}) : super(key: key);
   ThemeController themeController = Get.find<ThemeController>();
   SettingsController settingsController = Get.find<SettingsController>();
+
   @override
   Widget build(BuildContext context) {
     AboutController aboutController = Get.put(AboutController());
@@ -307,19 +309,23 @@ class HomeView extends GetView<HomeController> {
           child: Column(
             children: [
               DrawerHeader(
-                  decoration: const BoxDecoration(color: kLightSecondaryColor),
-                  child: Center(
-                    child: Row(
-                      children: [
-                        const CircleAvatar(
-                            radius: 30,
-                            backgroundImage: AssetImage(
-                              'assets/images/ic_launcher-playstore.png',
-                            )),
-                        const SizedBox(
-                          width: 10,
+                decoration: const BoxDecoration(color: kLightSecondaryColor),
+                child: Center(
+                  child: Row(
+                    children: [
+                      const Flexible(
+                        flex: 1,
+                        child: CircleAvatar(
+                          radius: 30,
+                          backgroundImage: AssetImage(
+                            'assets/images/ic_launcher-playstore.png',
+                          ),
                         ),
-                        Column(
+                      ),
+                      const Gap(10),
+                      Flexible(
+                        flex: 3,
+                        child: Column(
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: [
                             SizedBox(
@@ -354,9 +360,11 @@ class HomeView extends GetView<HomeController> {
                             ),
                           ],
                         ),
-                      ],
-                    ),
-                  )),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
               ListTile(
                 onTap: () {
                   Utils.hapticFeedback();
@@ -1003,7 +1011,8 @@ class HomeView extends GetView<HomeController> {
                                                                               Text(
                                                                             alarm.label,
                                                                             overflow:
-                                                                                TextOverflow.ellipsis, // Set overflow property here
+                                                                                TextOverflow.ellipsis,
+                                                                            // Set overflow property here
                                                                             style: Theme.of(context).textTheme.bodySmall!.copyWith(
                                                                                   fontWeight: FontWeight.w500,
                                                                                   color: alarm.isEnabled == true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   fluttertoast: ^8.2.4
   path_provider: ^2.1.1
   audio_session: ^0.1.18
-  gap: ^3.0.1
+
 
 dev_dependencies:
   flutter_lints: ^2.0.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   fluttertoast: ^8.2.4
   path_provider: ^2.1.1
   audio_session: ^0.1.18
+  gap: ^3.0.1
 
 dev_dependencies:
   flutter_lints: ^2.0.3


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this pull request -->
In home_view.dart in the DrawerHeader the row was overflowing on some devices due to it being static and not adjusting by the flex property.

### Proposed Changes
<!-- List the proposed changes introduced by this pull request -->
1) Added the flex property to the widget so that they never overflow using the Flexible widget,
2) Also replaced the sizedBox with Gap() which required an import and an extra package in pubspec.yaml
just because Gap works better in flexible containers and will give less issues in future versions aswell.


## Fixes #275 


## Screenshots

<!-- If applicable, add screenshots or images demonstrating the changes made -->
<img width="309" alt="SCR-20231228-umbb" src="https://github.com/CCExtractor/ultimate_alarm_clock/assets/72385500/c6d6f4cb-c77b-4bce-8a5a-f0ff781dec14">
<img width="306" alt="SCR-20231228-unpn" src="https://github.com/CCExtractor/ultimate_alarm_clock/assets/72385500/89b22ee0-9f54-4039-9070-9c19a2e2922f">



## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [ ] Code follows the established coding style guidelines
- [x] All tests are passing