### PR TITLE
Undo added on swipe to delete alarm using ScaffoldMessenger

### DIFF
--- a/lib/app/modules/home/controllers/home_controller.dart
+++ b/lib/app/modules/home/controllers/home_controller.dart
@@ -516,4 +516,35 @@ class HomeController extends GetxController {
       ),
     );
   }
+
+  Future<void> swipeToDeleteAlarm(UserModel? user, AlarmModel alarm) async {
+    AlarmModel? alarm_to_delete;
+
+    if (alarm.isSharedAlarmEnabled == true) {
+      alarm_to_delete = await FirestoreDb.getAlarm(user, alarm.firestoreId!);
+      await FirestoreDb.deleteAlarm(user, alarm.firestoreId!);
+    } else {
+      alarm_to_delete = await IsarDb.getAlarm(alarm.isarId);
+      await IsarDb.deleteAlarm(alarm.isarId);
+    }
+
+    // Display snackbar
+    Get.snackbar(
+      'Alarm deleted',
+      'The alarm has been deleted.',
+      duration: const Duration(seconds: 4),
+      snackPosition: SnackPosition.BOTTOM,
+      mainButton: TextButton(
+        onPressed: () async {
+          if (alarm.isSharedAlarmEnabled == true) {
+            await FirestoreDb.addAlarm(user, alarm_to_delete!);
+          } else {
+            await IsarDb.addAlarm(alarm_to_delete!);
+          }
+        },
+        child: const Text('Undo'),
+      ),
+    );
+  }
 }
+

--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -850,15 +850,34 @@ class HomeView extends GetView<HomeController> {
                                       // Main card
                                       return Dismissible(
                                         onDismissed: (direction) async {
+                                          AlarmModel? alarm_to_delete;
                                           if (alarm.isSharedAlarmEnabled ==
                                               true) {
+                                            alarm_to_delete = await FirestoreDb.getAlarm(controller.userModel.value, alarm.firestoreId!);
                                             await FirestoreDb.deleteAlarm(
                                                 controller.userModel.value,
                                                 alarm.firestoreId!);
                                           } else {
+                                            alarm_to_delete = await IsarDb.getAlarm(alarm.isarId);
                                             await IsarDb.deleteAlarm(
                                                 alarm.isarId);
                                           }
+                                          ScaffoldMessenger.of(context).clearSnackBars();
+                                          ScaffoldMessenger.of(context).showSnackBar(
+                                              SnackBar(
+                                                duration: const Duration(seconds: 4),
+                                                  content: const Text('Alarm deleted'),
+                                                action: SnackBarAction(
+                                                    label: 'Undo',
+                                                    onPressed: () async {
+                                                      if (alarm.isSharedAlarmEnabled == true){
+                                                        await FirestoreDb.addAlarm(controller.userModel.value, alarm_to_delete!);
+                                                      }else{
+                                                        await IsarDb.addAlarm(alarm_to_delete!);
+                                                      }
+                                                    },),
+                                              )
+                                          );
                                         },
                                         key: ValueKey(alarms[index]),
                                         child: Obx(

--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -850,34 +850,7 @@ class HomeView extends GetView<HomeController> {
                                       // Main card
                                       return Dismissible(
                                         onDismissed: (direction) async {
-                                          AlarmModel? alarm_to_delete;
-                                          if (alarm.isSharedAlarmEnabled ==
-                                              true) {
-                                            alarm_to_delete = await FirestoreDb.getAlarm(controller.userModel.value, alarm.firestoreId!);
-                                            await FirestoreDb.deleteAlarm(
-                                                controller.userModel.value,
-                                                alarm.firestoreId!);
-                                          } else {
-                                            alarm_to_delete = await IsarDb.getAlarm(alarm.isarId);
-                                            await IsarDb.deleteAlarm(
-                                                alarm.isarId);
-                                          }
-                                          ScaffoldMessenger.of(context).clearSnackBars();
-                                          ScaffoldMessenger.of(context).showSnackBar(
-                                              SnackBar(
-                                                duration: const Duration(seconds: 4),
-                                                  content: const Text('Alarm deleted'),
-                                                action: SnackBarAction(
-                                                    label: 'Undo',
-                                                    onPressed: () async {
-                                                      if (alarm.isSharedAlarmEnabled == true){
-                                                        await FirestoreDb.addAlarm(controller.userModel.value, alarm_to_delete!);
-                                                      }else{
-                                                        await IsarDb.addAlarm(alarm_to_delete!);
-                                                      }
-                                                    },),
-                                              )
-                                          );
+                                          await controller.swipeToDeleteAlarm(controller.userModel.value,alarm);
                                         },
                                         key: ValueKey(alarms[index]),
                                         child: Obx(


### PR DESCRIPTION
### Description
When users swipe to delete an alarm, the application temporarily stores the deleted alarm model in a variable, displaying a Snackbar with an "Undo" option. The Snackbar is powered by ScaffoldMessenger showSnackBar and has a duration of 4 seconds, allowing users to easily undo the deletion within that timeframe

### Proposed Changes

1. Used ScaffoldMessenger method showSnackBar to create a Snackbar for displaying the "Undo" feature.
2. Design the Snackbar to include an "Undo" button, providing users with an option to reverse the deletion.
3. When the user taps "Undo" within the Snackbar, restore the previously deleted alarm model back to the database.
4. Set the duration of the Snackbar to 4 seconds, providing users with a reasonable timeframe to decide whether to undo the deletion.
5. Optimize the visual representation of the alarms to make the swipe-to-delete and undo features intuitive.

## Fixes #314 


## Screenshots


https://github.com/CCExtractor/ultimate_alarm_clock/assets/91874023/a6e55dbd-ce3b-4fb0-999e-3b7f4b5f3c9b



## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing