### PR TITLE
Fixed stopwatch milliseconds reset issue

### DIFF
--- a/lib/app/modules/stopwatch/controllers/stopwatch_controller.dart
+++ b/lib/app/modules/stopwatch/controllers/stopwatch_controller.dart
@@ -40,7 +40,7 @@ class StopwatchController extends GetxController {
 
   void _updateResult() {
     _result.value =
-        '${_stopwatch.elapsed.inMinutes.toString().padLeft(2, '0')}:${(_stopwatch.elapsed.inSeconds % 60).toString().padLeft(2, '0')}:${(_stopwatch.elapsed.inMilliseconds % 100).toString().padLeft(2, '0')}';
+        '${_stopwatch.elapsed.inMinutes.toString().padLeft(2, '0')}:${(_stopwatch.elapsed.inSeconds % 60).toString().padLeft(2, '0')}:${(_stopwatch.elapsed.inMilliseconds % 1000 ~/ 10).toString().padLeft(2, '0')}';
   }
 
 }


### PR DESCRIPTION
### Description
I've made a small fix to the stopwatch functionality. Previously, there was an issue where the milliseconds part of the stopwatch would reset when pausing and resuming it. I've addressed this issue by updating how the milliseconds are calculated.


## Fixes #435 


## Screenshots

**before fix:**



https://github.com/CCExtractor/ultimate_alarm_clock/assets/144731286/9d6c6234-ac59-4199-ab80-b103d5f37315






**after fix:**

https://github.com/CCExtractor/ultimate_alarm_clock/assets/144731286/9a3f397a-9572-4bdf-9951-9c5d28a8831b




