### PR TITLE
Remove the previous "Undo" option before displaying the new one

### DIFF
--- a/lib/app/modules/home/controllers/home_controller.dart
+++ b/lib/app/modules/home/controllers/home_controller.dart
@@ -518,37 +518,32 @@ class HomeController extends GetxController {
   }
 
   Future<void> swipeToDeleteAlarm(UserModel? user, AlarmModel alarm) async {
-    AlarmModel? alarmToDelete;
-    
+    AlarmModel? alarm_to_delete;
+
     if (alarm.isSharedAlarmEnabled == true) {
-      alarmToDelete = await FirestoreDb.getAlarm(user, alarm.firestoreId!);
+      alarm_to_delete = await FirestoreDb.getAlarm(user, alarm.firestoreId!);
       await FirestoreDb.deleteAlarm(user, alarm.firestoreId!);
     } else {
-      alarmToDelete = await IsarDb.getAlarm(alarm.isarId);
+      alarm_to_delete = await IsarDb.getAlarm(alarm.isarId);
       await IsarDb.deleteAlarm(alarm.isarId);
     }
 
-    if (Get.isSnackbarOpen) {
-      Get.closeCurrentSnackbar();
-    }
-
-    GetSnackBar snackbar = GetSnackBar(
-      message: 'Alarm deleted',
-      duration: const Duration(seconds: 4),
+    Get.back();
+    Get.snackbar(
+      'Alarm deleted',
+      'The alarm has been deleted.',
+      duration: const Duration(seconds: 9),
+      snackPosition: SnackPosition.BOTTOM,
       mainButton: TextButton(
         onPressed: () async {
           if (alarm.isSharedAlarmEnabled == true) {
-            await FirestoreDb.addAlarm(user, alarmToDelete!);
+            await FirestoreDb.addAlarm(user, alarm_to_delete!);
           } else {
-            await IsarDb.addAlarm(alarmToDelete!);
+            await IsarDb.addAlarm(alarm_to_delete!);
           }
         },
         child: const Text('Undo'),
       ),
-    );
-
-    Get.showSnackbar(
-      snackbar,
     );
   }
 }

