### PR TITLE
Feature: Displayed snack bar on alarm deletion via pop-up menu

### DIFF
--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -1275,28 +1275,26 @@ class HomeView extends GetView<HomeController> {
                                                                             ),
                                                                           ),
                                                                         if (alarm
-                                                                          .isPedometerEnabled)
-                                                                        Padding(
-                                                                          padding:
-                                                                              const EdgeInsets.symmetric(
-                                                                            horizontal:
-                                                                                3.0,
+                                                                            .isPedometerEnabled)
+                                                                          Padding(
+                                                                            padding:
+                                                                                const EdgeInsets.symmetric(
+                                                                              horizontal: 3.0,
+                                                                            ),
+                                                                            child:
+                                                                                Icon(
+                                                                              Icons.directions_walk,
+                                                                              size: 24,
+                                                                              color: alarm.isEnabled == true
+                                                                                  ? themeController.isLightMode.value
+                                                                                      ? kLightPrimaryTextColor.withOpacity(0.5)
+                                                                                      : kprimaryTextColor.withOpacity(0.5)
+                                                                                  : themeController.isLightMode.value
+                                                                                      ? kLightPrimaryDisabledTextColor
+                                                                                      : kprimaryDisabledTextColor,
+                                                                            ),
                                                                           ),
-                                                                          child:
-                                                                              Icon(
-                                                                            Icons.directions_walk,
-                                                                            size:
-                                                                                24,
-                                                                            color: alarm.isEnabled == true
-                                                                                ? themeController.isLightMode.value
-                                                                                    ? kLightPrimaryTextColor.withOpacity(0.5)
-                                                                                    : kprimaryTextColor.withOpacity(0.5)
-                                                                                : themeController.isLightMode.value
-                                                                                    ? kLightPrimaryDisabledTextColor
-                                                                                    : kprimaryDisabledTextColor,
-                                                                          ),
-                                                                        ),
-                                                                    ],
+                                                                      ],
                                                                     ),
                                                                 ],
                                                               ),
@@ -1379,6 +1377,31 @@ class HomeView extends GetView<HomeController> {
                                                                                 } else {
                                                                                   await IsarDb.deleteAlarm(alarm.isarId);
                                                                                 }
+
+                                                                                if (Get.isSnackbarOpen) {
+                                                                                  Get.closeAllSnackbars();
+                                                                                }
+
+                                                                                Get.snackbar(
+                                                                                  'Alarm deleted',
+                                                                                  'The alarm has been deleted.',
+                                                                                  duration: const Duration(seconds: 4),
+                                                                                  snackPosition: SnackPosition.BOTTOM,
+                                                                                  margin: const EdgeInsets.symmetric(
+                                                                                    horizontal: 10,
+                                                                                    vertical: 15,
+                                                                                  ),
+                                                                                  mainButton: TextButton(
+                                                                                    onPressed: () async {
+                                                                                      if (alarm.isSharedAlarmEnabled == true) {
+                                                                                        await FirestoreDb.addAlarm(controller.userModel.value, alarm);
+                                                                                      } else {
+                                                                                        await IsarDb.addAlarm(alarm);
+                                                                                      }
+                                                                                    },
+                                                                                    child: const Text('Undo'),
+                                                                                  ),
+                                                                                );
 
                                                                                 String ringtoneName = alarm.ringtoneName;
 


### PR DESCRIPTION
### Description
Previously when the user deletes an alarm via swipe or pop-up menu button, the behavior seemed inconsistent as the snack bar was not being shown on alarm deletion via pop-up menu. 

So I have made changes to display the snack bar on alarm deletion via the pop-up menu button. 

### Proposed Changes
- Display `Get.snackbar` when the user deletes an alarm via the pop-up menu.

## Fixes #372 

## Screenshots

https://github.com/CCExtractor/ultimate_alarm_clock/assets/92971894/7d61b6a7-b9e0-4da8-a004-ff9c7f4f1185



## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [ ] All tests are passing