### PR TITLE
Customise undo duration

### DIFF
--- a/lib/app/modules/home/controllers/home_controller.dart
+++ b/lib/app/modules/home/controllers/home_controller.dart
@@ -25,6 +25,7 @@ class Pair<T, U> {
 }
 
 class HomeController extends GetxController {
+
   MethodChannel alarmChannel = const MethodChannel('ulticlock');
   Stream<QuerySnapshot>? firestoreStreamAlarms;
   Stream<QuerySnapshot>? sharedAlarmsStream;
@@ -59,6 +60,9 @@ class HomeController extends GetxController {
   Pair<List<AlarmModel>, List<RxBool>> alarmListPairs = Pair([], []);
 
   Set<Pair<dynamic, bool>> selectedAlarmSet = {};
+
+  final RxInt duration = 3.obs;
+  final RxDouble selecteddurationDouble = 0.0.obs;
 
   ThemeController themeController = Get.find<ThemeController>();
 
@@ -535,7 +539,7 @@ class HomeController extends GetxController {
     Get.snackbar(
       'Alarm deleted',
       'The alarm has been deleted.',
-      duration: const Duration(seconds: 4),
+      duration: Duration(seconds:  duration.toInt()),
       snackPosition: SnackPosition.BOTTOM,
       margin: const EdgeInsets.symmetric(
         horizontal: 10,

--- a/lib/app/modules/settings/controllers/settings_controller.dart
+++ b/lib/app/modules/settings/controllers/settings_controller.dart
@@ -39,6 +39,9 @@ class SettingsController extends GetxController {
   final RxString local = Get.locale.toString().obs;
   UserModel? userModel;
 
+  final RxInt duration = 0.obs;
+  final RxDouble selecteddurationDouble = 0.0.obs;
+
   final Map<String, dynamic> optionslocales = {
     'en_US': {
       'languageCode': 'en',

--- a/lib/app/modules/settings/controllers/settings_controller.dart
+++ b/lib/app/modules/settings/controllers/settings_controller.dart
@@ -39,9 +39,6 @@ class SettingsController extends GetxController {
   final RxString local = Get.locale.toString().obs;
   UserModel? userModel;
 
-  final RxInt duration = 0.obs;
-  final RxDouble selecteddurationDouble = 0.0.obs;
-
   final Map<String, dynamic> optionslocales = {
     'en_US': {
       'languageCode': 'en',

--- a/lib/app/modules/settings/views/customize_undo_duration.dart
+++ b/lib/app/modules/settings/views/customize_undo_duration.dart
@@ -1,0 +1,119 @@
+
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:get/get_core/src/get_main.dart';
+
+import '../../../utils/constants.dart';
+import '../../../utils/utils.dart';
+import '../controllers/theme_controller.dart';
+import 'package:ultimate_alarm_clock/app/modules/settings/controllers/settings_controller.dart';
+
+class CustomizeUndoDuration extends StatelessWidget{
+  CustomizeUndoDuration({
+    super.key ,
+    required this.controller,
+    required this.themeController,
+  });
+  final SettingsController controller;
+  final ThemeController themeController;
+
+  @override
+  Widget build(BuildContext context) {
+    int duration;
+    return InkWell(
+      onTap: () {
+        Utils.hapticFeedback();
+        duration = controller.duration.value;
+        Get.defaultDialog(
+          onWillPop: () async {
+            Get.back();
+            // Resetting the value to its initial state
+            controller.duration.value = duration;
+
+            return true;
+          },
+          titlePadding: const EdgeInsets.symmetric(vertical: 20, horizontal: 5),
+          backgroundColor: themeController.isLightMode.value
+              ? kLightSecondaryBackgroundColor
+              : ksecondaryBackgroundColor,
+          title: 'Customize Undo Duration'.tr,
+          titleStyle: Theme.of(context).textTheme.displaySmall,
+          content: Obx(
+                () => Column(
+              children: [
+                Text(
+                  '${controller.duration.value} seconds'.tr,
+                  style: Theme.of(context).textTheme.displaySmall,
+                ),
+                Slider(
+                  value: controller.selecteddurationDouble.value,
+                  onChanged: (double value) {
+                    controller.selecteddurationDouble.value = value;
+                    controller.duration.value = value.toInt();
+                  },
+                  min: 0.0,
+                  max: 20.0,
+                  divisions: 20,
+                  label: controller.duration.value.toString(),
+                ),
+                // Replace the volMin Slider with RangeSlider
+
+                ElevatedButton(
+                  onPressed: () {
+                    Get.back();
+                  },
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: kprimaryColor,
+                  ),
+                  child: Text(
+                    'Apply Duration'.tr,
+                    style: TextStyle(
+                      color: themeController.isLightMode.value
+                          ? kLightSecondaryTextColor
+                          : ksecondaryTextColor,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+      child: ListTile(
+        tileColor: themeController.isLightMode.value
+            ? kLightSecondaryBackgroundColor
+            : ksecondaryBackgroundColor,
+        title: Text(
+          'Undo Duration'.tr,
+          style: TextStyle(
+            color: themeController.isLightMode.value
+                ? kLightPrimaryTextColor
+                : kprimaryTextColor,
+          ),
+        ),
+        trailing: Wrap(
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: [
+            Obx(
+                  () => Text(
+                '${controller.duration.value.round().toInt()} seconds',
+                style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                  color: themeController.isLightMode.value
+                      ? kLightPrimaryTextColor
+                      : kprimaryTextColor,
+                ),
+              ),
+            ),
+            Icon(
+              Icons.chevron_right,
+              color: themeController.isLightMode.value
+                  ? kLightPrimaryDisabledTextColor
+                  : kprimaryDisabledTextColor,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+}

--- a/lib/app/modules/settings/views/customize_undo_duration.dart
+++ b/lib/app/modules/settings/views/customize_undo_duration.dart
@@ -2,6 +2,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:get/get_core/src/get_main.dart';
+import 'package:ultimate_alarm_clock/app/modules/home/controllers/home_controller.dart';
 
 import '../../../utils/constants.dart';
 import '../../../utils/utils.dart';
@@ -9,14 +10,13 @@ import '../controllers/theme_controller.dart';
 import 'package:ultimate_alarm_clock/app/modules/settings/controllers/settings_controller.dart';
 
 class CustomizeUndoDuration extends StatelessWidget{
+  HomeController homeController = Get.find<HomeController>();
   CustomizeUndoDuration({
     super.key ,
-    required this.controller,
     required this.themeController,
     required this.height,
     required this.width,
   });
-  final SettingsController controller;
   final ThemeController themeController;
   final double width;
   final double height;
@@ -27,12 +27,12 @@ class CustomizeUndoDuration extends StatelessWidget{
     return InkWell(
       onTap: () {
         Utils.hapticFeedback();
-        duration = controller.duration.value;
+        duration = homeController.duration.value;
         Get.defaultDialog(
           onWillPop: () async {
             Get.back();
             // Resetting the value to its initial state
-            controller.duration.value = duration;
+            homeController.duration.value = duration;
             return true;
           },
           titlePadding: const EdgeInsets.symmetric(vertical: 20, horizontal: 5),
@@ -45,20 +45,20 @@ class CustomizeUndoDuration extends StatelessWidget{
                 () => Column(
               children: [
                 Text(
-                  '${controller.duration.value} seconds'.tr,
+                  '${homeController.duration.value} seconds'.tr,
                   style: Theme.of(context).textTheme.displaySmall,
                 ),
                 Slider(
-                  value: controller.selecteddurationDouble.value,
+                  value: homeController.selecteddurationDouble.value,
                   onChanged: (double value) {
-                    controller.selecteddurationDouble.value = value;
-                    controller.duration.value = value.toInt();
+                    homeController.selecteddurationDouble.value = value;
+                    homeController.duration.value = value.toInt();
 
                   },
                   min: 0.0,
                   max: 20.0,
                   divisions: 20,
-                  label: controller.duration.value.toString(),
+                  label: homeController.duration.value.toString(),
                 ),
                 // Replace the volMin Slider with RangeSlider
 
@@ -89,40 +89,44 @@ class CustomizeUndoDuration extends StatelessWidget{
         decoration: Utils.getCustomTileBoxDecoration(
           isLightMode: themeController.isLightMode.value,
         ),
-        child: Padding(
-          padding: EdgeInsets.only(left: 10, right: 10),
-          child: ListTile(
-            tileColor: themeController.isLightMode.value
-                ? kLightSecondaryBackgroundColor
-                : ksecondaryBackgroundColor,
-            title: Text(
-              'Undo Duration'.tr,
-              style: TextStyle(
-                color: themeController.isLightMode.value
-                    ? kLightPrimaryTextColor
-                    : kprimaryTextColor,
+        child: Center(
+          child: Padding(
+            padding: EdgeInsets.only(left: 10, right: 10),
+            child: ListTile(
+              tileColor: themeController.isLightMode.value
+                  ? kLightSecondaryBackgroundColor
+                  : ksecondaryBackgroundColor,
+              title: Text(
+                'Undo Duration'.tr,
+                style: TextStyle(
+                  color: themeController.isLightMode.value
+                      ? kLightPrimaryTextColor
+                      : kprimaryTextColor,
+                  fontSize: 15
+                ),
               ),
-            ),
-            trailing: Wrap(
-              crossAxisAlignment: WrapCrossAlignment.center,
-              children: [
-                Obx(
-                      () => Text(
-                    '${controller.duration.value.round().toInt()} seconds',
-                    style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                      color: themeController.isLightMode.value
-                          ? kLightPrimaryTextColor
-                          : kprimaryTextColor,
+              trailing: Wrap(
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: [
+                  Obx(
+                        () => Text(
+                      '${homeController.duration.value.round().toInt()} seconds',
+                      style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                        color: themeController.isLightMode.value
+                            ? kLightPrimaryTextColor
+                            : kprimaryTextColor,
+                          fontSize: 13
+                      ),
                     ),
                   ),
-                ),
-                Icon(
-                  Icons.chevron_right,
-                  color: themeController.isLightMode.value
-                      ? kLightPrimaryDisabledTextColor
-                      : kprimaryDisabledTextColor,
-                ),
-              ],
+                  Icon(
+                    Icons.chevron_right,
+                    color: themeController.isLightMode.value
+                        ? kLightPrimaryDisabledTextColor
+                        : kprimaryDisabledTextColor,
+                  ),
+                ],
+              ),
             ),
           ),
         )

--- a/lib/app/modules/settings/views/customize_undo_duration.dart
+++ b/lib/app/modules/settings/views/customize_undo_duration.dart
@@ -13,9 +13,13 @@ class CustomizeUndoDuration extends StatelessWidget{
     super.key ,
     required this.controller,
     required this.themeController,
+    required this.height,
+    required this.width,
   });
   final SettingsController controller;
   final ThemeController themeController;
+  final double width;
+  final double height;
 
   @override
   Widget build(BuildContext context) {
@@ -29,7 +33,6 @@ class CustomizeUndoDuration extends StatelessWidget{
             Get.back();
             // Resetting the value to its initial state
             controller.duration.value = duration;
-
             return true;
           },
           titlePadding: const EdgeInsets.symmetric(vertical: 20, horizontal: 5),
@@ -50,6 +53,7 @@ class CustomizeUndoDuration extends StatelessWidget{
                   onChanged: (double value) {
                     controller.selecteddurationDouble.value = value;
                     controller.duration.value = value.toInt();
+
                   },
                   min: 0.0,
                   max: 20.0,
@@ -79,40 +83,50 @@ class CustomizeUndoDuration extends StatelessWidget{
           ),
         );
       },
-      child: ListTile(
-        tileColor: themeController.isLightMode.value
-            ? kLightSecondaryBackgroundColor
-            : ksecondaryBackgroundColor,
-        title: Text(
-          'Undo Duration'.tr,
-          style: TextStyle(
-            color: themeController.isLightMode.value
-                ? kLightPrimaryTextColor
-                : kprimaryTextColor,
-          ),
+      child: Container(
+        width: width * 0.91,
+        height: height * 0.09,
+        decoration: Utils.getCustomTileBoxDecoration(
+          isLightMode: themeController.isLightMode.value,
         ),
-        trailing: Wrap(
-          crossAxisAlignment: WrapCrossAlignment.center,
-          children: [
-            Obx(
-                  () => Text(
-                '${controller.duration.value.round().toInt()} seconds',
-                style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                  color: themeController.isLightMode.value
-                      ? kLightPrimaryTextColor
-                      : kprimaryTextColor,
-                ),
+        child: Padding(
+          padding: EdgeInsets.only(left: 10, right: 10),
+          child: ListTile(
+            tileColor: themeController.isLightMode.value
+                ? kLightSecondaryBackgroundColor
+                : ksecondaryBackgroundColor,
+            title: Text(
+              'Undo Duration'.tr,
+              style: TextStyle(
+                color: themeController.isLightMode.value
+                    ? kLightPrimaryTextColor
+                    : kprimaryTextColor,
               ),
             ),
-            Icon(
-              Icons.chevron_right,
-              color: themeController.isLightMode.value
-                  ? kLightPrimaryDisabledTextColor
-                  : kprimaryDisabledTextColor,
+            trailing: Wrap(
+              crossAxisAlignment: WrapCrossAlignment.center,
+              children: [
+                Obx(
+                      () => Text(
+                    '${controller.duration.value.round().toInt()} seconds',
+                    style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                      color: themeController.isLightMode.value
+                          ? kLightPrimaryTextColor
+                          : kprimaryTextColor,
+                    ),
+                  ),
+                ),
+                Icon(
+                  Icons.chevron_right,
+                  color: themeController.isLightMode.value
+                      ? kLightPrimaryDisabledTextColor
+                      : kprimaryDisabledTextColor,
+                ),
+              ],
             ),
-          ],
-        ),
-      ),
+          ),
+        )
+      )
     );
   }
 

--- a/lib/app/modules/settings/views/settings_view.dart
+++ b/lib/app/modules/settings/views/settings_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:ultimate_alarm_clock/app/modules/home/controllers/home_controller.dart';
 import 'package:ultimate_alarm_clock/app/modules/settings/controllers/theme_controller.dart';
+import 'package:ultimate_alarm_clock/app/modules/settings/views/customize_undo_duration.dart';
 
 import 'package:ultimate_alarm_clock/app/modules/settings/views/enable_24Hour_format.dart';
 
@@ -106,6 +107,13 @@ class SettingsView extends GetView<SettingsController> {
                   height: height,
                   width: width,
                   themeController: controller.themeController,
+                ),
+                const SizedBox(
+                  height: 20,
+                ),
+                CustomizeUndoDuration(
+                  controller: controller,
+                    themeController: controller.themeController
                 ),
                 const SizedBox(
                   height: 20,

--- a/lib/app/modules/settings/views/settings_view.dart
+++ b/lib/app/modules/settings/views/settings_view.dart
@@ -112,6 +112,8 @@ class SettingsView extends GetView<SettingsController> {
                   height: 20,
                 ),
                 CustomizeUndoDuration(
+                    width: width,
+                    height: height,
                   controller: controller,
                     themeController: controller.themeController
                 ),

--- a/lib/app/modules/settings/views/settings_view.dart
+++ b/lib/app/modules/settings/views/settings_view.dart
@@ -114,7 +114,6 @@ class SettingsView extends GetView<SettingsController> {
                 CustomizeUndoDuration(
                     width: width,
                     height: height,
-                  controller: controller,
                     themeController: controller.themeController
                 ),
                 const SizedBox(


### PR DESCRIPTION
### Description
Undo Duration allows users to customize the duration of the undo option. By default, the undo duration is set to 4 seconds, but with this new feature, users have the flexibility to adjust it according to their preferences.

The "Undo Duration" setting allows users to tailor the time window for undoing actions. By default, the duration is set to 4 seconds, striking a balance for typical use cases. Users seeking a personalized experience can easily adjust the undo duration to better suit their workflow.

### Proposed Changes
Flexibility: Users can adapt the undo duration to match the pace and complexity of their tasks.
Efficiency: Tailoring the undo duration enhances productivity for various use cases.
User-Centric: Providing customization options contributes to a user-friendly experience.

## Fixes #378 

Replace `issue_no` with the issue number which is fixed in this PR


## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing