### PR TITLE
Add options to select days while adding/updating an alarm

### DIFF
--- a/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
+++ b/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
@@ -91,6 +91,34 @@ class AddOrUpdateAlarmController extends GetxController {
     return userDetails;
   }
 
+  RxBool isDailySelected = false.obs;
+  RxBool isWeekdaysSelected = false.obs;
+  RxBool isCustomSelected = false.obs;
+
+  void setIsDailySelected(bool value) {
+    isDailySelected.value = value;
+    if (value == true) {
+      isCustomSelected.value = false;
+      isWeekdaysSelected.value = false;
+    }
+  }
+
+  void setIsWeekdaysSelected(bool value) {
+    isWeekdaysSelected.value = value;
+    if (value == true) {
+      isCustomSelected.value = false;
+      isDailySelected.value = false;
+    }
+  }
+
+  void setIsCustomSelected(bool value) {
+    isCustomSelected.value = value;
+    if (value == true) {
+      isWeekdaysSelected.value = false;
+      isDailySelected.value = false;
+    }
+  }
+
   checkOverlayPermissionAndNavigate() async {
     if (!(await Permission.systemAlertWindow.isGranted) ||
         !(await Permission.ignoreBatteryOptimizations.isGranted) ||

--- a/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
+++ b/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
@@ -112,7 +112,7 @@ class AddOrUpdateAlarmController extends GetxController {
   }
 
   void setIsCustomSelected(bool value) {
-    isCustomSelected.value = value;
+    isCustomSelected.value = true;
     if (value == true) {
       isWeekdaysSelected.value = false;
       isDailySelected.value = false;

--- a/lib/app/modules/addOrUpdateAlarm/views/repeat_once_tile.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/repeat_once_tile.dart
@@ -22,7 +22,7 @@ class RepeatOnceTile extends StatelessWidget {
           ? kLightSecondaryBackgroundColor
           : ksecondaryBackgroundColor,
       title: Text(
-        'Repeat only once'.tr,
+        'Ring once'.tr,
         style: TextStyle(
           color: themeController.isLightMode.value
               ? kLightPrimaryTextColor

--- a/lib/app/modules/addOrUpdateAlarm/views/repeat_tile.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/repeat_tile.dart
@@ -17,9 +17,6 @@ class RepeatTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    bool anyDaySelected =
-        controller.repeatDays.any((daySelected) => daySelected);
-
     List<bool> repeatDays = List<bool>.filled(7, false);
 
     return InkWell(
@@ -46,6 +43,8 @@ class RepeatTile extends StatelessWidget {
           content: Obx(
             () => Column(
               children: [
+                dailyTile(context: context),
+                weekdaysTile(context: context),
                 dayTile(dayIndex: 0, dayName: 'Monday'.tr, context: context),
                 dayTile(dayIndex: 1, dayName: 'Tuesday'.tr, context: context),
                 dayTile(dayIndex: 2, dayName: 'Wednesday'.tr, context: context),
@@ -140,6 +139,103 @@ class RepeatTile extends StatelessWidget {
     for (var i = 0; i < toUse.length; i++) {
       toSet[i] = toUse[i];
     }
+  }
+
+  Widget weekdaysTile({
+    required BuildContext context,
+  }) {
+    bool areWeekdaysSelected = controller.repeatDays
+        .sublist(0, controller.repeatDays.length - 2)
+        .every((daySelected) => daySelected);
+
+    return InkWell(
+      onTap: () {
+        Utils.hapticFeedback();
+        bool newWeekdaysValue = !areWeekdaysSelected;
+        for (int i = 0; i < controller.repeatDays.length - 2; i++) {
+          controller.repeatDays[i] = newWeekdaysValue;
+        }
+      },
+      child: Padding(
+        padding: const EdgeInsets.only(left: 10.0),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Checkbox.adaptive(
+              side: BorderSide(
+                width: 1.5,
+                color: themeController.isLightMode.value
+                    ? kLightPrimaryTextColor.withOpacity(0.5)
+                    : kprimaryTextColor.withOpacity(0.5),
+              ),
+              activeColor: kprimaryColor.withOpacity(0.8),
+              value: areWeekdaysSelected,
+              onChanged: (value) {
+                Utils.hapticFeedback();
+                bool newWeekdaysValue = !areWeekdaysSelected;
+                for (int i = 0; i < controller.repeatDays.length - 2; i++) {
+                  controller.repeatDays[i] = newWeekdaysValue;
+                }
+              },
+            ),
+            Text(
+              'Weekdays',
+              style:
+                  Theme.of(context).textTheme.bodySmall!.copyWith(fontSize: 15),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget dailyTile({
+    required BuildContext context,
+  }) {
+    bool isDailySelected =
+        controller.repeatDays.every((daySelected) => daySelected);
+
+    return InkWell(
+      onTap: () {
+        Utils.hapticFeedback();
+        bool newDailyValue = !isDailySelected;
+        for (int i = 0; i < controller.repeatDays.length; i++) {
+          controller.repeatDays[i] = newDailyValue;
+        }
+      },
+      child: Padding(
+        padding: const EdgeInsets.only(left: 10.0),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Checkbox.adaptive(
+              side: BorderSide(
+                width: 1.5,
+                color: themeController.isLightMode.value
+                    ? kLightPrimaryTextColor.withOpacity(0.5)
+                    : kprimaryTextColor.withOpacity(0.5),
+              ),
+              activeColor: kprimaryColor.withOpacity(0.8),
+              value: isDailySelected,
+              onChanged: (value) {
+                Utils.hapticFeedback();
+                bool newDailyValue = !isDailySelected;
+                for (int i = 0; i < controller.repeatDays.length; i++) {
+                  controller.repeatDays[i] = newDailyValue;
+                }
+              },
+            ),
+            Text(
+              'Daily',
+              style:
+                  Theme.of(context).textTheme.bodySmall!.copyWith(fontSize: 15),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 
   Widget dayTile({

--- a/lib/app/modules/addOrUpdateAlarm/views/repeat_tile.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/repeat_tile.dart
@@ -20,6 +20,7 @@ class RepeatTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     List<bool> repeatDays = List<bool>.filled(7, false);
+
     return InkWell(
       onTap: () {
         Get.bottomSheet(
@@ -31,19 +32,94 @@ class RepeatTile extends StatelessWidget {
                 ? kLightSecondaryBackgroundColor
                 : ksecondaryBackgroundColor,
             builder: (BuildContext context) {
-              return Column(
-                children: [
-                  buildDailyTile(
-                    controller: controller,
-                    themeController: themeController,
-                  ),
-                  buildWeekdaysTile(
-                      controller: controller, themeController: themeController),
-                  RepeatOnceTile(
-                    controller: controller,
-                    themeController: themeController,
-                  ),
-                ],
+              return Container(
+                height: MediaQuery.of(context).size.height * 0.6,
+                child: Column(
+                  children: [
+                    buildDailyTile(
+                      controller: controller,
+                      themeController: themeController,
+                    ),
+                    Container(
+                      color: themeController.isLightMode.value
+                          ? kLightSecondaryBackgroundColor
+                          : ksecondaryBackgroundColor,
+                      child: Divider(
+                        color: themeController.isLightMode.value
+                            ? kLightPrimaryDisabledTextColor
+                            : kprimaryDisabledTextColor,
+                      ),
+                    ),
+                    buildWeekdaysTile(
+                      controller: controller,
+                      themeController: themeController,
+                    ),
+                    Container(
+                      color: themeController.isLightMode.value
+                          ? kLightSecondaryBackgroundColor
+                          : ksecondaryBackgroundColor,
+                      child: Divider(
+                        color: themeController.isLightMode.value
+                            ? kLightPrimaryDisabledTextColor
+                            : kprimaryDisabledTextColor,
+                      ),
+                    ),
+                    buildCustomDaysTile(
+                      controller: controller,
+                      themeController: themeController,
+                      context: context,
+                    ),
+                    Container(
+                      color: themeController.isLightMode.value
+                          ? kLightSecondaryBackgroundColor
+                          : ksecondaryBackgroundColor,
+                      child: Divider(
+                        color: themeController.isLightMode.value
+                            ? kLightPrimaryDisabledTextColor
+                            : kprimaryDisabledTextColor,
+                      ),
+                    ),
+                    RepeatOnceTile(
+                      controller: controller,
+                      themeController: themeController,
+                    ),
+                    const SizedBox(
+                      height: 25,
+                    ),
+                    SizedBox(
+                      width: MediaQuery.of(context).size.width,
+                      child: Padding(
+                        padding: const EdgeInsets.only(
+                          left: 25,
+                          right: 25,
+                        ),
+                        child: TextButton(
+                          style: ButtonStyle(
+                            backgroundColor: MaterialStateProperty.all(
+                              kprimaryColor,
+                            ),
+                          ),
+                          onPressed: () {
+                            Utils.hapticFeedback();
+                            Get.back();
+                          },
+                          child: Text(
+                            'Done',
+                            style: Theme.of(context)
+                                .textTheme
+                                .displaySmall!
+                                .copyWith(
+                                  color: controller
+                                          .themeController.isLightMode.value
+                                      ? kLightPrimaryTextColor
+                                      : ksecondaryTextColor,
+                                ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
               );
             },
           ),
@@ -147,18 +223,151 @@ class RepeatTile extends StatelessWidget {
     );
   }
 
+  Widget dayTile({
+    required int dayIndex,
+    required String dayName,
+    required BuildContext context,
+  }) {
+    return Obx(
+      () => InkWell(
+        onTap: () {
+          Utils.hapticFeedback();
+          controller.repeatDays[dayIndex] = !controller.repeatDays[dayIndex];
+        },
+        child: Padding(
+          padding: const EdgeInsets.only(left: 10.0),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Checkbox.adaptive(
+                side: BorderSide(
+                  width: 1.5,
+                  color: themeController.isLightMode.value
+                      ? kLightPrimaryTextColor.withOpacity(0.5)
+                      : kprimaryTextColor.withOpacity(0.5),
+                ),
+                activeColor: kprimaryColor.withOpacity(0.8),
+                value: controller.repeatDays[dayIndex],
+                onChanged: (value) {
+                  Utils.hapticFeedback();
+                  controller.repeatDays[dayIndex] = value!;
+                },
+              ),
+              Text(
+                dayName,
+                style: Theme.of(context)
+                    .textTheme
+                    .bodySmall!
+                    .copyWith(fontSize: 15),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
   ListTile buildCustomDaysTile({
     required AddOrUpdateAlarmController controller,
     required ThemeController themeController,
+    required BuildContext context,
   }) {
+    List<bool> repeatDays = List<bool>.filled(7, false);
     return ListTile(
       contentPadding: EdgeInsets.only(left: 10.0),
       title: Obx(
         () => InkWell(
           onTap: () {
             Utils.hapticFeedback();
+            _storeOrPreset(repeatDays, controller.repeatDays);
+
             controller.setIsCustomSelected(!controller.isCustomSelected.value);
-            
+            Get.defaultDialog(
+              onWillPop: () async {
+                // presetting values to initial state
+                _storeOrPreset(controller.repeatDays, repeatDays);
+                return true;
+              },
+              titlePadding: const EdgeInsets.symmetric(vertical: 20),
+              backgroundColor: themeController.isLightMode.value
+                  ? kLightSecondaryBackgroundColor
+                  : ksecondaryBackgroundColor,
+              title: 'Days of the week'.tr,
+              titleStyle: TextStyle(
+                color: themeController.isLightMode.value
+                    ? kLightPrimaryTextColor
+                    : kprimaryTextColor,
+              ),
+              content: Column(
+                children: [
+                  dayTile(
+                    dayIndex: 0,
+                    dayName: 'Monday'.tr,
+                    context: context,
+                  ),
+                  dayTile(
+                    dayIndex: 1,
+                    dayName: 'Tuesday'.tr,
+                    context: context,
+                  ),
+                  dayTile(
+                    dayIndex: 2,
+                    dayName: 'Wednesday'.tr,
+                    context: context,
+                  ),
+                  dayTile(
+                    dayIndex: 3,
+                    dayName: 'Thursday'.tr,
+                    context: context,
+                  ),
+                  dayTile(
+                    dayIndex: 4,
+                    dayName: 'Friday'.tr,
+                    context: context,
+                  ),
+                  dayTile(
+                    dayIndex: 5,
+                    dayName: 'Saturday'.tr,
+                    context: context,
+                  ),
+                  dayTile(
+                    dayIndex: 6,
+                    dayName: 'Sunday'.tr,
+                    context: context,
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.only(left: 10.0),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        ElevatedButton(
+                          onPressed: () {
+                            Utils.hapticFeedback();
+                            Get.back();
+                          },
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: kprimaryColor,
+                          ),
+                          child: Text(
+                            'Done'.tr,
+                            style: Theme.of(context)
+                                .textTheme
+                                .displaySmall!
+                                .copyWith(
+                                  color: themeController.isLightMode.value
+                                      ? kLightPrimaryTextColor
+                                      : ksecondaryTextColor,
+                                ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            );
           },
           child: Padding(
             padding: EdgeInsets.all(8.0),
@@ -175,9 +384,13 @@ class RepeatTile extends StatelessWidget {
                         : kprimaryTextColor.withOpacity(0.5),
                   ),
                   activeColor: kprimaryColor.withOpacity(0.8),
-                  value: controller.isDailySelected.value,
+                  value: controller.isCustomSelected.value,
                   onChanged: (value) {
-                    // This onChanged can be empty, as we handle the tap in InkWell
+                    Utils.hapticFeedback();
+                    controller.setIsCustomSelected(value!);
+
+                    // Update repeatDays based on isCustomSelected value
+                    _storeOrPreset(controller.repeatDays, repeatDays);
                   },
                 ),
               ],

--- a/lib/app/modules/addOrUpdateAlarm/views/repeat_tile.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/repeat_tile.dart
@@ -33,7 +33,7 @@ class RepeatTile extends StatelessWidget {
                 : ksecondaryBackgroundColor,
             builder: (BuildContext context) {
               return Container(
-                height: MediaQuery.of(context).size.height * 0.6,
+                height: MediaQuery.of(context).size.height * 0.45,
                 child: Column(
                   children: [
                     buildDailyTile(
@@ -68,20 +68,6 @@ class RepeatTile extends StatelessWidget {
                       controller: controller,
                       themeController: themeController,
                       context: context,
-                    ),
-                    Container(
-                      color: themeController.isLightMode.value
-                          ? kLightSecondaryBackgroundColor
-                          : ksecondaryBackgroundColor,
-                      child: Divider(
-                        color: themeController.isLightMode.value
-                            ? kLightPrimaryDisabledTextColor
-                            : kprimaryDisabledTextColor,
-                      ),
-                    ),
-                    RepeatOnceTile(
-                      controller: controller,
-                      themeController: themeController,
                     ),
                     const SizedBox(
                       height: 25,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -389,26 +389,26 @@ packages:
     dependency: "direct main"
     description:
       name: fl_location
-      sha256: "4d19ccfb73e7d15dd9199c4f0e24dc1b058891eb43427507886871889427c62b"
+      sha256: "011d99a483bdb0e8fcef673d8991dce871ee91d37f5bdbadbe86ab06a38000fd"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "2.1.1"
   fl_location_platform_interface:
     dependency: transitive
     description:
       name: fl_location_platform_interface
-      sha256: ffb84044f1791ec719477bf43a26b6d347af697dacf624a25f5c28721d3a0ce1
+      sha256: "2e51523d4ebbee57212891f1d9674a179a2af3500b67e64d4af2ba040b952614"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "2.0.0"
   fl_location_web:
     dependency: transitive
     description:
       name: fl_location_web
-      sha256: db4cecc6e120dff002339e350be6a9e59e311925802bfd8c648c8789ed2c1003
+      sha256: "576e64609517c524fbc6b0f221e0170a9020244cccc40e5b612612a3fb5edded"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "2.0.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -418,10 +418,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_expandable_fab
-      sha256: "2aa5735bebcdbc49f43bcb32a29f9f03a9b7029212b8cd9837ae332ab2edf647"
+      sha256: "43147571b147e80511d7f9bd143300f4b1b881e2beaf7f83f0eccb5d88a4112b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "1.8.1"
   flutter_fgbg:
     dependency: "direct main"
     description:
@@ -434,18 +434,18 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: e2a421b7e59244faef694ba7b30562e489c2b489866e505074eb005cd7060db7
+      sha256: a25a15ebbdfc33ab1cd26c63a6ee519df92338a9c10f122adda92938253bef04
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "2.0.3"
   flutter_map:
     dependency: "direct main"
     description:
       name: flutter_map
-      sha256: cda8d72135b697f519287258b5294a57ce2f2a5ebf234f0e406aad4dc14c9399
+      sha256: "52c65a977daae42f9aae6748418dd1535eaf27186e9bac9bf431843082bc75a3"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.0"
+    version: "4.0.0"
   flutter_native_splash:
     dependency: "direct main"
     description:
@@ -466,10 +466,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: ffdbb60130e4665d2af814a0267c481bcf522c41ae2e43caf69fa0146876d685
+      sha256: "22dbf16f23a4bcf9d35e51be1c84ad5bb6f627750565edd70dab70f3ff5fff8f"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.0"
+    version: "8.1.0"
   flutter_secure_storage_linux:
     dependency: transitive
     description:
@@ -506,10 +506,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage_windows
-      sha256: "5809c66f9dd3b4b93b0a6e2e8561539405322ee767ac2f64d084e2ab5429d108"
+      sha256: "38f9501c7cb6f38961ef0e1eacacee2b2d4715c63cc83fe56449c4d3d0b47255"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "2.1.1"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -556,10 +556,10 @@ packages:
     dependency: "direct main"
     description:
       name: get
-      sha256: e4e7335ede17452b391ed3b2ede016545706c01a02292a6c97619705e7d2a85e
+      sha256: "2ba20a47c8f1f233bed775ba2dd0d3ac97b4cf32fc17731b3dfc672b06b0e92a"
       url: "https://pub.dev"
     source: hosted
-    version: "4.6.6"
+    version: "4.6.5"
   get_storage:
     dependency: "direct main"
     description:
@@ -644,10 +644,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: d4872660c46d929f6b8a9ef4e7a7eff7e49bbf0c4ec3f385ee32df5119175139
+      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "0.13.6"
   http_multi_server:
     dependency: transitive
     description:
@@ -684,10 +684,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.0"
+    version: "0.18.1"
   io:
     dependency: transitive
     description:
@@ -740,18 +740,18 @@ packages:
     dependency: "direct main"
     description:
       name: latlong2
-      sha256: "18712164760cee655bc790122b0fd8f3d5b3c36da2cb7bf94b68a197fbb0811b"
+      sha256: "08ef7282ba9f76e8495e49e2dc4d653015ac929dce5f92b375a415d30b407ea0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.0"
+    version: "0.8.2"
   lints:
     dependency: transitive
     description:
       name: lints
-      sha256: cbf8d4b858bb0134ef3ef87841abdf8d63bfc255c266b7bf6b39daa1085c4290
+      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "2.1.1"
   lists:
     dependency: transitive
     description:
@@ -760,14 +760,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
-  logger:
-    dependency: transitive
-    description:
-      name: logger
-      sha256: "6bbb9d6f7056729537a4309bda2e74e18e5d9f14302489cc1e93f33b3fe32cac"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.2+1"
   logging:
     dependency: transitive
     description:
@@ -1036,10 +1028,10 @@ packages:
     dependency: "direct main"
     description:
       name: screen_state
-      sha256: "4d89d4b429e4f30de89add477c630384feb5b786dcf4380ef1e015841e169672"
+      sha256: "39184c718baf303f26200f6b1392b12a549d88410e907e046d75594588c0df5d"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "2.0.0"
   sensors_plus:
     dependency: transitive
     description:
@@ -1189,6 +1181,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
+  tuple:
+    dependency: transitive
+    description:
+      name: tuple
+      sha256: a97ce2013f240b2f3807bcbaf218765b6f301c3eff91092bcfa23a039e7dd151
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   typed_data:
     dependency: transitive
     description:
@@ -1278,13 +1278,13 @@ packages:
     source: hosted
     version: "3.1.1"
   uuid:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: uuid
-      sha256: "22c94e5ad1e75f9934b766b53c742572ee2677c56bc871d850a57dad0f82127f"
+      sha256: cd210a09f7c18cbe5a02511718e0334de6559871052c90a90c0cca46a4aa81c8
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.2"
+    version: "4.3.3"
   vector_graphics:
     dependency: transitive
     description:
@@ -1337,10 +1337,10 @@ packages:
     dependency: "direct main"
     description:
       name: weather
-      sha256: "5ad1d5b77051aa524049fc0abf1076ac4533e91e0176b0a4bab1182a2d6f921b"
+      sha256: "80642558610a8097956e603163fe648c14bb926beee52fe7cd78a44f37c53877"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "2.0.1"
   web:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   fluttertoast: ^8.2.4
   path_provider: ^2.1.1
   audio_session: ^0.1.18
+  uuid: ^4.3.3
 
 dev_dependencies:
   flutter_lints: ^2.0.3


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this pull request -->
- Changed the Repeat once tile's name to `Ring once`
- Added 2 more options to select days easily:
   - Daily
   - Weekends

## Fixes #222 

## Screenshots

<!-- If applicable, add screenshots or images demonstrating the changes made -->
<img src="https://github.com/CCExtractor/ultimate_alarm_clock/assets/114338679/0c02ab85-08f7-4bce-9c59-46da7d062071" height="250"/>
<img src="https://github.com/CCExtractor/ultimate_alarm_clock/assets/114338679/9348b799-5788-4b0d-9988-00abce5fca5e" height="250"/>
<img src="https://github.com/CCExtractor/ultimate_alarm_clock/assets/114338679/c1aa89a2-ad50-4184-b913-94d9a15a652d" height="250"/>
<img src="https://github.com/CCExtractor/ultimate_alarm_clock/assets/114338679/d7138fcf-f464-4cfe-927d-aa8df5e3291e" height="250"/>

## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [ ] All tests are passing