### PR TITLE
Unnecessary ripple removed from settings

### DIFF
--- a/lib/app/modules/settings/views/google_sign_in.dart
+++ b/lib/app/modules/settings/views/google_sign_in.dart
@@ -23,6 +23,9 @@ class GoogleSignIn extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return InkWell(
+      highlightColor: Colors.transparent,
+      splashFactory: NoSplash.splashFactory,
+      splashColor: Colors.transparent,
       onTap: () async {
         Utils.hapticFeedback();
         if (controller.isUserLoggedIn.value == false) {

--- a/lib/app/modules/settings/views/weather_api.dart
+++ b/lib/app/modules/settings/views/weather_api.dart
@@ -23,6 +23,9 @@ class WeatherApi extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return InkWell(
+      highlightColor: Colors.transparent,
+      splashFactory: NoSplash.splashFactory,
+      splashColor: Colors.transparent,
       onTap: () async {
         Utils.hapticFeedback();
         Get.defaultDialog(


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this pull request -->
fixes #251 

- unnecessary ripple removed from settings includes buttons like 

- Open Weather map api
- sign- in with google

**Have a look**
https://github.com/CCExtractor/ultimate_alarm_clock/assets/103873587/dd6e2353-36b0-43c8-9805-811dfe508b25




### Proposed Changes
<!-- List the proposed changes introduced by this pull request -->

## Fixes #(issue_no)

Replace `issue_no` with the issue number which is fixed in this PR

## Screenshots

<!-- If applicable, add screenshots or images demonstrating the changes made -->

## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [ ] Code follows the established coding style guidelines
- [ ] All tests are passing