### PR TITLE
Feature: Replacing settings icon in the timer section to menu icon

### DIFF
--- a/lib/app/modules/timer/views/timer_view.dart
+++ b/lib/app/modules/timer/views/timer_view.dart
@@ -5,6 +5,7 @@ import 'package:ultimate_alarm_clock/app/data/providers/isar_provider.dart';
 import 'package:ultimate_alarm_clock/app/data/providers/secure_storage_provider.dart';
 import 'package:ultimate_alarm_clock/app/modules/settings/controllers/theme_controller.dart';
 import 'package:ultimate_alarm_clock/app/modules/timer/controllers/timer_controller.dart';
+import 'package:ultimate_alarm_clock/app/routes/app_pages.dart';
 import 'package:ultimate_alarm_clock/app/utils/constants.dart';
 import 'package:ultimate_alarm_clock/app/utils/utils.dart';
 
@@ -24,22 +25,7 @@ class TimerView extends GetView<TimerController> {
           toolbarHeight: height / 7.9,
           elevation: 0.0,
           centerTitle: true,
-          actions: [
-            IconButton(
-              onPressed: () {
-                Utils.hapticFeedback();
-                controller.saveTimerStateToStorage();
-                Get.toNamed('/settings');
-              },
-              icon: const Icon(
-                Icons.settings,
-                size: 27,
-              ),
-              color: themeController.isLightMode.value
-                  ? kLightPrimaryTextColor.withOpacity(0.75)
-                  : kprimaryTextColor.withOpacity(0.75),
-            ),
-          ],
+          
         ),
       ),
       body: Obx(
@@ -189,6 +175,126 @@ class TimerView extends GetView<TimerController> {
                   ),
                 ),
               ),
+      ),
+      endDrawer: Obx(
+        () => Drawer(
+          shape: const RoundedRectangleBorder(
+            borderRadius: BorderRadius.only(
+                topLeft: Radius.circular(10), bottomLeft: Radius.circular(10)),
+          ),
+          backgroundColor: themeController.isLightMode.value
+              ? kLightSecondaryBackgroundColor
+              : ksecondaryBackgroundColor,
+          child: Column(
+            children: [
+              DrawerHeader(
+                decoration: const BoxDecoration(color: kLightSecondaryColor),
+                child: Center(
+                  child: Row(
+                    children: [
+                      const Flexible(
+                        flex: 1,
+                        child: CircleAvatar(
+                          radius: 30,
+                          backgroundImage: AssetImage(
+                            'assets/images/ic_launcher-playstore.png',
+                          ),
+                        ),
+                      ),
+                      const SizedBox(
+                        width: 10,
+                      ),
+                      Flexible(
+                        flex: 3,
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            SizedBox(
+                              width: width * 0.5,
+                              child: Text(
+                                'Ultimate Alarm Clock'.tr,
+                                softWrap: true,
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .displayMedium!
+                                    .copyWith(
+                                        color: themeController.isLightMode.value
+                                            ? kprimaryTextColor
+                                            : ksecondaryTextColor,
+                                        fontWeight: FontWeight.bold),
+                              ),
+                            ),
+                            SizedBox(
+                              width: width * 0.5,
+                              child: Text(
+                                'v0.5.0'.tr,
+                                softWrap: true,
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .titleLarge!
+                                    .copyWith(
+                                        color: themeController.isLightMode.value
+                                            ? kprimaryTextColor
+                                            : ksecondaryTextColor,
+                                        fontWeight: FontWeight.bold),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              ListTile(
+                onTap: () {
+                  Utils.hapticFeedback();
+                  Get.back();
+                  Get.toNamed('/settings');
+                },
+                contentPadding: const EdgeInsets.only(left: 20, right: 44),
+                title: Text(
+                  'Settings'.tr,
+                  style: Theme.of(context).textTheme.titleLarge!.copyWith(
+                        color: themeController.isLightMode.value
+                            ? kLightPrimaryTextColor.withOpacity(0.8)
+                            : kprimaryTextColor.withOpacity(0.8),
+                      ),
+                ),
+                leading: Icon(
+                  Icons.settings,
+                  size: 26,
+                  color: themeController.isLightMode.value
+                      ? kLightPrimaryTextColor.withOpacity(0.8)
+                      : kprimaryTextColor.withOpacity(0.8),
+                ),
+              ),
+              // LanguageMenu(),
+              ListTile(
+                onTap: () {
+                  Utils.hapticFeedback();
+                  Get.back();
+                  Get.toNamed(Routes.ABOUT);
+                },
+                contentPadding: const EdgeInsets.only(left: 20, right: 44),
+                title: Text(
+                  'About'.tr,
+                  style: Theme.of(context).textTheme.titleLarge!.copyWith(
+                      color: themeController.isLightMode.value
+                          ? kLightPrimaryTextColor.withOpacity(0.8)
+                          : kprimaryTextColor.withOpacity(0.8)),
+                ),
+                leading: Icon(
+                  Icons.info_outline,
+                  size: 26,
+                  color: themeController.isLightMode.value
+                      ? kLightPrimaryTextColor.withOpacity(0.8)
+                      : kprimaryTextColor.withOpacity(0.8),
+                ),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
### Description
The issue was to change the settings icon to an endDrawer so that the UI stays the same in both the changes.


## Fixes #307

Issue `#307` Replacing settings icon in the timer section to menu icon

## Screenshots
![Screenshot_20240116_192353](https://github.com/CCExtractor/ultimate_alarm_clock/assets/22213675/0a038ab4-a0b8-4858-935a-5b9f7b3b9621)
![Screenshot_20240116_192349](https://github.com/CCExtractor/ultimate_alarm_clock/assets/22213675/fb72f4c7-3210-4919-b5ce-bc128f093460)



## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Tests have been added or updated to cover the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing