### PR TITLE
fix selected ringtone is visible outside the container

### DIFF
--- a/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
+++ b/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
@@ -821,11 +821,21 @@ class AddOrUpdateAlarmController extends GetxController {
             Get.snackbar(
               'Ringtone Deleted',
               'The selected ringtone has been successfully deleted.',
+              margin: EdgeInsets.all(15),
+              animationDuration: Duration(seconds: 1),
+              snackPosition: SnackPosition.BOTTOM,
+              barBlur: 15,
+              colorText: kprimaryTextColor,
             );
           } else {
             Get.snackbar(
               'Ringtone Not Found',
               'The selected ringtone does not exist and cannot be deleted.',
+              margin: EdgeInsets.all(15),
+              animationDuration: Duration(seconds: 1),
+              snackPosition: SnackPosition.BOTTOM,
+              barBlur: 15,
+              colorText: kprimaryTextColor,
             );
           }
         } else {
@@ -833,6 +843,11 @@ class AddOrUpdateAlarmController extends GetxController {
             'Ringtone in Use',
             'This ringtone cannot be deleted as it is currently assigned'
                 ' to one or more alarms.',
+            margin: EdgeInsets.all(15),
+            animationDuration: Duration(seconds: 1),
+            snackPosition: SnackPosition.BOTTOM,
+            barBlur: 15,
+            colorText: kprimaryTextColor,
           );
         }
       }

--- a/lib/app/modules/addOrUpdateAlarm/views/choose_ringtone_tile.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/choose_ringtone_tile.dart
@@ -54,62 +54,91 @@ class ChooseRingtoneTile extends StatelessWidget {
               () => Column(
                 children: [
                   Obx(
-                    () => SizedBox(
-                      width: width * 0.8,
-                      height: height * 0.2,
-                      child: Scrollbar(
-                        child: ListView.builder(
-                          itemCount: controller.customRingtoneNames.length,
-                          shrinkWrap: true,
-                          itemBuilder: (context, index) {
-                            return Obx(
-                              () => ListTile(
-                                onTap: () {
-                                  controller.customRingtoneName.value =
-                                      controller.customRingtoneNames[index];
+                    () => Padding(
+                      padding: EdgeInsets.all(4),
+                      child: SizedBox(
+                        width: width * 0.8,
+                        height: height * 0.2,
+                        child: Card(
+                          elevation: 0,
+                          color: themeController.isLightMode.value
+                              ? kLightSecondaryBackgroundColor
+                              : ksecondaryBackgroundColor,
+                          child: Scrollbar(
+                            radius: Radius.circular(5),
+                            thumbVisibility: true,
+                            child: Padding(
+                              padding: EdgeInsets.only(right: 4),
+                              child: ListView.separated(
+                                separatorBuilder: (context, index) {
+                                  return Divider(
+                                    color: themeController.isLightMode.value
+                                        ? ksecondaryBackgroundColor
+                                        : kLightSecondaryBackgroundColor,
+                                    height: 0,
+                                  );
                                 },
-                                tileColor: controller.customRingtoneName ==
-                                        controller.customRingtoneNames[index]
-                                    ? themeController.isLightMode.value
-                                        ? kLightPrimaryBackgroundColor
-                                        : kprimaryBackgroundColor
-                                    : themeController.isLightMode.value
-                                        ? kLightSecondaryBackgroundColor
-                                        : ksecondaryBackgroundColor,
-                                title: Text(
-                                  controller.customRingtoneNames[index],
-                                  overflow: TextOverflow.ellipsis,
-                                ),
-                                trailing: (controller
-                                                .customRingtoneName.value ==
+                                itemCount:
+                                    controller.customRingtoneNames.length,
+                                shrinkWrap: true,
+                                itemBuilder: (context, index) {
+                                  return Obx(
+                                    () => ListTile(
+                                      onTap: () {
+                                        controller.customRingtoneName.value =
                                             controller
-                                                .customRingtoneNames[index]) ||
-                                        (controller
-                                                .customRingtoneNames[index] ==
-                                            'Default'.tr)
-                                    ? null
-                                    : IconButton(
-                                        onPressed: () async {
-                                          await controller.deleteCustomRingtone(
-                                            ringtoneName: controller
-                                                .customRingtoneNames[index],
-                                            ringtoneIndex: index,
-                                          );
-                                        },
-                                        icon: const Icon(
-                                          Icons.delete,
-                                          color: Colors.red,
-                                        ),
+                                                .customRingtoneNames[index];
+                                      },
+                                      tileColor: controller
+                                                  .customRingtoneName ==
+                                              controller
+                                                  .customRingtoneNames[index]
+                                          ? themeController.isLightMode.value
+                                              ? kLightPrimaryBackgroundColor
+                                              : kprimaryBackgroundColor
+                                          : themeController.isLightMode.value
+                                              ? kLightSecondaryBackgroundColor
+                                              : ksecondaryBackgroundColor,
+                                      title: Text(
+                                        controller.customRingtoneNames[index],
+                                        overflow: TextOverflow.ellipsis,
                                       ),
+                                      trailing: (controller.customRingtoneName
+                                                      .value ==
+                                                  controller
+                                                          .customRingtoneNames[
+                                                      index]) ||
+                                              (controller.customRingtoneNames[
+                                                      index] ==
+                                                  'Default'.tr)
+                                          ? null
+                                          : IconButton(
+                                              onPressed: () async {
+                                                await controller
+                                                    .deleteCustomRingtone(
+                                                  ringtoneName: controller
+                                                          .customRingtoneNames[
+                                                      index],
+                                                  ringtoneIndex: index,
+                                                );
+                                              },
+                                              icon: const Icon(
+                                                Icons.delete,
+                                                color: Colors.red,
+                                              ),
+                                            ),
+                                    ),
+                                  );
+                                },
                               ),
-                            );
-                          },
+                            ),
+                          ),
                         ),
                       ),
                     ),
                   ),
                   const SizedBox(
-                    height: 30,
+                    height: 20,
                   ),
                   OutlinedButton(
                     onPressed: () async {
@@ -124,7 +153,7 @@ class ChooseRingtoneTile extends StatelessWidget {
                     ),
                   ),
                   const SizedBox(
-                    height: 30,
+                    height: 20,
                   ),
                   ElevatedButton(
                     onPressed: () async {


### PR DESCRIPTION
### Proposed Changes
- Wrapped scrollbar widget with card which doesn't allow the element of scrollbar widget to flow outside.
- Added divider between two list which is giving list effect.
- Make scroll bar always visible.
- Some changes in snackbar which appears after modification in list(like added margin, duration, position, colour and blur amount).

## Fixes #356 

## Video
https://github.com/CCExtractor/ultimate_alarm_clock/assets/78961406/04b0ad30-a2dc-484f-981d-b72d76ac38d1

## Checklist

- [x] Code follows the established coding style guidelines
- [x] All tests are passing