### PR TITLE
Feature: Added margin to snack bar on swipe to delete

### DIFF
--- a/lib/app/modules/home/controllers/home_controller.dart
+++ b/lib/app/modules/home/controllers/home_controller.dart
@@ -532,9 +532,15 @@ class HomeController extends GetxController {
       Get.closeAllSnackbars();
     }
 
-    GetSnackBar snackbar = GetSnackBar(
-      message: 'Alarm deleted',
+    Get.snackbar(
+      'Alarm deleted',
+      'The alarm has been deleted.',
       duration: const Duration(seconds: 4),
+      snackPosition: SnackPosition.BOTTOM,
+      margin: const EdgeInsets.symmetric(
+        horizontal: 10,
+        vertical: 15,
+      ),
       mainButton: TextButton(
         onPressed: () async {
           if (alarm.isSharedAlarmEnabled == true) {
@@ -547,9 +553,27 @@ class HomeController extends GetxController {
       ),
     );
 
-    Get.showSnackbar(
-      snackbar,
-    );
+    // GetSnackBar snackbar = GetSnackBar(
+    //   message: 'Alarm deleted',
+    //   duration: const Duration(seconds: 4),
+    //   margin: const EdgeInsets.symmetric(
+    //     horizontal: 10,
+    //     vertical: 15,
+    //   ),
+    //   mainButton: TextButton(
+    //     onPressed: () async {
+    //       if (alarm.isSharedAlarmEnabled == true) {
+    //         await FirestoreDb.addAlarm(user, alarmToDelete!);
+    //       } else {
+    //         await IsarDb.addAlarm(alarmToDelete!);
+    //       }
+    //     },
+    //     child: const Text('Undo'),
+    //   ),
+    // );
+
+    // Get.showSnackbar(
+    //   snackbar,
+    // );
   }
 }
-


### PR DESCRIPTION
### Description
Previously when the user swipes to delete an alarm, a bottom stacked snack bar was being shown which affects the overall user experience. 

So I have added a symmetric margin to the snack bar to improve the overall user experience.

### Proposed Changes
- Added `margin` to the `Get.snackbar` on swipe to delete.

## Fixes #370 

## Screenshots

https://github.com/CCExtractor/ultimate_alarm_clock/assets/92971894/423f1696-ddcf-4085-ba93-dbc876b01cef

## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [ ] All tests are passing