--- a/lib/app/modules/home/controllers/home_controller.dart
+++ b/lib/app/modules/home/controllers/home_controller.dart
@@ -532,7 +532,7 @@ class HomeController extends GetxController {
     Get.snackbar(
       'Alarm deleted',
       'The alarm has been deleted.',
-      duration: const Duration(seconds: 9),
+      duration: const Duration(seconds: 4),
       snackPosition: SnackPosition.BOTTOM,
       mainButton: TextButton(
         onPressed: () async {

--- a/lib/app/modules/home/controllers/home_controller.dart
+++ b/lib/app/modules/home/controllers/home_controller.dart
@@ -518,32 +518,38 @@ class HomeController extends GetxController {
   }
 
   Future<void> swipeToDeleteAlarm(UserModel? user, AlarmModel alarm) async {
-    AlarmModel? alarm_to_delete;
+    AlarmModel? alarmToDelete;
 
+    // Delete the alarm based on the type (shared or not shared)
     if (alarm.isSharedAlarmEnabled == true) {
-      alarm_to_delete = await FirestoreDb.getAlarm(user, alarm.firestoreId!);
+      alarmToDelete = await FirestoreDb.getAlarm(user, alarm.firestoreId!);
       await FirestoreDb.deleteAlarm(user, alarm.firestoreId!);
     } else {
-      alarm_to_delete = await IsarDb.getAlarm(alarm.isarId);
+      alarmToDelete = await IsarDb.getAlarm(alarm.isarId);
       await IsarDb.deleteAlarm(alarm.isarId);
     }
 
-    // Display snackbar
-    Get.snackbar(
-      'Alarm deleted',
-      'The alarm has been deleted.',
+    if (Get.isSnackbarOpen) {
+      Get.closeCurrentSnackbar();
+    }
+
+    GetBar _snackbar = GetBar(
+      message: 'Alarm deleted',
       duration: const Duration(seconds: 4),
-      snackPosition: SnackPosition.BOTTOM,
       mainButton: TextButton(
         onPressed: () async {
           if (alarm.isSharedAlarmEnabled == true) {
-            await FirestoreDb.addAlarm(user, alarm_to_delete!);
+            await FirestoreDb.addAlarm(user, alarmToDelete!);
           } else {
-            await IsarDb.addAlarm(alarm_to_delete!);
+            await IsarDb.addAlarm(alarmToDelete!);
           }
         },
         child: const Text('Undo'),
       ),
+    );
+
+    Get.showSnackbar(
+      _snackbar,
     );
   }
 }

--- a/lib/app/modules/home/controllers/home_controller.dart
+++ b/lib/app/modules/home/controllers/home_controller.dart
@@ -519,8 +519,7 @@ class HomeController extends GetxController {
 
   Future<void> swipeToDeleteAlarm(UserModel? user, AlarmModel alarm) async {
     AlarmModel? alarmToDelete;
-
-    // Delete the alarm based on the type (shared or not shared)
+    
     if (alarm.isSharedAlarmEnabled == true) {
       alarmToDelete = await FirestoreDb.getAlarm(user, alarm.firestoreId!);
       await FirestoreDb.deleteAlarm(user, alarm.firestoreId!);
@@ -533,7 +532,7 @@ class HomeController extends GetxController {
       Get.closeCurrentSnackbar();
     }
 
-    GetBar _snackbar = GetBar(
+    GetSnackBar snackbar = GetSnackBar(
       message: 'Alarm deleted',
       duration: const Duration(seconds: 4),
       mainButton: TextButton(
@@ -549,7 +548,7 @@ class HomeController extends GetxController {
     );
 
     Get.showSnackbar(
-      _snackbar,
+      snackbar,
     );
   }
 }

--- a/lib/app/modules/home/controllers/home_controller.dart
+++ b/lib/app/modules/home/controllers/home_controller.dart
@@ -518,32 +518,37 @@ class HomeController extends GetxController {
   }
 
   Future<void> swipeToDeleteAlarm(UserModel? user, AlarmModel alarm) async {
-    AlarmModel? alarm_to_delete;
+    AlarmModel? alarmToDelete;
 
     if (alarm.isSharedAlarmEnabled == true) {
-      alarm_to_delete = await FirestoreDb.getAlarm(user, alarm.firestoreId!);
+      alarmToDelete = await FirestoreDb.getAlarm(user, alarm.firestoreId!);
       await FirestoreDb.deleteAlarm(user, alarm.firestoreId!);
     } else {
-      alarm_to_delete = await IsarDb.getAlarm(alarm.isarId);
+      alarmToDelete = await IsarDb.getAlarm(alarm.isarId);
       await IsarDb.deleteAlarm(alarm.isarId);
     }
 
-    Get.back();
-    Get.snackbar(
-      'Alarm deleted',
-      'The alarm has been deleted.',
+    if (Get.isSnackbarOpen) {
+      Get.closeAllSnackbars();
+    }
+
+    GetSnackBar snackbar = GetSnackBar(
+      message: 'Alarm deleted',
       duration: const Duration(seconds: 4),
-      snackPosition: SnackPosition.BOTTOM,
       mainButton: TextButton(
         onPressed: () async {
           if (alarm.isSharedAlarmEnabled == true) {
-            await FirestoreDb.addAlarm(user, alarm_to_delete!);
+            await FirestoreDb.addAlarm(user, alarmToDelete!);
           } else {
-            await IsarDb.addAlarm(alarm_to_delete!);
+            await IsarDb.addAlarm(alarmToDelete!);
           }
         },
         child: const Text('Undo'),
       ),
+    );
+
+    Get.showSnackbar(
+      snackbar,
     );
   }
 }


### PR DESCRIPTION
### Description
When swiping to delete multiple alarms simultaneously, the application does not remove the previous "Undo" option before displaying the new one. This behavior can lead to confusion as users may unintentionally trigger the wrong undo action.

### Proposed Changes
Added a check to clear the current Snackbar if it is open before displaying a new one

## Fixes #353 


<!-- Mark the completed tasks with [x] -->
- [x] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing