### PR TITLE
Bug: Resolved Error Text Not Shown On Entering Whitespace

### DIFF
--- a/lib/app/modules/settings/views/weather_api.dart
+++ b/lib/app/modules/settings/views/weather_api.dart
@@ -110,7 +110,9 @@ class WeatherApi extends StatelessWidget {
                                               .value = true;
 
                                           // Validation If String is empty
-                                          if (controller.apiKey.text.isEmpty) {
+                                          if (controller.apiKey.text
+                                              .trim()
+                                              .isEmpty) {
                                             // setState(() {
                                             controller.isApiKeyEmpty.value =
                                                 true;
@@ -123,7 +125,7 @@ class WeatherApi extends StatelessWidget {
 
                                           // Reset state after getting error message
                                           if (controller
-                                              .apiKey.text.isNotEmpty) {
+                                              .apiKey.text.trim().isNotEmpty) {
                                             // setState(() {
                                             controller.isApiKeyEmpty.value =
                                                 false;

--- a/lib/app/modules/settings/views/weather_api.dart
+++ b/lib/app/modules/settings/views/weather_api.dart
@@ -124,8 +124,9 @@ class WeatherApi extends StatelessWidget {
                                           }
 
                                           // Reset state after getting error message
-                                          if (controller
-                                              .apiKey.text.trim().isNotEmpty) {
+                                          if (controller.apiKey.text
+                                              .trim()
+                                              .isNotEmpty) {
                                             // setState(() {
                                             controller.isApiKeyEmpty.value =
                                                 false;


### PR DESCRIPTION
### Description
Currently, the `Weather API Key Dialog` doesn't display an error message when the user enters only whitespaces in the API key field. This pull request addresses this issue by ensuring the error message is shown both for empty entries and entries containing only whitespace characters.

### Proposed Changes
- Instead of directly evaluating the text field's text property for emptiness, trim leading and trailing whitespaces first, and then check.

## Fixes #374

## Screenshots


https://github.com/CCExtractor/ultimate_alarm_clock/assets/92971894/5f99cc04-cf18-4d90-9315-ff78ae6434a2



## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [ ] All tests are passing