### PR TITLE
fix: onholdtodelete and swipetodelete will not run at same time

### DIFF
--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -854,11 +854,13 @@ class HomeView extends GetView<HomeController> {
                                           Utils.getRepeatDays(alarm.days);
                                       // Main card
                                       return Dismissible(
-                                        direction: DismissDirection.startToEnd,
+                                        direction: controller.isAnyAlarmHolded
+                                            .value ? DismissDirection.none : DismissDirection.startToEnd,
                                         onDismissed: (direction) async {
-                                          await controller.swipeToDeleteAlarm(
-                                              controller.userModel.value,
-                                              alarm);
+                                          if (!controller.isAnyAlarmHolded
+                                              .value) {
+                                            await controller.swipeToDeleteAlarm(controller.userModel.value, alarm);
+                                          }
                                         },
                                         key: ValueKey(alarms[index]),
                                         background: Container(


### PR DESCRIPTION
### Description
"Hold Gesture" for bulk deleting alarms and the "Swipe to Delete" functionality can run simultaneously

When attempting to use the "Hold Gesture" to initiate bulk deletion of alarms, the "Swipe to Delete" functionality can be triggered simultaneously. This behavior is inconsistent with the intended functionality, as the "Hold Gesture" should exclusively activate the bulk delete feature without interference from other gestures.

### Proposed Changes

conditionally setting the direction property of the Dismissible widget based on the value of the isAnyAlarmHolded controller 

## Fixes #371


## Screenshots


https://github.com/CCExtractor/ultimate_alarm_clock/assets/91874023/2e9cceed-2b71-4386-b514-497a9de69ad1



## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing