### PR TITLE
zoomed stopwatch and timer UI fixed

### DIFF
--- a/lib/app/modules/stopwatch/views/stopwatch_view.dart
+++ b/lib/app/modules/stopwatch/views/stopwatch_view.dart
@@ -52,9 +52,7 @@ class StopwatchView extends GetView<StopwatchController> {
               mainAxisAlignment: MainAxisAlignment.center,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                SizedBox(
-                  height: 55,
-                  width: 70,
+                Expanded(
                   child: Center(
                     child: Text(
                       controller.result.split(':')[0],
@@ -72,9 +70,7 @@ class StopwatchView extends GetView<StopwatchController> {
                     fontWeight: FontWeight.bold,
                   ),
                 ),
-                SizedBox(
-                  height: 55,
-                  width: 70,
+                Expanded(
                   child: Center(
                     child: Text(
                       controller.result.split(':')[1],
@@ -92,9 +88,7 @@ class StopwatchView extends GetView<StopwatchController> {
                     fontWeight: FontWeight.bold,
                   ),
                 ),
-                SizedBox(
-                  height: 55,
-                  width: 70,
+                Expanded(
                   child: Center(
                     child: Text(
                       controller.result.split(':')[2],

--- a/lib/app/modules/timer/views/timer_view.dart
+++ b/lib/app/modules/timer/views/timer_view.dart
@@ -72,9 +72,7 @@ class TimerView extends GetView<TimerController> {
                           mainAxisAlignment: MainAxisAlignment.center,
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            SizedBox(
-                              height: 55,
-                              width: 70,
+                            Expanded(
                               child: Center(
                                 child: Text(
                                   '$hours',
@@ -92,9 +90,7 @@ class TimerView extends GetView<TimerController> {
                                 fontWeight: FontWeight.bold,
                               ),
                             ),
-                            SizedBox(
-                              height: 55,
-                              width: 70,
+                            Expanded(
                               child: Center(
                                 child: Text(
                                   '$minutes',
@@ -112,9 +108,7 @@ class TimerView extends GetView<TimerController> {
                                 fontWeight: FontWeight.bold,
                               ),
                             ),
-                            SizedBox(
-                              height: 55,
-                              width: 70,
+                            Expanded(
                               child: Center(
                                 child: Text(
                                   '$seconds',


### PR DESCRIPTION
### Description
When the font size on the mobile device is increased, the stopwatch UI within the alarm app becomes partially hidden.

### Proposed Changes
Using Expanded instead of sizebox

## Fixes #426 

## Screenshots

Before:
 <img src="https://github.com/CCExtractor/ultimate_alarm_clock/assets/144731286/d8627c09-4b0f-420d-98a3-bc94f1f6654e" width="300" height="600">
 
 After:
 
 <img src="https://github.com/CCExtractor/ultimate_alarm_clock/assets/144731286/68e8c06d-26aa-4be1-be66-847e79b0f550" width="300" height="600">


