### PR TITLE
Add fix: change white background in dropdown menu to black

### DIFF
--- a/lib/app/modules/settings/views/language_menu.dart
+++ b/lib/app/modules/settings/views/language_menu.dart
@@ -41,6 +41,12 @@ class _LanguageMenuState extends State<LanguageMenu> {
             DropdownMenu(
                 inputDecorationTheme:
                     InputDecorationTheme(enabledBorder: InputBorder.none),
+                menuStyle: MenuStyle(
+                  backgroundColor: MaterialStateProperty.all(
+                      widget.themeController.isLightMode.value
+                          ? Colors.white
+                          : Colors.black),
+                ),
                 trailingIcon: Icon(Icons.arrow_drop_down_outlined,
                     size: 40.0,
                     color: widget.themeController.isLightMode.value
@@ -54,6 +60,11 @@ class _LanguageMenuState extends State<LanguageMenu> {
                   return DropdownMenuEntry(
                     value: e.key,
                     label: "${e.value['description']}",
+                    style: MenuItemButton.styleFrom(
+                      foregroundColor: !widget.themeController.isLightMode.value
+                          ? Colors.white
+                          : Colors.black,
+                    ),
                   );
                 }).toList(),
                 onSelected: (newValue) {


### PR DESCRIPTION
### Description
When selecting the language in dark mode, the background of menu was white. 

### Proposed Changes
- added MenuStyle property of DropdownMenu and use background property to change background
- added style property of DropdownMenuEntry to change the text color when background changes

## Fixes #316

## Screenshots
![415043851_413337014368708_1696398006730402413_n](https://github.com/CCExtractor/ultimate_alarm_clock/assets/89399577/1d6b355b-1726-4313-8d55-e80f5e4f93b3)

![415319191_933782248360675_7345361031406302094_n](https://github.com/CCExtractor/ultimate_alarm_clock/assets/89399577/694a878e-9bc3-4586-9908-2a9f952ef86b)



## Checklist

<!-- Mark the completed tasks with [x] -->
- [x ] Tests have been added or updated to cover the changes
- [ x] Documentation has been updated to reflect the changes
- [x ] Code follows the established coding style guidelines
- [x ] All tests are passing