### PR TITLE
Bug: Resolved Error Text Persisting in API Dialog

### DIFF
--- a/lib/app/modules/settings/controllers/settings_controller.dart
+++ b/lib/app/modules/settings/controllers/settings_controller.dart
@@ -78,7 +78,6 @@ class SettingsController extends GetxController {
     _loadPreference();
   }
 
-
   // Logins user using GoogleSignIn
   loginWithGoogle() async {
     try {

--- a/lib/app/modules/settings/controllers/settings_controller.dart
+++ b/lib/app/modules/settings/controllers/settings_controller.dart
@@ -78,10 +78,6 @@ class SettingsController extends GetxController {
     _loadPreference();
   }
 
-  @override
-  void onClose() {
-    super.onClose();
-  }
 
   // Logins user using GoogleSignIn
   loginWithGoogle() async {
@@ -265,7 +261,9 @@ class SettingsController extends GetxController {
 
   void _save24HoursFormatPreference() async {
     await _secureStorageProvider.write24HoursEnabled(
-        key: _f24HrsEnabledKey, is24HoursEnabled: is24HrsEnabled.value);
+      key: _f24HrsEnabledKey,
+      is24HoursEnabled: is24HrsEnabled.value,
+    );
   }
 
   void toggle24HoursFormat(bool enabled) {

--- a/lib/app/modules/settings/controllers/settings_controller.dart
+++ b/lib/app/modules/settings/controllers/settings_controller.dart
@@ -34,7 +34,7 @@ class SettingsController extends GetxController {
   final Rx<WeatherKeyState> weatherKeyState = WeatherKeyState.add.obs;
   final RxBool didWeatherKeyError = false.obs;
   final RxBool showingCircularProgressIndicator = false.obs;
-  RxBool validate = false.obs;
+  RxBool isApiKeyEmpty = false.obs;
   final storage = Get.find<GetStorageProvider>();
   final RxString local = Get.locale.toString().obs;
   UserModel? userModel;

--- a/lib/app/modules/settings/views/weather_api.dart
+++ b/lib/app/modules/settings/views/weather_api.dart
@@ -35,6 +35,17 @@ class WeatherApi extends StatelessWidget {
               : ksecondaryBackgroundColor,
           title: 'API Key',
           titleStyle: Theme.of(context).textTheme.displaySmall,
+          onWillPop: () async {
+            Future.delayed(
+              const Duration(
+                milliseconds: 300,
+              ),
+              () {
+                controller.validate.value = false;
+              },
+            );
+            return true;
+          },
           content: Obx(
             () => Stack(
               alignment: Alignment.center,

--- a/lib/app/modules/settings/views/weather_api.dart
+++ b/lib/app/modules/settings/views/weather_api.dart
@@ -41,7 +41,7 @@ class WeatherApi extends StatelessWidget {
                 milliseconds: 300,
               ),
               () {
-                controller.validate.value = false;
+                controller.isApiKeyEmpty.value = false;
               },
             );
             return true;
@@ -51,9 +51,9 @@ class WeatherApi extends StatelessWidget {
               alignment: Alignment.center,
               children: [
                 Container(
-                  // If the user hasn't clicked on the 'Save' or 'Update' button of
-                  // the dialog, or there is no error in the weather key, then
-                  // show the dialog
+                  // If the user hasn't clicked on the 'Save' or 'Update' button
+                  // of the dialog, or there is no error in the weather key,
+                  // then show the dialog
                   child: (controller.weatherKeyState.value !=
                               WeatherKeyState.saveAdded &&
                           controller.weatherKeyState.value !=
@@ -65,9 +65,9 @@ class WeatherApi extends StatelessWidget {
                                   obscureText: false,
                                   controller: controller.apiKey,
                                   decoration: InputDecoration(
-                                    border: OutlineInputBorder(),
+                                    border: const OutlineInputBorder(),
                                     hintText: 'API Key',
-                                    errorText: controller.validate.value
+                                    errorText: controller.isApiKeyEmpty.value
                                         ? 'API Key cannot be empty'
                                         : null,
                                   ),
@@ -110,10 +110,10 @@ class WeatherApi extends StatelessWidget {
                                               .value = true;
 
                                           // Validation If String is empty
-                                          if (await controller
-                                              .apiKey.text.isEmpty) {
+                                          if (controller.apiKey.text.isEmpty) {
                                             // setState(() {
-                                            controller.validate.value = true;
+                                            controller.isApiKeyEmpty.value =
+                                                true;
                                             // });
                                             controller
                                                 .showingCircularProgressIndicator
@@ -122,10 +122,11 @@ class WeatherApi extends StatelessWidget {
                                           }
 
                                           // Reset state after getting error message
-                                          if (await controller
+                                          if (controller
                                               .apiKey.text.isNotEmpty) {
                                             // setState(() {
-                                            controller.validate.value = false;
+                                            controller.isApiKeyEmpty.value =
+                                                false;
                                             // });
                                           }
 
@@ -155,7 +156,8 @@ class WeatherApi extends StatelessWidget {
                                               controller.weatherKeyState.value =
                                                   WeatherKeyState.saveUpdated;
                                               controller.addWeatherState(
-                                                  'saveUpdated');
+                                                'saveUpdated',
+                                              );
                                             }
                                           } else {
                                             // If the API key is not valid
@@ -208,9 +210,10 @@ class WeatherApi extends StatelessWidget {
                                 ),
                                 Padding(
                                   padding: const EdgeInsets.symmetric(
-                                      vertical: 15.0),
+                                    vertical: 15.0,
+                                  ),
                                   child: Text(
-                                    "Error adding key!",
+                                    'Error adding key!',
                                     style: Theme.of(context)
                                         .textTheme
                                         .displaySmall,
@@ -312,7 +315,7 @@ class WeatherApi extends StatelessWidget {
           isLightMode: themeController.isLightMode.value,
         ),
         child: Padding(
-          padding: EdgeInsets.only(left: 30, right: 30),
+          padding: const EdgeInsets.only(left: 30, right: 30),
           child: Row(
             children: [
               Text(
@@ -365,7 +368,7 @@ class WeatherApi extends StatelessWidget {
                                   RichText(
                                     textAlign: TextAlign.justify,
                                     text: TextSpan(
-                                      style: TextStyle(
+                                      style: const TextStyle(
                                         fontSize: 16,
                                       ),
                                       children: [
@@ -374,7 +377,7 @@ class WeatherApi extends StatelessWidget {
                                         ),
                                         TextSpan(
                                           text: 'step1.2'.tr,
-                                          style: TextStyle(
+                                          style: const TextStyle(
                                             fontWeight: FontWeight.bold,
                                           ),
                                         ),
@@ -383,7 +386,7 @@ class WeatherApi extends StatelessWidget {
                                         ),
                                         TextSpan(
                                           text: 'step1.4'.tr,
-                                          style: TextStyle(
+                                          style: const TextStyle(
                                             fontWeight: FontWeight.bold,
                                           ),
                                         ),
@@ -393,13 +396,13 @@ class WeatherApi extends StatelessWidget {
                                       ],
                                     ),
                                   ),
-                                  SizedBox(
+                                  const SizedBox(
                                     height: 15,
                                   ),
                                   RichText(
                                     textAlign: TextAlign.justify,
                                     text: TextSpan(
-                                      style: TextStyle(
+                                      style: const TextStyle(
                                         fontSize: 16,
                                       ),
                                       children: [
@@ -408,7 +411,7 @@ class WeatherApi extends StatelessWidget {
                                         ),
                                         TextSpan(
                                           text: 'step2.2'.tr,
-                                          style: TextStyle(
+                                          style: const TextStyle(
                                             fontWeight: FontWeight.bold,
                                           ),
                                         ),
@@ -418,13 +421,13 @@ class WeatherApi extends StatelessWidget {
                                       ],
                                     ),
                                   ),
-                                  SizedBox(
+                                  const SizedBox(
                                     height: 15,
                                   ),
                                   RichText(
                                     textAlign: TextAlign.justify,
                                     text: TextSpan(
-                                      style: TextStyle(
+                                      style: const TextStyle(
                                         fontSize: 16,
                                       ),
                                       children: [
@@ -434,13 +437,13 @@ class WeatherApi extends StatelessWidget {
                                       ],
                                     ),
                                   ),
-                                  SizedBox(
+                                  const SizedBox(
                                     height: 15,
                                   ),
                                   RichText(
                                     textAlign: TextAlign.justify,
                                     text: TextSpan(
-                                      style: TextStyle(
+                                      style: const TextStyle(
                                         fontSize: 16,
                                       ),
                                       children: [
@@ -449,7 +452,7 @@ class WeatherApi extends StatelessWidget {
                                         ),
                                         TextSpan(
                                           text: 'step4.2'.tr,
-                                          style: TextStyle(
+                                          style: const TextStyle(
                                             fontWeight: FontWeight.bold,
                                           ),
                                         ),
@@ -458,7 +461,7 @@ class WeatherApi extends StatelessWidget {
                                         ),
                                         TextSpan(
                                           text: 'step4.4'.tr,
-                                          style: TextStyle(
+                                          style: const TextStyle(
                                             fontWeight: FontWeight.bold,
                                           ),
                                         ),
@@ -468,13 +471,13 @@ class WeatherApi extends StatelessWidget {
                                       ],
                                     ),
                                   ),
-                                  SizedBox(
+                                  const SizedBox(
                                     height: 15,
                                   ),
                                   RichText(
                                     textAlign: TextAlign.justify,
                                     text: TextSpan(
-                                      style: TextStyle(
+                                      style: const TextStyle(
                                         fontSize: 16,
                                       ),
                                       children: [
@@ -519,7 +522,7 @@ class WeatherApi extends StatelessWidget {
                   ),
                 },
               ),
-              Spacer(),
+              const Spacer(),
               Icon(
                 Icons.arrow_forward_ios_sharp,
                 color: themeController.isLightMode.value


### PR DESCRIPTION
### Description
Currently, the API Key dialog displays an error text even after the user closes and reopens the dialog. This PR addresses the issue by ensuring that the error text is not shown once the dialog is closed.

### Proposed Changes
- Resolved the issue of error text persisting in the API Key dialog.
- Renamed the `validate` variable to `isApiKeyEmpty` for improved clarity.
- Added missing required trailing commas in the `SettingsController` and `weather_api.dart`. 
- Formatted the `SettingsController` and `weather_api.dart` files for consistency.

## Fixes #375

## Screenshots


https://github.com/CCExtractor/ultimate_alarm_clock/assets/92971894/39df6ca7-6990-4067-97bc-3ca2c3cfa0d7



## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [ ] All tests are passing