### PR TITLE
Bug: Resolved the Repeat Tile Bugs

### DIFF
--- a/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
+++ b/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
@@ -525,7 +525,9 @@ class AddOrUpdateAlarmController extends GetxController {
       } else {
         // Deleting alarm on firestore to ensure no duplicate entry
         await FirestoreDb.deleteAlarm(
-            userModel.value, alarmRecord!.firestoreId!);
+          userModel.value,
+          alarmRecord!.firestoreId!,
+        );
         createAlarm(alarmData);
       }
     }

--- a/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
+++ b/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
@@ -79,7 +79,7 @@ class AddOrUpdateAlarmController extends GetxController {
   final RxInt snoozeDuration = 1.obs;
   var customRingtoneName = 'Default'.obs;
   var customRingtoneNames = [].obs;
-  var previousRingtone='';
+  var previousRingtone = '';
   final noteController = TextEditingController();
   final RxString note = ''.obs;
   final deleteAfterGoesOff = false.obs;
@@ -137,7 +137,7 @@ class AddOrUpdateAlarmController extends GetxController {
   }
 
   void setIsCustomSelected(bool value) {
-    isCustomSelected.value = true;
+    isCustomSelected.value = value;
     if (value == true) {
       isWeekdaysSelected.value = false;
       isDailySelected.value = false;
@@ -446,7 +446,6 @@ class AddOrUpdateAlarmController extends GetxController {
             showQRDialog();
           }
         },
-
         confirm: TextButton(
           style: ButtonStyle(
             backgroundColor: MaterialStateProperty.all(kprimaryColor),
@@ -458,7 +457,6 @@ class AddOrUpdateAlarmController extends GetxController {
                       ? kLightPrimaryTextColor
                       : ksecondaryTextColor,
                 ),
-
           ),
           onPressed: () async {
             Get.back(); // Close the alert box
@@ -579,7 +577,7 @@ class AddOrUpdateAlarmController extends GetxController {
       );
       hours.value = selectedTime.value.hour;
       minutes.value = selectedTime.value.minute;
-      
+
       if (settingsController.is24HrsEnabled.value == false) {
         if (selectedTime.value.hour == 0) {
           hours.value = 12;

--- a/lib/app/modules/addOrUpdateAlarm/views/repeat_tile.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/repeat_tile.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:get/get_connect/http/src/utils/utils.dart';
-import 'package:ultimate_alarm_clock/app/modules/addOrUpdateAlarm/views/repeat_once_tile.dart';
 import 'package:ultimate_alarm_clock/app/utils/constants.dart';
 import 'package:ultimate_alarm_clock/app/utils/utils.dart';
 
@@ -168,25 +166,29 @@ class RepeatTile extends StatelessWidget {
     }
   }
 
+  void handleDailyTileTap() {
+    Utils.hapticFeedback();
+    controller.setIsDailySelected(!controller.isDailySelected.value);
+
+    // Update repeatDays based on isDailySelected value
+    for (int i = 0; i < controller.repeatDays.length; i++) {
+      controller.repeatDays[i] = controller.isDailySelected.value;
+    }
+  }
+
   ListTile buildDailyTile({
     required AddOrUpdateAlarmController controller,
     required ThemeController themeController,
   }) {
     return ListTile(
-      contentPadding: EdgeInsets.only(left: 10.0),
+      contentPadding: const EdgeInsets.only(left: 10.0),
       title: Obx(
         () => InkWell(
           onTap: () {
-            Utils.hapticFeedback();
-            controller.setIsDailySelected(!controller.isDailySelected.value);
-
-            // Update repeatDays based on isDailySelected value
-            for (int i = 0; i < controller.repeatDays.length; i++) {
-              controller.repeatDays[i] = controller.isDailySelected.value;
-            }
+            handleDailyTileTap();
           },
           child: Padding(
-            padding: EdgeInsets.all(8.0), // Adjust the padding as needed
+            padding: const EdgeInsets.all(8.0), // Adjust the padding as needed
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               crossAxisAlignment: CrossAxisAlignment.center,
@@ -204,7 +206,7 @@ class RepeatTile extends StatelessWidget {
                   activeColor: kprimaryColor.withOpacity(0.8),
                   value: controller.isDailySelected.value,
                   onChanged: (value) {
-                    // This onChanged can be empty, as we handle the tap in InkWell
+                    handleDailyTileTap();
                   },
                 ),
               ],
@@ -260,6 +262,103 @@ class RepeatTile extends StatelessWidget {
     );
   }
 
+  void checkIfAnyDaySelectedInCustomTile() {
+    controller.isCustomSelected.value = false;
+
+    for (bool repeatDay in controller.repeatDays) {
+      if (controller.isCustomSelected.value) {
+        continue;
+      } else if (repeatDay) {
+        controller.isCustomSelected.value = true;
+      }
+    }
+  }
+
+  void showCustomDaySelectionDialog({required BuildContext context}) {
+    Get.defaultDialog(
+      onWillPop: () async {
+        checkIfAnyDaySelectedInCustomTile();
+        return true;
+      },
+      titlePadding: const EdgeInsets.symmetric(vertical: 20),
+      backgroundColor: themeController.isLightMode.value
+          ? kLightSecondaryBackgroundColor
+          : ksecondaryBackgroundColor,
+      title: 'Days of the week'.tr,
+      titleStyle: TextStyle(
+        color: themeController.isLightMode.value
+            ? kLightPrimaryTextColor
+            : kprimaryTextColor,
+      ),
+      content: Column(
+        children: [
+          dayTile(
+            dayIndex: 0,
+            dayName: 'Monday'.tr,
+            context: context,
+          ),
+          dayTile(
+            dayIndex: 1,
+            dayName: 'Tuesday'.tr,
+            context: context,
+          ),
+          dayTile(
+            dayIndex: 2,
+            dayName: 'Wednesday'.tr,
+            context: context,
+          ),
+          dayTile(
+            dayIndex: 3,
+            dayName: 'Thursday'.tr,
+            context: context,
+          ),
+          dayTile(
+            dayIndex: 4,
+            dayName: 'Friday'.tr,
+            context: context,
+          ),
+          dayTile(
+            dayIndex: 5,
+            dayName: 'Saturday'.tr,
+            context: context,
+          ),
+          dayTile(
+            dayIndex: 6,
+            dayName: 'Sunday'.tr,
+            context: context,
+          ),
+          Padding(
+            padding: const EdgeInsets.only(left: 10.0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                ElevatedButton(
+                  onPressed: () {
+                    Utils.hapticFeedback();
+                    checkIfAnyDaySelectedInCustomTile();
+                    Get.back();
+                  },
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: kprimaryColor,
+                  ),
+                  child: Text(
+                    'Done'.tr,
+                    style: Theme.of(context).textTheme.displaySmall!.copyWith(
+                          color: themeController.isLightMode.value
+                              ? kLightPrimaryTextColor
+                              : ksecondaryTextColor,
+                        ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   ListTile buildCustomDaysTile({
     required AddOrUpdateAlarmController controller,
     required ThemeController themeController,
@@ -267,7 +366,7 @@ class RepeatTile extends StatelessWidget {
   }) {
     List<bool> repeatDays = List<bool>.filled(7, false);
     return ListTile(
-      contentPadding: EdgeInsets.only(left: 10.0),
+      contentPadding: const EdgeInsets.only(left: 10.0),
       title: Obx(
         () => InkWell(
           onTap: () {
@@ -275,94 +374,10 @@ class RepeatTile extends StatelessWidget {
             _storeOrPreset(repeatDays, controller.repeatDays);
 
             controller.setIsCustomSelected(!controller.isCustomSelected.value);
-            Get.defaultDialog(
-              onWillPop: () async {
-                // presetting values to initial state
-                _storeOrPreset(controller.repeatDays, repeatDays);
-                return true;
-              },
-              titlePadding: const EdgeInsets.symmetric(vertical: 20),
-              backgroundColor: themeController.isLightMode.value
-                  ? kLightSecondaryBackgroundColor
-                  : ksecondaryBackgroundColor,
-              title: 'Days of the week'.tr,
-              titleStyle: TextStyle(
-                color: themeController.isLightMode.value
-                    ? kLightPrimaryTextColor
-                    : kprimaryTextColor,
-              ),
-              content: Column(
-                children: [
-                  dayTile(
-                    dayIndex: 0,
-                    dayName: 'Monday'.tr,
-                    context: context,
-                  ),
-                  dayTile(
-                    dayIndex: 1,
-                    dayName: 'Tuesday'.tr,
-                    context: context,
-                  ),
-                  dayTile(
-                    dayIndex: 2,
-                    dayName: 'Wednesday'.tr,
-                    context: context,
-                  ),
-                  dayTile(
-                    dayIndex: 3,
-                    dayName: 'Thursday'.tr,
-                    context: context,
-                  ),
-                  dayTile(
-                    dayIndex: 4,
-                    dayName: 'Friday'.tr,
-                    context: context,
-                  ),
-                  dayTile(
-                    dayIndex: 5,
-                    dayName: 'Saturday'.tr,
-                    context: context,
-                  ),
-                  dayTile(
-                    dayIndex: 6,
-                    dayName: 'Sunday'.tr,
-                    context: context,
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.only(left: 10.0),
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      children: [
-                        ElevatedButton(
-                          onPressed: () {
-                            Utils.hapticFeedback();
-                            Get.back();
-                          },
-                          style: ElevatedButton.styleFrom(
-                            backgroundColor: kprimaryColor,
-                          ),
-                          child: Text(
-                            'Done'.tr,
-                            style: Theme.of(context)
-                                .textTheme
-                                .displaySmall!
-                                .copyWith(
-                                  color: themeController.isLightMode.value
-                                      ? kLightPrimaryTextColor
-                                      : ksecondaryTextColor,
-                                ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-            );
+            showCustomDaySelectionDialog(context: context);
           },
           child: Padding(
-            padding: EdgeInsets.all(8.0),
+            padding: const EdgeInsets.all(8.0),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               crossAxisAlignment: CrossAxisAlignment.center,
@@ -380,9 +395,12 @@ class RepeatTile extends StatelessWidget {
                   onChanged: (value) {
                     Utils.hapticFeedback();
                     controller.setIsCustomSelected(value!);
-
                     // Update repeatDays based on isCustomSelected value
                     _storeOrPreset(controller.repeatDays, repeatDays);
+
+                    if (value) {
+                      showCustomDaySelectionDialog(context: context);
+                    }
                   },
                 ),
               ],
@@ -393,33 +411,36 @@ class RepeatTile extends StatelessWidget {
     );
   }
 
+  void handleWeekdayTileTap() {
+    Utils.hapticFeedback();
+    controller.setIsWeekdaysSelected(!controller.isWeekdaysSelected.value);
+
+    // Update repeatDays based on isWeekdaysSelected value
+    for (int i = 0; i < controller.repeatDays.length; i++) {
+      // Assuming weekdays are from Monday to Friday (index 0 to 5)
+      controller.repeatDays[i] =
+          controller.isWeekdaysSelected.value && i >= 0 && i < 5;
+    }
+  }
+
   ListTile buildWeekdaysTile({
     required AddOrUpdateAlarmController controller,
     required ThemeController themeController,
   }) {
     return ListTile(
-      contentPadding: EdgeInsets.only(left: 10.0),
+      contentPadding: const EdgeInsets.only(left: 10.0),
       title: Obx(
         () => InkWell(
           onTap: () {
-            Utils.hapticFeedback();
-            controller
-                .setIsWeekdaysSelected(!controller.isWeekdaysSelected.value);
-
-            // Update repeatDays based on isWeekdaysSelected value
-            for (int i = 0; i < controller.repeatDays.length; i++) {
-              // Assuming weekdays are from Monday to Friday (index 0 to 5)
-              controller.repeatDays[i] =
-                  controller.isWeekdaysSelected.value && i >= 0 && i < 5;
-            }
+            handleWeekdayTileTap();
           },
           child: Padding(
-            padding: EdgeInsets.all(8.0), // Adjust the padding as needed
+            padding: const EdgeInsets.all(8.0), // Adjust the padding as needed
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
-                Text(
+                const Text(
                   'Weekdays',
                 ),
                 Checkbox.adaptive(
@@ -432,18 +453,7 @@ class RepeatTile extends StatelessWidget {
                   activeColor: kprimaryColor.withOpacity(0.8),
                   value: controller.isWeekdaysSelected.value,
                   onChanged: (value) {
-                    Utils.hapticFeedback();
-                    controller.setIsWeekdaysSelected(
-                        !controller.isWeekdaysSelected.value);
-
-                    // Update repeatDays based on isWeekdaysSelected value
-                    for (int i = 0; i < controller.repeatDays.length; i++) {
-                      // Assuming weekdays are from Monday to Friday (index 1 to 5)
-                      controller.repeatDays[i] =
-                          controller.isWeekdaysSelected.value &&
-                              i >= 1 &&
-                              i <= 5;
-                    }
+                    handleWeekdayTileTap();
                   },
                 ),
               ],


### PR DESCRIPTION
### Description

This pull request addresses several bugs related to the `RepeatTile` in the `AddOrUpdateAlarmView`:

- Daily list tile's checkbox is not responsive.
- Weekdays checkbox functionality inconsistency.
- Custom list tile checkbox remains selected even with no days selected.
- Custom list tile checkbox doesn't trigger day selection dialog.
- Toggling Custom list tile checkbox is broken after selection.

### Proposed Changes

- **Daily Tile**: Investigated and fixed the cause of the unresponsive checkbox behavior.
- **Weekday Tile**:
  - Added `handleWeekdayTileTap` to accurately reflect selected days in the tile text when tapped.
  - Ensured consistency between checkbox selection and tile text display.
- **Custom Tile**:
  - Implemented `checkIfAnyDaySelectedInCustomTile` to accurately determine if any custom days are selected.
  - Added `showCustomDaySelectionDialog` to trigger the day selection dialog when the Custom tile checkbox is tapped.
  - Addressed the issue where the Custom tile checkbox cannot be toggled after selection by setting the `isCustomSelected.value` to the actual selected value instead of a fixed true.

## Fixes #373

## Screenshots


https://github.com/CCExtractor/ultimate_alarm_clock/assets/92971894/6e00a295-907b-4be0-8dd9-d54ccfdd4cb2



## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [ ] All tests are passing