### PR TITLE
fix: dropdown theme

### DIFF
--- a/lib/app/modules/settings/views/language_menu.dart
+++ b/lib/app/modules/settings/views/language_menu.dart
@@ -39,6 +39,13 @@ class _LanguageMenuState extends State<LanguageMenu> {
         child: Row(
           children: [
             DropdownMenu(
+              menuStyle: MenuStyle(
+                  backgroundColor: MaterialStatePropertyAll(
+                    widget.themeController.isLightMode.value
+                        ? kLightSecondaryBackgroundColor
+                        : ksecondaryBackgroundColor,
+                  ),
+                ),
                 inputDecorationTheme:
                     InputDecorationTheme(enabledBorder: InputBorder.none),
                 trailingIcon: Icon(Icons.arrow_drop_down_outlined,
@@ -54,11 +61,18 @@ class _LanguageMenuState extends State<LanguageMenu> {
                   return DropdownMenuEntry(
                     value: e.key,
                     label: "${e.value['description']}",
+                    style: ButtonStyle(
+                      foregroundColor: MaterialStatePropertyAll(
+                        widget.themeController.isLightMode.value
+                            ? kLightPrimaryTextColor
+                            : kprimaryTextColor,
+                      ),
+                    ),
                   );
                 }).toList(),
                 onSelected: (newValue) {
                   widget.controller.updateLocale(newValue!);
-                }
+                },
             ),
           ],
         ),


### PR DESCRIPTION
### Description
fixed background and text colour of select language menu list according to theme.

### Proposed Changes
In dark mode list should be in dark theme and in light mode should be light theme

## Fixes #316 

## Screenshots
![1](https://github.com/CCExtractor/ultimate_alarm_clock/assets/78961406/e7ba3116-90f1-4cf5-a6c3-a18dd172551c)
![2](https://github.com/CCExtractor/ultimate_alarm_clock/assets/78961406/9f42cc22-3e97-4cf7-8e79-fc564f680991)

## Checklist
- [x] Tests have been added or updated to cover the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing