### PR TITLE
fix: appBar pixel overflow in Russian language

### DIFF
--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -446,8 +446,8 @@ class HomeView extends GetView<HomeController> {
                                         MainAxisAlignment.spaceBetween,
                                     children: [
                                       Container(
-                                        padding: EdgeInsets.symmetric(
-                                          horizontal: 25 *
+                                        padding: EdgeInsets.only(
+                                          left: 25 *
                                               controller.scalingFactor.value,
                                         ),
                                         child: Column(


### PR DESCRIPTION
### Description
When you choose Russian then the russian conversion of message 'No upcoming alarms!' got overflows

### Proposed Changes
I have removed right padding of container and currently only left side has padding of 25 which was initially defined, if you allow me to decrease left padding to 20 then it would be safer.

## Fixes #334 

## Screenshots
![4](https://github.com/CCExtractor/ultimate_alarm_clock/assets/78961406/26ba8da9-a9cd-4dec-88a5-adffcce6febb)

## Checklist
- [x] Code follows the established coding style guidelines
- [x] All tests are passing