### PR TITLE
[Ringtone counter fixed] issue #262

### DIFF
--- a/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
+++ b/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
@@ -79,6 +79,7 @@ class AddOrUpdateAlarmController extends GetxController {
   final RxInt snoozeDuration = 1.obs;
   var customRingtoneName = 'Default'.obs;
   var customRingtoneNames = [].obs;
+  var previousRingtone='';
   final noteController = TextEditingController();
   final RxString note = ''.obs;
   final deleteAfterGoesOff = false.obs;
@@ -842,7 +843,7 @@ class AddOrUpdateAlarmController extends GetxController {
           RingtoneModel customRingtone = RingtoneModel(
             ringtoneName: customRingtoneName.value,
             ringtonePath: savedFilePath,
-            currentCounterOfUsage: 0,
+            currentCounterOfUsage: 1,
           );
           await IsarDb.addCustomRingtone(customRingtone);
         }

--- a/lib/app/modules/addOrUpdateAlarm/views/choose_ringtone_tile.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/choose_ringtone_tile.dart
@@ -99,10 +99,33 @@ class ChooseRingtoneTile extends StatelessWidget {
                                 itemBuilder: (context, index) {
                                   return Obx(
                                     () => ListTile(
-                                      onTap: () {
+                                      onTap: () async {
+                                        controller.previousRingtone =
+                                            controller.customRingtoneName.value;
+
                                         controller.customRingtoneName.value =
                                             controller
                                                 .customRingtoneNames[index];
+
+                                        if (controller
+                                                .customRingtoneName.value !=
+                                            controller.previousRingtone) {
+                                          await AudioUtils
+                                              .updateRingtoneCounterOfUsage(
+                                            customRingtoneName: controller
+                                                .customRingtoneName.value,
+                                            counterUpdate:
+                                                CounterUpdate.increment,
+                                          );
+
+                                          await AudioUtils
+                                              .updateRingtoneCounterOfUsage(
+                                            customRingtoneName:
+                                                controller.previousRingtone,
+                                            counterUpdate:
+                                                CounterUpdate.decrement,
+                                          );
+                                        }
                                       },
                                       tileColor: controller
                                                   .customRingtoneName ==
@@ -208,10 +231,6 @@ class ChooseRingtoneTile extends StatelessWidget {
                   ElevatedButton(
                     onPressed: () async {
                       Utils.hapticFeedback();
-                      await AudioUtils.updateRingtoneCounterOfUsage(
-                        customRingtoneName: controller.customRingtoneName.value,
-                        counterUpdate: CounterUpdate.increment,
-                      );
                       Get.back();
                     },
                     style: ElevatedButton.styleFrom(


### PR DESCRIPTION
### Description
Previously, the application faced issues with inaccurate ringtone counter values, resulting in the failure to delete custom ringtones under certain conditions.

### Proposed Changes
A new variable has been introduced to track the previously selected ringtone. When some other ringtone is selected, its counter is incremented while the counter for the previously selected ringtone is decremented.

## Fixes #262

## Screenshots

Before fix:

https://github.com/CCExtractor/ultimate_alarm_clock/assets/144731286/c85b0c98-de7b-4b84-8143-e6616cefc05e



After fix:


https://github.com/CCExtractor/ultimate_alarm_clock/assets/144731286/c52ebc3b-ba56-4938-aa5d-951f1ace5c01


