### PR TITLE
Feature: Swipe Pages and Animation Effect on deletion

### DIFF
--- a/lib/app/modules/bottomNavigationBar/views/bottom_navigation_bar_view.dart
+++ b/lib/app/modules/bottomNavigationBar/views/bottom_navigation_bar_view.dart
@@ -4,21 +4,22 @@ import 'package:ultimate_alarm_clock/app/modules/bottomNavigationBar/controllers
 import 'package:ultimate_alarm_clock/app/utils/utils.dart';
 
 class BottomNavigationBarView extends GetView<BottomNavigationBarController> {
-  const BottomNavigationBarView({Key? key}) : super(key: key);
+  final PageController pageController = PageController();
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Obx(
-        () => IndexedStack(
-          index: controller.activeTabIndex.value,
-          children: controller.pages,
-        ),
+      body: PageView(
+        controller: pageController,
+        children: controller.pages,
+        onPageChanged: (index) {
+          controller.changeTab(index);
+        },
       ),
       bottomNavigationBar: Obx(
         () => BottomNavigationBar(
           useLegacyColorScheme: false,
-          items:  [
+          items: [
             BottomNavigationBarItem(
               icon: Icon(Icons.alarm),
               label: 'Alarm'.tr,
@@ -31,6 +32,8 @@ class BottomNavigationBarView extends GetView<BottomNavigationBarController> {
           onTap: (index) {
             Utils.hapticFeedback();
             controller.changeTab(index);
+            pageController.animateToPage(index,
+                duration: Duration(milliseconds: 300), curve: Curves.easeInOut);
           },
           currentIndex: controller.activeTabIndex.value,
         ),
@@ -38,3 +41,4 @@ class BottomNavigationBarView extends GetView<BottomNavigationBarController> {
     );
   }
 }
+

--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -815,7 +815,8 @@ class HomeView extends GetView<HomeController> {
                                           ),
                                           Text(
                                             'Add an alarm to get started!'.tr,
-                                            textWidthBasis: TextWidthBasis.longestLine,
+                                            textWidthBasis:
+                                                TextWidthBasis.longestLine,
                                             style: Theme.of(context)
                                                 .textTheme
                                                 .displaySmall!
@@ -850,10 +851,24 @@ class HomeView extends GetView<HomeController> {
                                           Utils.getRepeatDays(alarm.days);
                                       // Main card
                                       return Dismissible(
+                                        direction: DismissDirection.startToEnd,
                                         onDismissed: (direction) async {
-                                          await controller.swipeToDeleteAlarm(controller.userModel.value,alarm);
+                                          await controller.swipeToDeleteAlarm(
+                                              controller.userModel.value,
+                                              alarm);
                                         },
                                         key: ValueKey(alarms[index]),
+                                        background: Container(
+                                          color: Colors
+                                              .red, // Set the background color to red
+                                          padding: EdgeInsets.symmetric(
+                                              horizontal: 20),
+                                          alignment: Alignment.center,
+                                          child: Icon(
+                                            Icons.delete,
+                                            color: Colors.white,
+                                          ),
+                                        ),
                                         child: Obx(
                                           () => GestureDetector(
                                             onTap: () {

--- a/lib/app/modules/timer/views/timer_view.dart
+++ b/lib/app/modules/timer/views/timer_view.dart
@@ -5,6 +5,7 @@ import 'package:ultimate_alarm_clock/app/data/providers/isar_provider.dart';
 import 'package:ultimate_alarm_clock/app/data/providers/secure_storage_provider.dart';
 import 'package:ultimate_alarm_clock/app/modules/settings/controllers/theme_controller.dart';
 import 'package:ultimate_alarm_clock/app/modules/timer/controllers/timer_controller.dart';
+import 'package:ultimate_alarm_clock/app/routes/app_pages.dart';
 import 'package:ultimate_alarm_clock/app/utils/constants.dart';
 import 'package:ultimate_alarm_clock/app/utils/utils.dart';
 
@@ -24,22 +25,7 @@ class TimerView extends GetView<TimerController> {
           toolbarHeight: height / 7.9,
           elevation: 0.0,
           centerTitle: true,
-          actions: [
-            IconButton(
-              onPressed: () {
-                Utils.hapticFeedback();
-                controller.saveTimerStateToStorage();
-                Get.toNamed('/settings');
-              },
-              icon: const Icon(
-                Icons.settings,
-                size: 27,
-              ),
-              color: themeController.isLightMode.value
-                  ? kLightPrimaryTextColor.withOpacity(0.75)
-                  : kprimaryTextColor.withOpacity(0.75),
-            ),
-          ],
+          
         ),
       ),
       body: Obx(
@@ -189,6 +175,126 @@ class TimerView extends GetView<TimerController> {
                   ),
                 ),
               ),
+      ),
+      endDrawer: Obx(
+        () => Drawer(
+          shape: const RoundedRectangleBorder(
+            borderRadius: BorderRadius.only(
+                topLeft: Radius.circular(10), bottomLeft: Radius.circular(10)),
+          ),
+          backgroundColor: themeController.isLightMode.value
+              ? kLightSecondaryBackgroundColor
+              : ksecondaryBackgroundColor,
+          child: Column(
+            children: [
+              DrawerHeader(
+                decoration: const BoxDecoration(color: kLightSecondaryColor),
+                child: Center(
+                  child: Row(
+                    children: [
+                      const Flexible(
+                        flex: 1,
+                        child: CircleAvatar(
+                          radius: 30,
+                          backgroundImage: AssetImage(
+                            'assets/images/ic_launcher-playstore.png',
+                          ),
+                        ),
+                      ),
+                      const SizedBox(
+                        width: 10,
+                      ),
+                      Flexible(
+                        flex: 3,
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            SizedBox(
+                              width: width * 0.5,
+                              child: Text(
+                                'Ultimate Alarm Clock'.tr,
+                                softWrap: true,
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .displayMedium!
+                                    .copyWith(
+                                        color: themeController.isLightMode.value
+                                            ? kprimaryTextColor
+                                            : ksecondaryTextColor,
+                                        fontWeight: FontWeight.bold),
+                              ),
+                            ),
+                            SizedBox(
+                              width: width * 0.5,
+                              child: Text(
+                                'v0.5.0'.tr,
+                                softWrap: true,
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .titleLarge!
+                                    .copyWith(
+                                        color: themeController.isLightMode.value
+                                            ? kprimaryTextColor
+                                            : ksecondaryTextColor,
+                                        fontWeight: FontWeight.bold),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              ListTile(
+                onTap: () {
+                  Utils.hapticFeedback();
+                  Get.back();
+                  Get.toNamed('/settings');
+                },
+                contentPadding: const EdgeInsets.only(left: 20, right: 44),
+                title: Text(
+                  'Settings'.tr,
+                  style: Theme.of(context).textTheme.titleLarge!.copyWith(
+                        color: themeController.isLightMode.value
+                            ? kLightPrimaryTextColor.withOpacity(0.8)
+                            : kprimaryTextColor.withOpacity(0.8),
+                      ),
+                ),
+                leading: Icon(
+                  Icons.settings,
+                  size: 26,
+                  color: themeController.isLightMode.value
+                      ? kLightPrimaryTextColor.withOpacity(0.8)
+                      : kprimaryTextColor.withOpacity(0.8),
+                ),
+              ),
+              // LanguageMenu(),
+              ListTile(
+                onTap: () {
+                  Utils.hapticFeedback();
+                  Get.back();
+                  Get.toNamed(Routes.ABOUT);
+                },
+                contentPadding: const EdgeInsets.only(left: 20, right: 44),
+                title: Text(
+                  'About'.tr,
+                  style: Theme.of(context).textTheme.titleLarge!.copyWith(
+                      color: themeController.isLightMode.value
+                          ? kLightPrimaryTextColor.withOpacity(0.8)
+                          : kprimaryTextColor.withOpacity(0.8)),
+                ),
+                leading: Icon(
+                  Icons.info_outline,
+                  size: 26,
+                  color: themeController.isLightMode.value
+                      ? kLightPrimaryTextColor.withOpacity(0.8)
+                      : kprimaryTextColor.withOpacity(0.8),
+                ),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/lib/app/modules/timer/views/timer_view.dart
+++ b/lib/app/modules/timer/views/timer_view.dart
@@ -5,7 +5,6 @@ import 'package:ultimate_alarm_clock/app/data/providers/isar_provider.dart';
 import 'package:ultimate_alarm_clock/app/data/providers/secure_storage_provider.dart';
 import 'package:ultimate_alarm_clock/app/modules/settings/controllers/theme_controller.dart';
 import 'package:ultimate_alarm_clock/app/modules/timer/controllers/timer_controller.dart';
-import 'package:ultimate_alarm_clock/app/routes/app_pages.dart';
 import 'package:ultimate_alarm_clock/app/utils/constants.dart';
 import 'package:ultimate_alarm_clock/app/utils/utils.dart';
 
@@ -25,7 +24,22 @@ class TimerView extends GetView<TimerController> {
           toolbarHeight: height / 7.9,
           elevation: 0.0,
           centerTitle: true,
-          
+          actions: [
+            IconButton(
+              onPressed: () {
+                Utils.hapticFeedback();
+                controller.saveTimerStateToStorage();
+                Get.toNamed('/settings');
+              },
+              icon: const Icon(
+                Icons.settings,
+                size: 27,
+              ),
+              color: themeController.isLightMode.value
+                  ? kLightPrimaryTextColor.withOpacity(0.75)
+                  : kprimaryTextColor.withOpacity(0.75),
+            ),
+          ],
         ),
       ),
       body: Obx(
@@ -175,126 +189,6 @@ class TimerView extends GetView<TimerController> {
                   ),
                 ),
               ),
-      ),
-      endDrawer: Obx(
-        () => Drawer(
-          shape: const RoundedRectangleBorder(
-            borderRadius: BorderRadius.only(
-                topLeft: Radius.circular(10), bottomLeft: Radius.circular(10)),
-          ),
-          backgroundColor: themeController.isLightMode.value
-              ? kLightSecondaryBackgroundColor
-              : ksecondaryBackgroundColor,
-          child: Column(
-            children: [
-              DrawerHeader(
-                decoration: const BoxDecoration(color: kLightSecondaryColor),
-                child: Center(
-                  child: Row(
-                    children: [
-                      const Flexible(
-                        flex: 1,
-                        child: CircleAvatar(
-                          radius: 30,
-                          backgroundImage: AssetImage(
-                            'assets/images/ic_launcher-playstore.png',
-                          ),
-                        ),
-                      ),
-                      const SizedBox(
-                        width: 10,
-                      ),
-                      Flexible(
-                        flex: 3,
-                        child: Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            SizedBox(
-                              width: width * 0.5,
-                              child: Text(
-                                'Ultimate Alarm Clock'.tr,
-                                softWrap: true,
-                                style: Theme.of(context)
-                                    .textTheme
-                                    .displayMedium!
-                                    .copyWith(
-                                        color: themeController.isLightMode.value
-                                            ? kprimaryTextColor
-                                            : ksecondaryTextColor,
-                                        fontWeight: FontWeight.bold),
-                              ),
-                            ),
-                            SizedBox(
-                              width: width * 0.5,
-                              child: Text(
-                                'v0.5.0'.tr,
-                                softWrap: true,
-                                style: Theme.of(context)
-                                    .textTheme
-                                    .titleLarge!
-                                    .copyWith(
-                                        color: themeController.isLightMode.value
-                                            ? kprimaryTextColor
-                                            : ksecondaryTextColor,
-                                        fontWeight: FontWeight.bold),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-              ListTile(
-                onTap: () {
-                  Utils.hapticFeedback();
-                  Get.back();
-                  Get.toNamed('/settings');
-                },
-                contentPadding: const EdgeInsets.only(left: 20, right: 44),
-                title: Text(
-                  'Settings'.tr,
-                  style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                        color: themeController.isLightMode.value
-                            ? kLightPrimaryTextColor.withOpacity(0.8)
-                            : kprimaryTextColor.withOpacity(0.8),
-                      ),
-                ),
-                leading: Icon(
-                  Icons.settings,
-                  size: 26,
-                  color: themeController.isLightMode.value
-                      ? kLightPrimaryTextColor.withOpacity(0.8)
-                      : kprimaryTextColor.withOpacity(0.8),
-                ),
-              ),
-              // LanguageMenu(),
-              ListTile(
-                onTap: () {
-                  Utils.hapticFeedback();
-                  Get.back();
-                  Get.toNamed(Routes.ABOUT);
-                },
-                contentPadding: const EdgeInsets.only(left: 20, right: 44),
-                title: Text(
-                  'About'.tr,
-                  style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                      color: themeController.isLightMode.value
-                          ? kLightPrimaryTextColor.withOpacity(0.8)
-                          : kprimaryTextColor.withOpacity(0.8)),
-                ),
-                leading: Icon(
-                  Icons.info_outline,
-                  size: 26,
-                  color: themeController.isLightMode.value
-                      ? kLightPrimaryTextColor.withOpacity(0.8)
-                      : kprimaryTextColor.withOpacity(0.8),
-                ),
-              ),
-            ],
-          ),
-        ),
       ),
     );
   }

--- a/lib/app/routes/app_pages.dart
+++ b/lib/app/routes/app_pages.dart
@@ -65,7 +65,7 @@ class AppPages {
     ),
     GetPage(
       name: _Paths.BOTTOM_NAVIGATION_BAR,
-      page: () => const BottomNavigationBarView(),
+      page: () => BottomNavigationBarView(),
       binding: BottomNavigationBarBinding(),
     ),
     GetPage(


### PR DESCRIPTION
### Description
Our app only had the option to use bottomNavigationButton to switch pages. Now, we can simply swipe pages to go to the next one. On top of that, I have limited the deletion to only left to right so that if the page is filled with alarms, the user doesn't accidentally delete it.

I have also added a red animation on the dismiss of the tile to delete.


## Fixes #308 

Fixes Issue #308 Feature: Adding swipeable view

## Screenrecording


https://github.com/CCExtractor/ultimate_alarm_clock/assets/22213675/a3b4dc67-3512-474c-b422-89d48639b76b



## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Code follows the established coding style guidelines
- [x] All tests are passing