### PR TITLE
Feature: Added Manual Time Entry Option in Timer

### DIFF
--- a/lib/app/modules/addOrUpdateAlarm/controllers/input_time_controller.dart
+++ b/lib/app/modules/addOrUpdateAlarm/controllers/input_time_controller.dart
@@ -108,7 +108,7 @@ class InputTimeController extends GetxController {
           addOrUpdateAlarmController.hours.value = 12;
         } else if (selectedDateTime.value.hour > 12) {
           addOrUpdateAlarmController.hours.value =
-              (selectedDateTime.value.hour-12);
+              (selectedDateTime.value.hour - 12);
         } else {
           addOrUpdateAlarmController.hours.value = selectedDateTime.value.hour;
         }
@@ -126,7 +126,7 @@ class InputTimeController extends GetxController {
       debugPrint(e.toString());
     }
   }
-  
+
   void setTimerTime() {
     try {
       int hours = int.parse(inputHoursControllerTimer.text);
@@ -135,7 +135,7 @@ class InputTimeController extends GetxController {
 
       timerController.hours.value = hours;
       timerController.minutes.value = minutes;
-      timerController.seconds.value = seconds; 
+      timerController.seconds.value = seconds;
     } catch (e) {
       debugPrint(e.toString());
     }
@@ -146,7 +146,7 @@ class InputTimeController extends GetxController {
     inputHrsController.dispose();
     inputMinutesController.dispose();
     inputHoursControllerTimer.dispose();
-    inputMinutesControllerTimer.dispose(); 
+    inputMinutesControllerTimer.dispose();
     inputSecondsControllerTimer.dispose();
     super.onClose();
   }

--- a/lib/app/modules/addOrUpdateAlarm/controllers/input_time_controller.dart
+++ b/lib/app/modules/addOrUpdateAlarm/controllers/input_time_controller.dart
@@ -3,14 +3,20 @@ import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'package:ultimate_alarm_clock/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart';
 import 'package:ultimate_alarm_clock/app/modules/settings/controllers/settings_controller.dart';
+import 'package:ultimate_alarm_clock/app/modules/timer/controllers/timer_controller.dart';
 
 class InputTimeController extends GetxController {
   AddOrUpdateAlarmController addOrUpdateAlarmController =
       Get.find<AddOrUpdateAlarmController>();
+  TimerController timerController = Get.find<TimerController>();
   SettingsController settingsController = Get.find<SettingsController>();
   final isTimePicker = false.obs;
+  final isTimePickerTimer = false.obs;
   TextEditingController inputHrsController = TextEditingController();
   TextEditingController inputMinutesController = TextEditingController();
+  TextEditingController inputHoursControllerTimer = TextEditingController();
+  TextEditingController inputMinutesControllerTimer = TextEditingController();
+  TextEditingController inputSecondsControllerTimer = TextEditingController();
   final selectedDateTime = DateTime.now().obs;
   bool isInputtingTime = false;
 
@@ -32,6 +38,9 @@ class InputTimeController extends GetxController {
                 ? (selectedDateTime.value.hour - 12).toString()
                 : selectedDateTime.value.hour.toString()));
     inputMinutesController.text = selectedDateTime.value.minute.toString();
+    inputHoursControllerTimer.text = timerController.hours.value.toString();
+    inputMinutesControllerTimer.text = timerController.minutes.value.toString();
+    inputSecondsControllerTimer.text = timerController.seconds.value.toString();
     super.onInit();
   }
 
@@ -42,6 +51,10 @@ class InputTimeController extends GetxController {
 
   changeDatePicker() {
     isTimePicker.value = !isTimePicker.value;
+  }
+
+  changeTimePickerTimer() {
+    isTimePickerTimer.value = !isTimePickerTimer.value;
   }
 
   int convert24(int value) {
@@ -113,11 +126,28 @@ class InputTimeController extends GetxController {
       debugPrint(e.toString());
     }
   }
+  
+  void setTimerTime() {
+    try {
+      int hours = int.parse(inputHoursControllerTimer.text);
+      int minutes = int.parse(inputMinutesControllerTimer.text);
+      int seconds = int.parse(inputSecondsControllerTimer.text);
+
+      timerController.hours.value = hours;
+      timerController.minutes.value = minutes;
+      timerController.seconds.value = seconds; 
+    } catch (e) {
+      debugPrint(e.toString());
+    }
+  }
 
   @override
   void onClose() {
     inputHrsController.dispose();
     inputMinutesController.dispose();
+    inputHoursControllerTimer.dispose();
+    inputMinutesControllerTimer.dispose(); 
+    inputSecondsControllerTimer.dispose();
     super.onClose();
   }
 }

--- a/lib/app/modules/bottomNavigationBar/bindings/bottom_navigation_bar_binding.dart
+++ b/lib/app/modules/bottomNavigationBar/bindings/bottom_navigation_bar_binding.dart
@@ -1,4 +1,5 @@
 import 'package:get/get.dart';
+import 'package:ultimate_alarm_clock/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart';
 import 'package:ultimate_alarm_clock/app/modules/bottomNavigationBar/controllers/bottom_navigation_bar_controller.dart';
 import 'package:ultimate_alarm_clock/app/modules/home/controllers/home_controller.dart';
 import 'package:ultimate_alarm_clock/app/modules/settings/controllers/settings_controller.dart';
@@ -19,5 +20,6 @@ class BottomNavigationBarBinding extends Bindings {
     );
     Get.lazyPut<SettingsController>(() => SettingsController(), fenix: true);
     Get.lazyPut(() => HomeController());
+    Get.lazyPut(() => AddOrUpdateAlarmController());
   }
 }

--- a/lib/app/modules/timer/bindings/timer_binding.dart
+++ b/lib/app/modules/timer/bindings/timer_binding.dart
@@ -1,4 +1,6 @@
 import 'package:get/get.dart';
+import 'package:ultimate_alarm_clock/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart';
+import 'package:ultimate_alarm_clock/app/modules/addOrUpdateAlarm/controllers/input_time_controller.dart';
 import 'package:ultimate_alarm_clock/app/modules/bottomNavigationBar/controllers/bottom_navigation_bar_controller.dart';
 import 'package:ultimate_alarm_clock/app/modules/home/controllers/home_controller.dart';
 import 'package:ultimate_alarm_clock/app/modules/settings/controllers/settings_controller.dart';

--- a/lib/app/modules/timer/views/timer_view.dart
+++ b/lib/app/modules/timer/views/timer_view.dart
@@ -1,8 +1,10 @@
+import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'package:flutter/material.dart';
 import 'package:numberpicker/numberpicker.dart';
 import 'package:ultimate_alarm_clock/app/data/providers/isar_provider.dart';
 import 'package:ultimate_alarm_clock/app/data/providers/secure_storage_provider.dart';
+import 'package:ultimate_alarm_clock/app/modules/addOrUpdateAlarm/controllers/input_time_controller.dart';
 import 'package:ultimate_alarm_clock/app/modules/settings/controllers/theme_controller.dart';
 import 'package:ultimate_alarm_clock/app/modules/timer/controllers/timer_controller.dart';
 import 'package:ultimate_alarm_clock/app/routes/app_pages.dart';
@@ -14,439 +16,660 @@ class TimerView extends GetView<TimerController> {
   TimerView({Key? key}) : super(key: key);
 
   ThemeController themeController = Get.find<ThemeController>();
+  InputTimeController inputTimeController = Get.put(InputTimeController());
 
   @override
   Widget build(BuildContext context) {
     var width = Get.width;
     var height = Get.height;
     return Scaffold(
-      appBar: PreferredSize(
-        preferredSize: Size.fromHeight(height / 7.9),
-        child: AppBar(
-          toolbarHeight: height / 7.9,
-          elevation: 0.0,
-          centerTitle: true,
-          actions: [
-            LayoutBuilder(
-              builder: (BuildContext context, BoxConstraints constraints) {
-                return IconButton(
-                  onPressed: () {
-                    Utils.hapticFeedback();
-                    Scaffold.of(context).openEndDrawer();
-                  },
-                  icon: const Icon(
-                    Icons.menu,
-                  ),
-                  color: themeController.isLightMode.value
-                      ? kLightPrimaryTextColor.withOpacity(0.75)
-                      : kprimaryTextColor.withOpacity(0.75),
-                  iconSize: 27,
-                  // splashRadius: 0.000001,
-                );
-              },
-            ),
-          ],
-        ),
-      ),
-      body: Obx(
-        () => controller.isTimerRunning.value
-            ? Column(
-                children: [
-                  SizedBox(
-                    height: height * 0.3,
-                  ),
-                  Center(
-                    child: Obx(
-                      () {
-                        final hours = controller.strDigits(
-                          controller.remainingTime.value.inHours.remainder(24),
-                        );
-                        final minutes = controller.strDigits(
-                          controller.remainingTime.value.inMinutes
-                              .remainder(60),
-                        );
-                        final seconds = controller.strDigits(
-                          controller.remainingTime.value.inSeconds
-                              .remainder(60),
-                        );
-                        return Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Expanded(
-                              child: Center(
-                                child: Text(
-                                  '$hours',
-                                  style: const TextStyle(
-                                    fontSize: 50.0,
-                                    fontWeight: FontWeight.bold,
-                                  ),
-                                ),
-                              ),
-                            ),
-                            const Text(
-                              ':',
-                              style: TextStyle(
-                                fontSize: 50.0,
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
-                            Expanded(
-                              child: Center(
-                                child: Text(
-                                  '$minutes',
-                                  style: const TextStyle(
-                                    fontSize: 50.0,
-                                    fontWeight: FontWeight.bold,
-                                  ),
-                                ),
-                              ),
-                            ),
-                            const Text(
-                              ':',
-                              style: TextStyle(
-                                fontSize: 50.0,
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
-                            Expanded(
-                              child: Center(
-                                child: Text(
-                                  '$seconds',
-                                  style: const TextStyle(
-                                    fontSize: 50.0,
-                                    fontWeight: FontWeight.bold,
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ],
-                        );
-                      },
-                    ),
-                  ),
-                  SizedBox(
-                    height: height * 0.15,
-                  ),
-                  Obx(
-                    () => Row(
-                      children: [
-                        SizedBox(
-                          width: width * 0.20,
-                        ),
-                        FloatingActionButton.small(
-                          heroTag: 'stop',
-                          onPressed: () async {
-                            Utils.hapticFeedback();
-                            controller.stopTimer();
-                            int timerId =
-                                await SecureStorageProvider().readTimerId();
-                            await IsarDb.deleteAlarm(timerId);
-                          },
-                          child: const Icon(Icons.close_rounded),
-                        ),
-                        SizedBox(
-                          width: width * 0.11,
-                        ),
-                        FloatingActionButton(
-                          heroTag: 'pause',
-                          onPressed: () {
-                            Utils.hapticFeedback();
-                            controller.isTimerPaused.value
-                                ? controller.resumeTimer()
-                                : controller.pauseTimer();
-                          },
-                          child: Icon(
-                            controller.isTimerPaused.value
-                                ? Icons.play_arrow_rounded
-                                : Icons.pause_rounded,
-                            size: 33,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
-              )
-            : Obx(
-                () => Container(
-                  color: themeController.isLightMode.value
-                      ? kLightPrimaryBackgroundColor
-                      : kprimaryBackgroundColor,
-                  height: height * 0.32,
-                  width: width,
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: [
-                      Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Text(
-                            'Hours',
-                            style: Theme.of(context)
-                                .textTheme
-                                .displaySmall!
-                                .copyWith(
-                                  fontWeight: FontWeight.bold,
-                                  color: themeController.isLightMode.value
-                                      ? kLightPrimaryDisabledTextColor
-                                      : kprimaryDisabledTextColor,
-                                ),
-                          ),
-                          SizedBox(
-                            height: height * 0.008,
-                          ),
-                          NumberPicker(
-                            minValue: 0,
-                            maxValue: 23,
-                            value: controller.hours.value,
-                            onChanged: (value) {
-                              Utils.hapticFeedback();
-                              controller.hours.value = value;
-                            },
-                            infiniteLoop: true,
-                            itemWidth: width * 0.17,
-                            zeroPad: true,
-                            selectedTextStyle: Theme.of(context)
-                                .textTheme
-                                .displayLarge!
-                                .copyWith(
-                                  fontWeight: FontWeight.bold,
-                                  color: kprimaryColor,
-                                ),
-                            textStyle: Theme.of(context)
-                                .textTheme
-                                .displayMedium!
-                                .copyWith(
-                                  fontSize: 20,
-                                  color: themeController.isLightMode.value
-                                      ? kLightPrimaryDisabledTextColor
-                                      : kprimaryDisabledTextColor,
-                                ),
-                            decoration: BoxDecoration(
-                              border: Border(
-                                top: BorderSide(
-                                  width: width * 0.005,
-                                  color: themeController.isLightMode.value
-                                      ? kLightPrimaryDisabledTextColor
-                                      : kprimaryDisabledTextColor,
-                                ),
-                                bottom: BorderSide(
-                                  width: width * 0.005,
-                                  color: themeController.isLightMode.value
-                                      ? kLightPrimaryDisabledTextColor
-                                      : kprimaryDisabledTextColor,
-                                ),
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                      Padding(
-                        padding: EdgeInsets.only(
-                          left: width * 0.02,
-                          right: width * 0.02,
-                          top: height * 0.035,
-                        ),
-                        child: Text(
-                          ':',
-                          style: Theme.of(context)
-                              .textTheme
-                              .displayLarge!
-                              .copyWith(
-                                fontWeight: FontWeight.bold,
-                                color: themeController.isLightMode.value
-                                    ? kLightPrimaryDisabledTextColor
-                                    : kprimaryDisabledTextColor,
-                              ),
-                        ),
-                      ),
-                      Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Text(
-                            'Minutes',
-                            style: Theme.of(context)
-                                .textTheme
-                                .displaySmall!
-                                .copyWith(
-                                  fontWeight: FontWeight.bold,
-                                  color: themeController.isLightMode.value
-                                      ? kLightPrimaryDisabledTextColor
-                                      : kprimaryDisabledTextColor,
-                                ),
-                          ),
-                          SizedBox(
-                            height: height * 0.008,
-                          ),
-                          NumberPicker(
-                            minValue: 0,
-                            maxValue: 59,
-                            value: controller.minutes.value,
-                            onChanged: (value) {
-                              controller.minutes.value = value;
-                            },
-                            infiniteLoop: true,
-                            itemWidth: width * 0.17,
-                            zeroPad: true,
-                            selectedTextStyle: Theme.of(context)
-                                .textTheme
-                                .displayLarge!
-                                .copyWith(
-                                  fontWeight: FontWeight.bold,
-                                  color: kprimaryColor,
-                                ),
-                            textStyle: Theme.of(context)
-                                .textTheme
-                                .displayMedium!
-                                .copyWith(
-                                  fontSize: 20,
-                                  color: themeController.isLightMode.value
-                                      ? kLightPrimaryDisabledTextColor
-                                      : kprimaryDisabledTextColor,
-                                ),
-                            decoration: BoxDecoration(
-                              border: Border(
-                                top: BorderSide(
-                                  width: width * 0.005,
-                                  color: themeController.isLightMode.value
-                                      ? kLightPrimaryDisabledTextColor
-                                      : kprimaryDisabledTextColor,
-                                ),
-                                bottom: BorderSide(
-                                  width: width * 0.005,
-                                  color: themeController.isLightMode.value
-                                      ? kLightPrimaryDisabledTextColor
-                                      : kprimaryDisabledTextColor,
-                                ),
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                      Padding(
-                        padding: EdgeInsets.only(
-                          left: width * 0.02,
-                          right: width * 0.02,
-                          top: height * 0.035,
-                        ),
-                        child: Text(
-                          ':',
-                          style: Theme.of(context)
-                              .textTheme
-                              .displayLarge!
-                              .copyWith(
-                                fontWeight: FontWeight.bold,
-                                color: themeController.isLightMode.value
-                                    ? kLightPrimaryDisabledTextColor
-                                    : kprimaryDisabledTextColor,
-                              ),
-                        ),
-                      ),
-                      Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Text(
-                            'Seconds',
-                            style: Theme.of(context)
-                                .textTheme
-                                .displaySmall!
-                                .copyWith(
-                                  fontWeight: FontWeight.bold,
-                                  color: themeController.isLightMode.value
-                                      ? kLightPrimaryDisabledTextColor
-                                      : kprimaryDisabledTextColor,
-                                ),
-                          ),
-                          SizedBox(
-                            height: height * 0.008,
-                          ),
-                          NumberPicker(
-                            minValue: 0,
-                            maxValue: 59,
-                            value: controller.seconds.value,
-                            onChanged: (value) {
-                              controller.seconds.value = value;
-                            },
-                            infiniteLoop: true,
-                            itemWidth: width * 0.17,
-                            zeroPad: true,
-                            selectedTextStyle: Theme.of(context)
-                                .textTheme
-                                .displayLarge!
-                                .copyWith(
-                                  fontWeight: FontWeight.bold,
-                                  color: kprimaryColor,
-                                ),
-                            textStyle: Theme.of(context)
-                                .textTheme
-                                .displayMedium!
-                                .copyWith(
-                                  fontSize: 20,
-                                  color: themeController.isLightMode.value
-                                      ? kLightPrimaryDisabledTextColor
-                                      : kprimaryDisabledTextColor,
-                                ),
-                            decoration: BoxDecoration(
-                              border: Border(
-                                top: BorderSide(
-                                  width: width * 0.005,
-                                  color: themeController.isLightMode.value
-                                      ? kLightPrimaryDisabledTextColor
-                                      : kprimaryDisabledTextColor,
-                                ),
-                                bottom: BorderSide(
-                                  width: width * 0.005,
-                                  color: themeController.isLightMode.value
-                                      ? kLightPrimaryDisabledTextColor
-                                      : kprimaryDisabledTextColor,
-                                ),
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-      ),
-      floatingActionButton: Obx(
-        () => controller.isTimerRunning.value
-            ? const SizedBox()
-            : Obx(
-                () => AbsorbPointer(
-                  absorbing: controller.hours.value == 0 &&
-                          controller.minutes.value == 0 &&
-                          controller.seconds.value == 0
-                      ? true
-                      : false,
-                  child: FloatingActionButton(
+        appBar: PreferredSize(
+          preferredSize: Size.fromHeight(height / 7.9),
+          child: AppBar(
+            toolbarHeight: height / 7.9,
+            elevation: 0.0,
+            centerTitle: true,
+            actions: [
+              LayoutBuilder(
+                builder: (BuildContext context, BoxConstraints constraints) {
+                  return IconButton(
                     onPressed: () {
                       Utils.hapticFeedback();
-                      controller.remainingTime.value = Duration(
-                        hours: controller.hours.value,
-                        minutes: controller.minutes.value,
-                        seconds: controller.seconds.value,
-                      );
-                      controller.startTimer();
-                      controller.createTimer();
+                      Scaffold.of(context).openEndDrawer();
                     },
-                    backgroundColor: controller.hours.value == 0 &&
-                            controller.minutes.value == 0 &&
-                            controller.seconds.value == 0
-                        ? kprimaryDisabledTextColor
-                        : kprimaryColor,
-                    child: const Icon(
-                      Icons.play_arrow_rounded,
-                      size: 33,
+                    icon: const Icon(
+                      Icons.menu,
+                    ),
+                    color: themeController.isLightMode.value
+                        ? kLightPrimaryTextColor.withOpacity(0.75)
+                        : kprimaryTextColor.withOpacity(0.75),
+                    iconSize: 27,
+                    // splashRadius: 0.000001,
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+        body: Obx(
+          () => controller.isTimerRunning.value
+              ? Column(
+                  children: [
+                    SizedBox(
+                      height: height * 0.3,
+                    ),
+                    Center(
+                      child: Obx(
+                        () {
+                          final hours = controller.strDigits(
+                            controller.remainingTime.value.inHours
+                                .remainder(24),
+                          );
+                          final minutes = controller.strDigits(
+                            controller.remainingTime.value.inMinutes
+                                .remainder(60),
+                          );
+                          final seconds = controller.strDigits(
+                            controller.remainingTime.value.inSeconds
+                                .remainder(60),
+                          );
+                          return Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Expanded(
+                                child: Center(
+                                  child: Text(
+                                    hours,
+                                    style: const TextStyle(
+                                      fontSize: 50.0,
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                              const Text(
+                                ':',
+                                style: TextStyle(
+                                  fontSize: 50.0,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                              Expanded(
+                                child: Center(
+                                  child: Text(
+                                    minutes,
+                                    style: const TextStyle(
+                                      fontSize: 50.0,
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                              const Text(
+                                ':',
+                                style: TextStyle(
+                                  fontSize: 50.0,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                              Expanded(
+                                child: Center(
+                                  child: Text(
+                                    seconds,
+                                    style: const TextStyle(
+                                      fontSize: 50.0,
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ],
+                          );
+                        },
+                      ),
+                    ),
+                    SizedBox(
+                      height: height * 0.15,
+                    ),
+                    Obx(
+                      () => Row(
+                        children: [
+                          SizedBox(
+                            width: width * 0.20,
+                          ),
+                          FloatingActionButton.small(
+                            heroTag: 'stop',
+                            onPressed: () async {
+                              Utils.hapticFeedback();
+                              controller.stopTimer();
+                              int timerId =
+                                  await SecureStorageProvider().readTimerId();
+                              await IsarDb.deleteAlarm(timerId);
+                            },
+                            child: const Icon(Icons.close_rounded),
+                          ),
+                          SizedBox(
+                            width: width * 0.11,
+                          ),
+                          FloatingActionButton(
+                            heroTag: 'pause',
+                            onPressed: () {
+                              Utils.hapticFeedback();
+                              controller.isTimerPaused.value
+                                  ? controller.resumeTimer()
+                                  : controller.pauseTimer();
+                            },
+                            child: Icon(
+                              controller.isTimerPaused.value
+                                  ? Icons.play_arrow_rounded
+                                  : Icons.pause_rounded,
+                              size: 33,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                )
+              : InkWell(
+                  onTap: () {
+                    Utils.hapticFeedback();
+                    inputTimeController.changeTimePickerTimer();
+                  },
+                  child: Obx(
+                    () => Container(
+                      color: themeController.isLightMode.value
+                          ? kLightPrimaryBackgroundColor
+                          : kprimaryBackgroundColor,
+                      height: height * 0.32,
+                      width: width,
+                      child: inputTimeController.isTimePickerTimer.value
+                          ? Row(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              crossAxisAlignment: CrossAxisAlignment.center,
+                              children: [
+                                Column(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    Text(
+                                      'Hours',
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .displaySmall!
+                                          .copyWith(
+                                            fontWeight: FontWeight.bold,
+                                            color: themeController
+                                                    .isLightMode.value
+                                                ? kLightPrimaryDisabledTextColor
+                                                : kprimaryDisabledTextColor,
+                                          ),
+                                    ),
+                                    SizedBox(
+                                      height: height * 0.008,
+                                    ),
+                                    NumberPicker(
+                                      minValue: 0,
+                                      maxValue: 23,
+                                      value: controller.hours.value,
+                                      onChanged: (value) {
+                                        Utils.hapticFeedback();
+                                        controller.hours.value = value;
+                                      },
+                                      infiniteLoop: true,
+                                      itemWidth: width * 0.17,
+                                      zeroPad: true,
+                                      selectedTextStyle: Theme.of(context)
+                                          .textTheme
+                                          .displayLarge!
+                                          .copyWith(
+                                            fontWeight: FontWeight.bold,
+                                            color: kprimaryColor,
+                                          ),
+                                      textStyle: Theme.of(context)
+                                          .textTheme
+                                          .displayMedium!
+                                          .copyWith(
+                                            fontSize: 20,
+                                            color: themeController
+                                                    .isLightMode.value
+                                                ? kLightPrimaryDisabledTextColor
+                                                : kprimaryDisabledTextColor,
+                                          ),
+                                      decoration: BoxDecoration(
+                                        border: Border(
+                                          top: BorderSide(
+                                            width: width * 0.005,
+                                            color: themeController
+                                                    .isLightMode.value
+                                                ? kLightPrimaryDisabledTextColor
+                                                : kprimaryDisabledTextColor,
+                                          ),
+                                          bottom: BorderSide(
+                                            width: width * 0.005,
+                                            color: themeController
+                                                    .isLightMode.value
+                                                ? kLightPrimaryDisabledTextColor
+                                                : kprimaryDisabledTextColor,
+                                          ),
+                                        ),
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                                Padding(
+                                  padding: EdgeInsets.only(
+                                    left: width * 0.02,
+                                    right: width * 0.02,
+                                    top: height * 0.035,
+                                  ),
+                                  child: Text(
+                                    ':',
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .displayLarge!
+                                        .copyWith(
+                                          fontWeight: FontWeight.bold,
+                                          color: themeController
+                                                  .isLightMode.value
+                                              ? kLightPrimaryDisabledTextColor
+                                              : kprimaryDisabledTextColor,
+                                        ),
+                                  ),
+                                ),
+                                Column(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    Text(
+                                      'Minutes',
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .displaySmall!
+                                          .copyWith(
+                                            fontWeight: FontWeight.bold,
+                                            color: themeController
+                                                    .isLightMode.value
+                                                ? kLightPrimaryDisabledTextColor
+                                                : kprimaryDisabledTextColor,
+                                          ),
+                                    ),
+                                    SizedBox(
+                                      height: height * 0.008,
+                                    ),
+                                    NumberPicker(
+                                      minValue: 0,
+                                      maxValue: 59,
+                                      value: controller.minutes.value,
+                                      onChanged: (value) {
+                                        controller.minutes.value = value;
+                                      },
+                                      infiniteLoop: true,
+                                      itemWidth: width * 0.17,
+                                      zeroPad: true,
+                                      selectedTextStyle: Theme.of(context)
+                                          .textTheme
+                                          .displayLarge!
+                                          .copyWith(
+                                            fontWeight: FontWeight.bold,
+                                            color: kprimaryColor,
+                                          ),
+                                      textStyle: Theme.of(context)
+                                          .textTheme
+                                          .displayMedium!
+                                          .copyWith(
+                                            fontSize: 20,
+                                            color: themeController
+                                                    .isLightMode.value
+                                                ? kLightPrimaryDisabledTextColor
+                                                : kprimaryDisabledTextColor,
+                                          ),
+                                      decoration: BoxDecoration(
+                                        border: Border(
+                                          top: BorderSide(
+                                            width: width * 0.005,
+                                            color: themeController
+                                                    .isLightMode.value
+                                                ? kLightPrimaryDisabledTextColor
+                                                : kprimaryDisabledTextColor,
+                                          ),
+                                          bottom: BorderSide(
+                                            width: width * 0.005,
+                                            color: themeController
+                                                    .isLightMode.value
+                                                ? kLightPrimaryDisabledTextColor
+                                                : kprimaryDisabledTextColor,
+                                          ),
+                                        ),
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                                Padding(
+                                  padding: EdgeInsets.only(
+                                    left: width * 0.02,
+                                    right: width * 0.02,
+                                    top: height * 0.035,
+                                  ),
+                                  child: Text(
+                                    ':',
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .displayLarge!
+                                        .copyWith(
+                                          fontWeight: FontWeight.bold,
+                                          color: themeController
+                                                  .isLightMode.value
+                                              ? kLightPrimaryDisabledTextColor
+                                              : kprimaryDisabledTextColor,
+                                        ),
+                                  ),
+                                ),
+                                Column(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    Text(
+                                      'Seconds',
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .displaySmall!
+                                          .copyWith(
+                                            fontWeight: FontWeight.bold,
+                                            color: themeController
+                                                    .isLightMode.value
+                                                ? kLightPrimaryDisabledTextColor
+                                                : kprimaryDisabledTextColor,
+                                          ),
+                                    ),
+                                    SizedBox(
+                                      height: height * 0.008,
+                                    ),
+                                    NumberPicker(
+                                      minValue: 0,
+                                      maxValue: 59,
+                                      value: controller.seconds.value,
+                                      onChanged: (value) {
+                                        controller.seconds.value = value;
+                                      },
+                                      infiniteLoop: true,
+                                      itemWidth: width * 0.17,
+                                      zeroPad: true,
+                                      selectedTextStyle: Theme.of(context)
+                                          .textTheme
+                                          .displayLarge!
+                                          .copyWith(
+                                            fontWeight: FontWeight.bold,
+                                            color: kprimaryColor,
+                                          ),
+                                      textStyle: Theme.of(context)
+                                          .textTheme
+                                          .displayMedium!
+                                          .copyWith(
+                                            fontSize: 20,
+                                            color: themeController
+                                                    .isLightMode.value
+                                                ? kLightPrimaryDisabledTextColor
+                                                : kprimaryDisabledTextColor,
+                                          ),
+                                      decoration: BoxDecoration(
+                                        border: Border(
+                                          top: BorderSide(
+                                            width: width * 0.005,
+                                            color: themeController
+                                                    .isLightMode.value
+                                                ? kLightPrimaryDisabledTextColor
+                                                : kprimaryDisabledTextColor,
+                                          ),
+                                          bottom: BorderSide(
+                                            width: width * 0.005,
+                                            color: themeController
+                                                    .isLightMode.value
+                                                ? kLightPrimaryDisabledTextColor
+                                                : kprimaryDisabledTextColor,
+                                          ),
+                                        ),
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ],
+                            )
+                          : Row(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              crossAxisAlignment: CrossAxisAlignment.center,
+                              children: [
+                                Column(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    Text(
+                                      'Hours',
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .displaySmall!
+                                          .copyWith(
+                                            fontWeight: FontWeight.bold,
+                                            color: themeController
+                                                    .isLightMode.value
+                                                ? kLightPrimaryDisabledTextColor
+                                                : kprimaryDisabledTextColor,
+                                          ),
+                                    ),
+                                    SizedBox(
+                                      height: height * 0.008,
+                                    ),
+                                    SizedBox(
+                                      width: 80,
+                                      child: TextField(
+                                        onChanged: (_) {
+                                          inputTimeController.setTimerTime();
+                                        },
+                                        decoration: const InputDecoration(
+                                          hintText: 'HH',
+                                          border: InputBorder.none,
+                                        ),
+                                        textAlign: TextAlign.center,
+                                        controller: inputTimeController
+                                            .inputHoursControllerTimer,
+                                        keyboardType: TextInputType.number,
+                                        inputFormatters: [
+                                          FilteringTextInputFormatter.allow(
+                                            RegExp(
+                                              '[1,2,3,4,5,6,7,8,9,0]',
+                                            ),
+                                          ),
+                                          LengthLimitingTextInputFormatter(
+                                            2,
+                                          ),
+                                          LimitRange(
+                                            0,
+                                            23,
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                                Padding(
+                                  padding: EdgeInsets.only(
+                                    left: width * 0.02,
+                                    right: width * 0.02,
+                                    top: height * 0.035,
+                                  ),
+                                  child: Text(
+                                    ':',
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .displayLarge!
+                                        .copyWith(
+                                          fontWeight: FontWeight.bold,
+                                          color: themeController
+                                                  .isLightMode.value
+                                              ? kLightPrimaryDisabledTextColor
+                                              : kprimaryDisabledTextColor,
+                                        ),
+                                  ),
+                                ),
+                                Column(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    Text(
+                                      'Minutes',
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .displaySmall!
+                                          .copyWith(
+                                            fontWeight: FontWeight.bold,
+                                            color: themeController
+                                                    .isLightMode.value
+                                                ? kLightPrimaryDisabledTextColor
+                                                : kprimaryDisabledTextColor,
+                                          ),
+                                    ),
+                                    SizedBox(
+                                      height: height * 0.008,
+                                    ),
+                                    SizedBox(
+                                      width: 80,
+                                      child: TextField(
+                                        onChanged: (_) {
+                                          inputTimeController.setTimerTime();
+                                        },
+                                        decoration: const InputDecoration(
+                                          hintText: 'MM',
+                                          border: InputBorder.none,
+                                        ),
+                                        textAlign: TextAlign.center,
+                                        controller: inputTimeController
+                                            .inputMinutesControllerTimer,
+                                        keyboardType: TextInputType.number,
+                                        inputFormatters: [
+                                          FilteringTextInputFormatter.allow(
+                                            RegExp(
+                                              '[1,2,3,4,5,6,7,8,9,0]',
+                                            ),
+                                          ),
+                                          LengthLimitingTextInputFormatter(
+                                            2,
+                                          ),
+                                          LimitRange(
+                                            0,
+                                            59,
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                                Padding(
+                                  padding: EdgeInsets.only(
+                                    left: width * 0.02,
+                                    right: width * 0.02,
+                                    top: height * 0.035,
+                                  ),
+                                  child: Text(
+                                    ':',
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .displayLarge!
+                                        .copyWith(
+                                          fontWeight: FontWeight.bold,
+                                          color: themeController
+                                                  .isLightMode.value
+                                              ? kLightPrimaryDisabledTextColor
+                                              : kprimaryDisabledTextColor,
+                                        ),
+                                  ),
+                                ),
+                                Column(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    Text(
+                                      'Seconds',
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .displaySmall!
+                                          .copyWith(
+                                            fontWeight: FontWeight.bold,
+                                            color: themeController
+                                                    .isLightMode.value
+                                                ? kLightPrimaryDisabledTextColor
+                                                : kprimaryDisabledTextColor,
+                                          ),
+                                    ),
+                                    SizedBox(
+                                      height: height * 0.008,
+                                    ),
+                                    SizedBox(
+                                      width: 80,
+                                      child: TextField(
+                                        onChanged: (_) {
+                                          inputTimeController.setTimerTime();
+                                        },
+                                        decoration: const InputDecoration(
+                                          hintText: 'SS',
+                                          border: InputBorder.none,
+                                        ),
+                                        textAlign: TextAlign.center,
+                                        controller: inputTimeController
+                                            .inputSecondsControllerTimer,
+                                        keyboardType: TextInputType.number,
+                                        inputFormatters: [
+                                          FilteringTextInputFormatter.allow(
+                                            RegExp(
+                                              '[1,2,3,4,5,6,7,8,9,0]',
+                                            ),
+                                          ),
+                                          LengthLimitingTextInputFormatter(
+                                            2,
+                                          ),
+                                          LimitRange(
+                                            0,
+                                            59,
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ],
+                            ),
                     ),
                   ),
                 ),
-              ),
-      ),
-      endDrawer: buildEndDrawer(context)
-    );
+        ),
+        floatingActionButton: Obx(
+          () => controller.isTimerRunning.value
+              ? const SizedBox()
+              : Obx(
+                  () => AbsorbPointer(
+                    absorbing: controller.hours.value == 0 &&
+                            controller.minutes.value == 0 &&
+                            controller.seconds.value == 0
+                        ? true
+                        : false,
+                    child: FloatingActionButton(
+                      onPressed: () {
+                        Utils.hapticFeedback();
+                        controller.remainingTime.value = Duration(
+                          hours: controller.hours.value,
+                          minutes: controller.minutes.value,
+                          seconds: controller.seconds.value,
+                        );
+                        controller.startTimer();
+                        controller.createTimer();
+                      },
+                      backgroundColor: controller.hours.value == 0 &&
+                              controller.minutes.value == 0 &&
+                              controller.seconds.value == 0
+                          ? kprimaryDisabledTextColor
+                          : kprimaryColor,
+                      child: const Icon(
+                        Icons.play_arrow_rounded,
+                        size: 33,
+                      ),
+                    ),
+                  ),
+                ),
+        ),
+        endDrawer: buildEndDrawer(context));
   }
 }

--- a/lib/app/modules/timer/views/timer_view.dart
+++ b/lib/app/modules/timer/views/timer_view.dart
@@ -23,251 +23,495 @@ class TimerView extends GetView<TimerController> {
     var width = Get.width;
     var height = Get.height;
     return Scaffold(
-        appBar: PreferredSize(
-          preferredSize: Size.fromHeight(height / 7.9),
-          child: AppBar(
-            toolbarHeight: height / 7.9,
-            elevation: 0.0,
-            centerTitle: true,
-            actions: [
-              LayoutBuilder(
-                builder: (BuildContext context, BoxConstraints constraints) {
-                  return IconButton(
-                    onPressed: () {
-                      Utils.hapticFeedback();
-                      Scaffold.of(context).openEndDrawer();
-                    },
-                    icon: const Icon(
-                      Icons.menu,
-                    ),
-                    color: themeController.isLightMode.value
-                        ? kLightPrimaryTextColor.withOpacity(0.75)
-                        : kprimaryTextColor.withOpacity(0.75),
-                    iconSize: 27,
-                    // splashRadius: 0.000001,
-                  );
-                },
-              ),
-            ],
-          ),
+      appBar: PreferredSize(
+        preferredSize: Size.fromHeight(height / 7.9),
+        child: AppBar(
+          toolbarHeight: height / 7.9,
+          elevation: 0.0,
+          centerTitle: true,
+          actions: [
+            LayoutBuilder(
+              builder: (BuildContext context, BoxConstraints constraints) {
+                return IconButton(
+                  onPressed: () {
+                    Utils.hapticFeedback();
+                    Scaffold.of(context).openEndDrawer();
+                  },
+                  icon: const Icon(
+                    Icons.menu,
+                  ),
+                  color: themeController.isLightMode.value
+                      ? kLightPrimaryTextColor.withOpacity(0.75)
+                      : kprimaryTextColor.withOpacity(0.75),
+                  iconSize: 27,
+                  // splashRadius: 0.000001,
+                );
+              },
+            ),
+          ],
         ),
-        body: Obx(
-          () => controller.isTimerRunning.value
-              ? Column(
-                  children: [
-                    SizedBox(
-                      height: height * 0.3,
+      ),
+      body: Obx(
+        () => controller.isTimerRunning.value
+            ? Column(
+                children: [
+                  SizedBox(
+                    height: height * 0.3,
+                  ),
+                  Center(
+                    child: Obx(
+                      () {
+                        final hours = controller.strDigits(
+                          controller.remainingTime.value.inHours.remainder(24),
+                        );
+                        final minutes = controller.strDigits(
+                          controller.remainingTime.value.inMinutes
+                              .remainder(60),
+                        );
+                        final seconds = controller.strDigits(
+                          controller.remainingTime.value.inSeconds
+                              .remainder(60),
+                        );
+                        return Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Expanded(
+                              child: Center(
+                                child: Text(
+                                  hours,
+                                  style: const TextStyle(
+                                    fontSize: 50.0,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                ),
+                              ),
+                            ),
+                            const Text(
+                              ':',
+                              style: TextStyle(
+                                fontSize: 50.0,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                            Expanded(
+                              child: Center(
+                                child: Text(
+                                  minutes,
+                                  style: const TextStyle(
+                                    fontSize: 50.0,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                ),
+                              ),
+                            ),
+                            const Text(
+                              ':',
+                              style: TextStyle(
+                                fontSize: 50.0,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                            Expanded(
+                              child: Center(
+                                child: Text(
+                                  seconds,
+                                  style: const TextStyle(
+                                    fontSize: 50.0,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
+                        );
+                      },
                     ),
-                    Center(
-                      child: Obx(
-                        () {
-                          final hours = controller.strDigits(
-                            controller.remainingTime.value.inHours
-                                .remainder(24),
-                          );
-                          final minutes = controller.strDigits(
-                            controller.remainingTime.value.inMinutes
-                                .remainder(60),
-                          );
-                          final seconds = controller.strDigits(
-                            controller.remainingTime.value.inSeconds
-                                .remainder(60),
-                          );
-                          return Row(
+                  ),
+                  SizedBox(
+                    height: height * 0.15,
+                  ),
+                  Obx(
+                    () => Row(
+                      children: [
+                        SizedBox(
+                          width: width * 0.20,
+                        ),
+                        FloatingActionButton.small(
+                          heroTag: 'stop',
+                          onPressed: () async {
+                            Utils.hapticFeedback();
+                            controller.stopTimer();
+                            int timerId =
+                                await SecureStorageProvider().readTimerId();
+                            await IsarDb.deleteAlarm(timerId);
+                          },
+                          child: const Icon(Icons.close_rounded),
+                        ),
+                        SizedBox(
+                          width: width * 0.11,
+                        ),
+                        FloatingActionButton(
+                          heroTag: 'pause',
+                          onPressed: () {
+                            Utils.hapticFeedback();
+                            controller.isTimerPaused.value
+                                ? controller.resumeTimer()
+                                : controller.pauseTimer();
+                          },
+                          child: Icon(
+                            controller.isTimerPaused.value
+                                ? Icons.play_arrow_rounded
+                                : Icons.pause_rounded,
+                            size: 33,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              )
+            : InkWell(
+                onTap: () {
+                  Utils.hapticFeedback();
+                  inputTimeController.changeTimePickerTimer();
+                },
+                child: Obx(
+                  () => Container(
+                    color: themeController.isLightMode.value
+                        ? kLightPrimaryBackgroundColor
+                        : kprimaryBackgroundColor,
+                    height: height * 0.32,
+                    width: width,
+                    child: inputTimeController.isTimePickerTimer.value
+                        ? Row(
                             mainAxisAlignment: MainAxisAlignment.center,
-                            crossAxisAlignment: CrossAxisAlignment.start,
+                            crossAxisAlignment: CrossAxisAlignment.center,
                             children: [
-                              Expanded(
-                                child: Center(
-                                  child: Text(
-                                    hours,
-                                    style: const TextStyle(
-                                      fontSize: 50.0,
-                                      fontWeight: FontWeight.bold,
+                              Column(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  Text(
+                                    'Hours',
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .displaySmall!
+                                        .copyWith(
+                                          fontWeight: FontWeight.bold,
+                                          color: themeController
+                                                  .isLightMode.value
+                                              ? kLightPrimaryDisabledTextColor
+                                              : kprimaryDisabledTextColor,
+                                        ),
+                                  ),
+                                  SizedBox(
+                                    height: height * 0.008,
+                                  ),
+                                  NumberPicker(
+                                    minValue: 0,
+                                    maxValue: 23,
+                                    value: controller.hours.value,
+                                    onChanged: (value) {
+                                      Utils.hapticFeedback();
+                                      controller.hours.value = value;
+                                    },
+                                    infiniteLoop: true,
+                                    itemWidth: width * 0.17,
+                                    zeroPad: true,
+                                    selectedTextStyle: Theme.of(context)
+                                        .textTheme
+                                        .displayLarge!
+                                        .copyWith(
+                                          fontWeight: FontWeight.bold,
+                                          color: kprimaryColor,
+                                        ),
+                                    textStyle: Theme.of(context)
+                                        .textTheme
+                                        .displayMedium!
+                                        .copyWith(
+                                          fontSize: 20,
+                                          color: themeController
+                                                  .isLightMode.value
+                                              ? kLightPrimaryDisabledTextColor
+                                              : kprimaryDisabledTextColor,
+                                        ),
+                                    decoration: BoxDecoration(
+                                      border: Border(
+                                        top: BorderSide(
+                                          width: width * 0.005,
+                                          color: themeController
+                                                  .isLightMode.value
+                                              ? kLightPrimaryDisabledTextColor
+                                              : kprimaryDisabledTextColor,
+                                        ),
+                                        bottom: BorderSide(
+                                          width: width * 0.005,
+                                          color: themeController
+                                                  .isLightMode.value
+                                              ? kLightPrimaryDisabledTextColor
+                                              : kprimaryDisabledTextColor,
+                                        ),
+                                      ),
                                     ),
                                   ),
+                                ],
+                              ),
+                              Padding(
+                                padding: EdgeInsets.only(
+                                  left: width * 0.02,
+                                  right: width * 0.02,
+                                  top: height * 0.035,
+                                ),
+                                child: Text(
+                                  ':',
+                                  style: Theme.of(context)
+                                      .textTheme
+                                      .displayLarge!
+                                      .copyWith(
+                                        fontWeight: FontWeight.bold,
+                                        color: themeController.isLightMode.value
+                                            ? kLightPrimaryDisabledTextColor
+                                            : kprimaryDisabledTextColor,
+                                      ),
                                 ),
                               ),
-                              const Text(
-                                ':',
-                                style: TextStyle(
-                                  fontSize: 50.0,
-                                  fontWeight: FontWeight.bold,
-                                ),
-                              ),
-                              Expanded(
-                                child: Center(
-                                  child: Text(
-                                    minutes,
-                                    style: const TextStyle(
-                                      fontSize: 50.0,
-                                      fontWeight: FontWeight.bold,
+                              Column(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  Text(
+                                    'Minutes',
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .displaySmall!
+                                        .copyWith(
+                                          fontWeight: FontWeight.bold,
+                                          color: themeController
+                                                  .isLightMode.value
+                                              ? kLightPrimaryDisabledTextColor
+                                              : kprimaryDisabledTextColor,
+                                        ),
+                                  ),
+                                  SizedBox(
+                                    height: height * 0.008,
+                                  ),
+                                  NumberPicker(
+                                    minValue: 0,
+                                    maxValue: 59,
+                                    value: controller.minutes.value,
+                                    onChanged: (value) {
+                                      controller.minutes.value = value;
+                                    },
+                                    infiniteLoop: true,
+                                    itemWidth: width * 0.17,
+                                    zeroPad: true,
+                                    selectedTextStyle: Theme.of(context)
+                                        .textTheme
+                                        .displayLarge!
+                                        .copyWith(
+                                          fontWeight: FontWeight.bold,
+                                          color: kprimaryColor,
+                                        ),
+                                    textStyle: Theme.of(context)
+                                        .textTheme
+                                        .displayMedium!
+                                        .copyWith(
+                                          fontSize: 20,
+                                          color: themeController
+                                                  .isLightMode.value
+                                              ? kLightPrimaryDisabledTextColor
+                                              : kprimaryDisabledTextColor,
+                                        ),
+                                    decoration: BoxDecoration(
+                                      border: Border(
+                                        top: BorderSide(
+                                          width: width * 0.005,
+                                          color: themeController
+                                                  .isLightMode.value
+                                              ? kLightPrimaryDisabledTextColor
+                                              : kprimaryDisabledTextColor,
+                                        ),
+                                        bottom: BorderSide(
+                                          width: width * 0.005,
+                                          color: themeController
+                                                  .isLightMode.value
+                                              ? kLightPrimaryDisabledTextColor
+                                              : kprimaryDisabledTextColor,
+                                        ),
+                                      ),
                                     ),
                                   ),
+                                ],
+                              ),
+                              Padding(
+                                padding: EdgeInsets.only(
+                                  left: width * 0.02,
+                                  right: width * 0.02,
+                                  top: height * 0.035,
+                                ),
+                                child: Text(
+                                  ':',
+                                  style: Theme.of(context)
+                                      .textTheme
+                                      .displayLarge!
+                                      .copyWith(
+                                        fontWeight: FontWeight.bold,
+                                        color: themeController.isLightMode.value
+                                            ? kLightPrimaryDisabledTextColor
+                                            : kprimaryDisabledTextColor,
+                                      ),
                                 ),
                               ),
-                              const Text(
-                                ':',
-                                style: TextStyle(
-                                  fontSize: 50.0,
-                                  fontWeight: FontWeight.bold,
-                                ),
-                              ),
-                              Expanded(
-                                child: Center(
-                                  child: Text(
-                                    seconds,
-                                    style: const TextStyle(
-                                      fontSize: 50.0,
-                                      fontWeight: FontWeight.bold,
+                              Column(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  Text(
+                                    'Seconds',
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .displaySmall!
+                                        .copyWith(
+                                          fontWeight: FontWeight.bold,
+                                          color: themeController
+                                                  .isLightMode.value
+                                              ? kLightPrimaryDisabledTextColor
+                                              : kprimaryDisabledTextColor,
+                                        ),
+                                  ),
+                                  SizedBox(
+                                    height: height * 0.008,
+                                  ),
+                                  NumberPicker(
+                                    minValue: 0,
+                                    maxValue: 59,
+                                    value: controller.seconds.value,
+                                    onChanged: (value) {
+                                      controller.seconds.value = value;
+                                    },
+                                    infiniteLoop: true,
+                                    itemWidth: width * 0.17,
+                                    zeroPad: true,
+                                    selectedTextStyle: Theme.of(context)
+                                        .textTheme
+                                        .displayLarge!
+                                        .copyWith(
+                                          fontWeight: FontWeight.bold,
+                                          color: kprimaryColor,
+                                        ),
+                                    textStyle: Theme.of(context)
+                                        .textTheme
+                                        .displayMedium!
+                                        .copyWith(
+                                          fontSize: 20,
+                                          color: themeController
+                                                  .isLightMode.value
+                                              ? kLightPrimaryDisabledTextColor
+                                              : kprimaryDisabledTextColor,
+                                        ),
+                                    decoration: BoxDecoration(
+                                      border: Border(
+                                        top: BorderSide(
+                                          width: width * 0.005,
+                                          color: themeController
+                                                  .isLightMode.value
+                                              ? kLightPrimaryDisabledTextColor
+                                              : kprimaryDisabledTextColor,
+                                        ),
+                                        bottom: BorderSide(
+                                          width: width * 0.005,
+                                          color: themeController
+                                                  .isLightMode.value
+                                              ? kLightPrimaryDisabledTextColor
+                                              : kprimaryDisabledTextColor,
+                                        ),
+                                      ),
                                     ),
                                   ),
-                                ),
+                                ],
                               ),
                             ],
-                          );
-                        },
-                      ),
-                    ),
-                    SizedBox(
-                      height: height * 0.15,
-                    ),
-                    Obx(
-                      () => Row(
-                        children: [
-                          SizedBox(
-                            width: width * 0.20,
-                          ),
-                          FloatingActionButton.small(
-                            heroTag: 'stop',
-                            onPressed: () async {
-                              Utils.hapticFeedback();
-                              controller.stopTimer();
-                              int timerId =
-                                  await SecureStorageProvider().readTimerId();
-                              await IsarDb.deleteAlarm(timerId);
-                            },
-                            child: const Icon(Icons.close_rounded),
-                          ),
-                          SizedBox(
-                            width: width * 0.11,
-                          ),
-                          FloatingActionButton(
-                            heroTag: 'pause',
-                            onPressed: () {
-                              Utils.hapticFeedback();
-                              controller.isTimerPaused.value
-                                  ? controller.resumeTimer()
-                                  : controller.pauseTimer();
-                            },
-                            child: Icon(
-                              controller.isTimerPaused.value
-                                  ? Icons.play_arrow_rounded
-                                  : Icons.pause_rounded,
-                              size: 33,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ],
-                )
-              : InkWell(
-                  onTap: () {
-                    Utils.hapticFeedback();
-                    inputTimeController.changeTimePickerTimer();
-                  },
-                  child: Obx(
-                    () => Container(
-                      color: themeController.isLightMode.value
-                          ? kLightPrimaryBackgroundColor
-                          : kprimaryBackgroundColor,
-                      height: height * 0.32,
-                      width: width,
-                      child: inputTimeController.isTimePickerTimer.value
-                          ? Row(
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              crossAxisAlignment: CrossAxisAlignment.center,
-                              children: [
-                                Column(
-                                  mainAxisAlignment: MainAxisAlignment.center,
-                                  children: [
-                                    Text(
-                                      'Hours',
-                                      style: Theme.of(context)
-                                          .textTheme
-                                          .displaySmall!
-                                          .copyWith(
-                                            fontWeight: FontWeight.bold,
-                                            color: themeController
-                                                    .isLightMode.value
-                                                ? kLightPrimaryDisabledTextColor
-                                                : kprimaryDisabledTextColor,
-                                          ),
-                                    ),
-                                    SizedBox(
-                                      height: height * 0.008,
-                                    ),
-                                    NumberPicker(
-                                      minValue: 0,
-                                      maxValue: 23,
-                                      value: controller.hours.value,
-                                      onChanged: (value) {
-                                        Utils.hapticFeedback();
-                                        controller.hours.value = value;
+                          )
+                        : Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            crossAxisAlignment: CrossAxisAlignment.center,
+                            children: [
+                              Column(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  Text(
+                                    'Hours',
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .displaySmall!
+                                        .copyWith(
+                                          fontWeight: FontWeight.bold,
+                                          color: themeController
+                                                  .isLightMode.value
+                                              ? kLightPrimaryDisabledTextColor
+                                              : kprimaryDisabledTextColor,
+                                        ),
+                                  ),
+                                  SizedBox(
+                                    height: height * 0.008,
+                                  ),
+                                  SizedBox(
+                                    width: 80,
+                                    child: TextField(
+                                      onChanged: (_) {
+                                        inputTimeController.setTimerTime();
                                       },
-                                      infiniteLoop: true,
-                                      itemWidth: width * 0.17,
-                                      zeroPad: true,
-                                      selectedTextStyle: Theme.of(context)
-                                          .textTheme
-                                          .displayLarge!
-                                          .copyWith(
-                                            fontWeight: FontWeight.bold,
-                                            color: kprimaryColor,
-                                          ),
-                                      textStyle: Theme.of(context)
-                                          .textTheme
-                                          .displayMedium!
-                                          .copyWith(
-                                            fontSize: 20,
-                                            color: themeController
-                                                    .isLightMode.value
-                                                ? kLightPrimaryDisabledTextColor
-                                                : kprimaryDisabledTextColor,
-                                          ),
-                                      decoration: BoxDecoration(
-                                        border: Border(
-                                          top: BorderSide(
-                                            width: width * 0.005,
-                                            color: themeController
-                                                    .isLightMode.value
-                                                ? kLightPrimaryDisabledTextColor
-                                                : kprimaryDisabledTextColor,
-                                          ),
-                                          bottom: BorderSide(
-                                            width: width * 0.005,
-                                            color: themeController
-                                                    .isLightMode.value
-                                                ? kLightPrimaryDisabledTextColor
-                                                : kprimaryDisabledTextColor,
+                                      decoration: const InputDecoration(
+                                        hintText: 'HH',
+                                        border: InputBorder.none,
+                                      ),
+                                      textAlign: TextAlign.center,
+                                      controller: inputTimeController
+                                          .inputHoursControllerTimer,
+                                      keyboardType: TextInputType.number,
+                                      inputFormatters: [
+                                        FilteringTextInputFormatter.allow(
+                                          RegExp(
+                                            '[1,2,3,4,5,6,7,8,9,0]',
                                           ),
                                         ),
-                                      ),
+                                        LengthLimitingTextInputFormatter(
+                                          2,
+                                        ),
+                                        LimitRange(
+                                          0,
+                                          23,
+                                        ),
+                                      ],
                                     ),
-                                  ],
-                                ),
-                                Padding(
-                                  padding: EdgeInsets.only(
-                                    left: width * 0.02,
-                                    right: width * 0.02,
-                                    top: height * 0.035,
                                   ),
-                                  child: Text(
-                                    ':',
+                                ],
+                              ),
+                              Padding(
+                                padding: EdgeInsets.only(
+                                  left: width * 0.02,
+                                  right: width * 0.02,
+                                  top: height * 0.035,
+                                ),
+                                child: Text(
+                                  ':',
+                                  style: Theme.of(context)
+                                      .textTheme
+                                      .displayLarge!
+                                      .copyWith(
+                                        fontWeight: FontWeight.bold,
+                                        color: themeController.isLightMode.value
+                                            ? kLightPrimaryDisabledTextColor
+                                            : kprimaryDisabledTextColor,
+                                      ),
+                                ),
+                              ),
+                              Column(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  Text(
+                                    'Minutes',
                                     style: Theme.of(context)
                                         .textTheme
-                                        .displayLarge!
+                                        .displaySmall!
                                         .copyWith(
                                           fontWeight: FontWeight.bold,
                                           color: themeController
@@ -276,85 +520,68 @@ class TimerView extends GetView<TimerController> {
                                               : kprimaryDisabledTextColor,
                                         ),
                                   ),
-                                ),
-                                Column(
-                                  mainAxisAlignment: MainAxisAlignment.center,
-                                  children: [
-                                    Text(
-                                      'Minutes',
-                                      style: Theme.of(context)
-                                          .textTheme
-                                          .displaySmall!
-                                          .copyWith(
-                                            fontWeight: FontWeight.bold,
-                                            color: themeController
-                                                    .isLightMode.value
-                                                ? kLightPrimaryDisabledTextColor
-                                                : kprimaryDisabledTextColor,
-                                          ),
-                                    ),
-                                    SizedBox(
-                                      height: height * 0.008,
-                                    ),
-                                    NumberPicker(
-                                      minValue: 0,
-                                      maxValue: 59,
-                                      value: controller.minutes.value,
-                                      onChanged: (value) {
-                                        controller.minutes.value = value;
+                                  SizedBox(
+                                    height: height * 0.008,
+                                  ),
+                                  SizedBox(
+                                    width: 80,
+                                    child: TextField(
+                                      onChanged: (_) {
+                                        inputTimeController.setTimerTime();
                                       },
-                                      infiniteLoop: true,
-                                      itemWidth: width * 0.17,
-                                      zeroPad: true,
-                                      selectedTextStyle: Theme.of(context)
-                                          .textTheme
-                                          .displayLarge!
-                                          .copyWith(
-                                            fontWeight: FontWeight.bold,
-                                            color: kprimaryColor,
-                                          ),
-                                      textStyle: Theme.of(context)
-                                          .textTheme
-                                          .displayMedium!
-                                          .copyWith(
-                                            fontSize: 20,
-                                            color: themeController
-                                                    .isLightMode.value
-                                                ? kLightPrimaryDisabledTextColor
-                                                : kprimaryDisabledTextColor,
-                                          ),
-                                      decoration: BoxDecoration(
-                                        border: Border(
-                                          top: BorderSide(
-                                            width: width * 0.005,
-                                            color: themeController
-                                                    .isLightMode.value
-                                                ? kLightPrimaryDisabledTextColor
-                                                : kprimaryDisabledTextColor,
-                                          ),
-                                          bottom: BorderSide(
-                                            width: width * 0.005,
-                                            color: themeController
-                                                    .isLightMode.value
-                                                ? kLightPrimaryDisabledTextColor
-                                                : kprimaryDisabledTextColor,
+                                      decoration: const InputDecoration(
+                                        hintText: 'MM',
+                                        border: InputBorder.none,
+                                      ),
+                                      textAlign: TextAlign.center,
+                                      controller: inputTimeController
+                                          .inputMinutesControllerTimer,
+                                      keyboardType: TextInputType.number,
+                                      inputFormatters: [
+                                        FilteringTextInputFormatter.allow(
+                                          RegExp(
+                                            '[1,2,3,4,5,6,7,8,9,0]',
                                           ),
                                         ),
-                                      ),
+                                        LengthLimitingTextInputFormatter(
+                                          2,
+                                        ),
+                                        LimitRange(
+                                          0,
+                                          59,
+                                        ),
+                                      ],
                                     ),
-                                  ],
-                                ),
-                                Padding(
-                                  padding: EdgeInsets.only(
-                                    left: width * 0.02,
-                                    right: width * 0.02,
-                                    top: height * 0.035,
                                   ),
-                                  child: Text(
-                                    ':',
+                                ],
+                              ),
+                              Padding(
+                                padding: EdgeInsets.only(
+                                  left: width * 0.02,
+                                  right: width * 0.02,
+                                  top: height * 0.035,
+                                ),
+                                child: Text(
+                                  ':',
+                                  style: Theme.of(context)
+                                      .textTheme
+                                      .displayLarge!
+                                      .copyWith(
+                                        fontWeight: FontWeight.bold,
+                                        color: themeController.isLightMode.value
+                                            ? kLightPrimaryDisabledTextColor
+                                            : kprimaryDisabledTextColor,
+                                      ),
+                                ),
+                              ),
+                              Column(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  Text(
+                                    'Seconds',
                                     style: Theme.of(context)
                                         .textTheme
-                                        .displayLarge!
+                                        .displaySmall!
                                         .copyWith(
                                           fontWeight: FontWeight.bold,
                                           color: themeController
@@ -363,313 +590,82 @@ class TimerView extends GetView<TimerController> {
                                               : kprimaryDisabledTextColor,
                                         ),
                                   ),
-                                ),
-                                Column(
-                                  mainAxisAlignment: MainAxisAlignment.center,
-                                  children: [
-                                    Text(
-                                      'Seconds',
-                                      style: Theme.of(context)
-                                          .textTheme
-                                          .displaySmall!
-                                          .copyWith(
-                                            fontWeight: FontWeight.bold,
-                                            color: themeController
-                                                    .isLightMode.value
-                                                ? kLightPrimaryDisabledTextColor
-                                                : kprimaryDisabledTextColor,
-                                          ),
-                                    ),
-                                    SizedBox(
-                                      height: height * 0.008,
-                                    ),
-                                    NumberPicker(
-                                      minValue: 0,
-                                      maxValue: 59,
-                                      value: controller.seconds.value,
-                                      onChanged: (value) {
-                                        controller.seconds.value = value;
+                                  SizedBox(
+                                    height: height * 0.008,
+                                  ),
+                                  SizedBox(
+                                    width: 80,
+                                    child: TextField(
+                                      onChanged: (_) {
+                                        inputTimeController.setTimerTime();
                                       },
-                                      infiniteLoop: true,
-                                      itemWidth: width * 0.17,
-                                      zeroPad: true,
-                                      selectedTextStyle: Theme.of(context)
-                                          .textTheme
-                                          .displayLarge!
-                                          .copyWith(
-                                            fontWeight: FontWeight.bold,
-                                            color: kprimaryColor,
-                                          ),
-                                      textStyle: Theme.of(context)
-                                          .textTheme
-                                          .displayMedium!
-                                          .copyWith(
-                                            fontSize: 20,
-                                            color: themeController
-                                                    .isLightMode.value
-                                                ? kLightPrimaryDisabledTextColor
-                                                : kprimaryDisabledTextColor,
-                                          ),
-                                      decoration: BoxDecoration(
-                                        border: Border(
-                                          top: BorderSide(
-                                            width: width * 0.005,
-                                            color: themeController
-                                                    .isLightMode.value
-                                                ? kLightPrimaryDisabledTextColor
-                                                : kprimaryDisabledTextColor,
-                                          ),
-                                          bottom: BorderSide(
-                                            width: width * 0.005,
-                                            color: themeController
-                                                    .isLightMode.value
-                                                ? kLightPrimaryDisabledTextColor
-                                                : kprimaryDisabledTextColor,
-                                          ),
-                                        ),
+                                      decoration: const InputDecoration(
+                                        hintText: 'SS',
+                                        border: InputBorder.none,
                                       ),
-                                    ),
-                                  ],
-                                ),
-                              ],
-                            )
-                          : Row(
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              crossAxisAlignment: CrossAxisAlignment.center,
-                              children: [
-                                Column(
-                                  mainAxisAlignment: MainAxisAlignment.center,
-                                  children: [
-                                    Text(
-                                      'Hours',
-                                      style: Theme.of(context)
-                                          .textTheme
-                                          .displaySmall!
-                                          .copyWith(
-                                            fontWeight: FontWeight.bold,
-                                            color: themeController
-                                                    .isLightMode.value
-                                                ? kLightPrimaryDisabledTextColor
-                                                : kprimaryDisabledTextColor,
+                                      textAlign: TextAlign.center,
+                                      controller: inputTimeController
+                                          .inputSecondsControllerTimer,
+                                      keyboardType: TextInputType.number,
+                                      inputFormatters: [
+                                        FilteringTextInputFormatter.allow(
+                                          RegExp(
+                                            '[1,2,3,4,5,6,7,8,9,0]',
                                           ),
-                                    ),
-                                    SizedBox(
-                                      height: height * 0.008,
-                                    ),
-                                    SizedBox(
-                                      width: 80,
-                                      child: TextField(
-                                        onChanged: (_) {
-                                          inputTimeController.setTimerTime();
-                                        },
-                                        decoration: const InputDecoration(
-                                          hintText: 'HH',
-                                          border: InputBorder.none,
                                         ),
-                                        textAlign: TextAlign.center,
-                                        controller: inputTimeController
-                                            .inputHoursControllerTimer,
-                                        keyboardType: TextInputType.number,
-                                        inputFormatters: [
-                                          FilteringTextInputFormatter.allow(
-                                            RegExp(
-                                              '[1,2,3,4,5,6,7,8,9,0]',
-                                            ),
-                                          ),
-                                          LengthLimitingTextInputFormatter(
-                                            2,
-                                          ),
-                                          LimitRange(
-                                            0,
-                                            23,
-                                          ),
-                                        ],
-                                      ),
+                                        LengthLimitingTextInputFormatter(
+                                          2,
+                                        ),
+                                        LimitRange(
+                                          0,
+                                          59,
+                                        ),
+                                      ],
                                     ),
-                                  ],
-                                ),
-                                Padding(
-                                  padding: EdgeInsets.only(
-                                    left: width * 0.02,
-                                    right: width * 0.02,
-                                    top: height * 0.035,
                                   ),
-                                  child: Text(
-                                    ':',
-                                    style: Theme.of(context)
-                                        .textTheme
-                                        .displayLarge!
-                                        .copyWith(
-                                          fontWeight: FontWeight.bold,
-                                          color: themeController
-                                                  .isLightMode.value
-                                              ? kLightPrimaryDisabledTextColor
-                                              : kprimaryDisabledTextColor,
-                                        ),
-                                  ),
-                                ),
-                                Column(
-                                  mainAxisAlignment: MainAxisAlignment.center,
-                                  children: [
-                                    Text(
-                                      'Minutes',
-                                      style: Theme.of(context)
-                                          .textTheme
-                                          .displaySmall!
-                                          .copyWith(
-                                            fontWeight: FontWeight.bold,
-                                            color: themeController
-                                                    .isLightMode.value
-                                                ? kLightPrimaryDisabledTextColor
-                                                : kprimaryDisabledTextColor,
-                                          ),
-                                    ),
-                                    SizedBox(
-                                      height: height * 0.008,
-                                    ),
-                                    SizedBox(
-                                      width: 80,
-                                      child: TextField(
-                                        onChanged: (_) {
-                                          inputTimeController.setTimerTime();
-                                        },
-                                        decoration: const InputDecoration(
-                                          hintText: 'MM',
-                                          border: InputBorder.none,
-                                        ),
-                                        textAlign: TextAlign.center,
-                                        controller: inputTimeController
-                                            .inputMinutesControllerTimer,
-                                        keyboardType: TextInputType.number,
-                                        inputFormatters: [
-                                          FilteringTextInputFormatter.allow(
-                                            RegExp(
-                                              '[1,2,3,4,5,6,7,8,9,0]',
-                                            ),
-                                          ),
-                                          LengthLimitingTextInputFormatter(
-                                            2,
-                                          ),
-                                          LimitRange(
-                                            0,
-                                            59,
-                                          ),
-                                        ],
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                                Padding(
-                                  padding: EdgeInsets.only(
-                                    left: width * 0.02,
-                                    right: width * 0.02,
-                                    top: height * 0.035,
-                                  ),
-                                  child: Text(
-                                    ':',
-                                    style: Theme.of(context)
-                                        .textTheme
-                                        .displayLarge!
-                                        .copyWith(
-                                          fontWeight: FontWeight.bold,
-                                          color: themeController
-                                                  .isLightMode.value
-                                              ? kLightPrimaryDisabledTextColor
-                                              : kprimaryDisabledTextColor,
-                                        ),
-                                  ),
-                                ),
-                                Column(
-                                  mainAxisAlignment: MainAxisAlignment.center,
-                                  children: [
-                                    Text(
-                                      'Seconds',
-                                      style: Theme.of(context)
-                                          .textTheme
-                                          .displaySmall!
-                                          .copyWith(
-                                            fontWeight: FontWeight.bold,
-                                            color: themeController
-                                                    .isLightMode.value
-                                                ? kLightPrimaryDisabledTextColor
-                                                : kprimaryDisabledTextColor,
-                                          ),
-                                    ),
-                                    SizedBox(
-                                      height: height * 0.008,
-                                    ),
-                                    SizedBox(
-                                      width: 80,
-                                      child: TextField(
-                                        onChanged: (_) {
-                                          inputTimeController.setTimerTime();
-                                        },
-                                        decoration: const InputDecoration(
-                                          hintText: 'SS',
-                                          border: InputBorder.none,
-                                        ),
-                                        textAlign: TextAlign.center,
-                                        controller: inputTimeController
-                                            .inputSecondsControllerTimer,
-                                        keyboardType: TextInputType.number,
-                                        inputFormatters: [
-                                          FilteringTextInputFormatter.allow(
-                                            RegExp(
-                                              '[1,2,3,4,5,6,7,8,9,0]',
-                                            ),
-                                          ),
-                                          LengthLimitingTextInputFormatter(
-                                            2,
-                                          ),
-                                          LimitRange(
-                                            0,
-                                            59,
-                                          ),
-                                        ],
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ],
-                            ),
-                    ),
+                                ],
+                              ),
+                            ],
+                          ),
                   ),
                 ),
-        ),
-        floatingActionButton: Obx(
-          () => controller.isTimerRunning.value
-              ? const SizedBox()
-              : Obx(
-                  () => AbsorbPointer(
-                    absorbing: controller.hours.value == 0 &&
+              ),
+      ),
+      floatingActionButton: Obx(
+        () => controller.isTimerRunning.value
+            ? const SizedBox()
+            : Obx(
+                () => AbsorbPointer(
+                  absorbing: controller.hours.value == 0 &&
+                          controller.minutes.value == 0 &&
+                          controller.seconds.value == 0
+                      ? true
+                      : false,
+                  child: FloatingActionButton(
+                    onPressed: () {
+                      Utils.hapticFeedback();
+                      controller.remainingTime.value = Duration(
+                        hours: controller.hours.value,
+                        minutes: controller.minutes.value,
+                        seconds: controller.seconds.value,
+                      );
+                      controller.startTimer();
+                      controller.createTimer();
+                    },
+                    backgroundColor: controller.hours.value == 0 &&
                             controller.minutes.value == 0 &&
                             controller.seconds.value == 0
-                        ? true
-                        : false,
-                    child: FloatingActionButton(
-                      onPressed: () {
-                        Utils.hapticFeedback();
-                        controller.remainingTime.value = Duration(
-                          hours: controller.hours.value,
-                          minutes: controller.minutes.value,
-                          seconds: controller.seconds.value,
-                        );
-                        controller.startTimer();
-                        controller.createTimer();
-                      },
-                      backgroundColor: controller.hours.value == 0 &&
-                              controller.minutes.value == 0 &&
-                              controller.seconds.value == 0
-                          ? kprimaryDisabledTextColor
-                          : kprimaryColor,
-                      child: const Icon(
-                        Icons.play_arrow_rounded,
-                        size: 33,
-                      ),
+                        ? kprimaryDisabledTextColor
+                        : kprimaryColor,
+                    child: const Icon(
+                      Icons.play_arrow_rounded,
+                      size: 33,
                     ),
                   ),
                 ),
-        ),
-        endDrawer: buildEndDrawer(context));
+              ),
+      ),
+      endDrawer: buildEndDrawer(context),
+    );
   }
 }


### PR DESCRIPTION
### Description
Currently, the app only offers the `TimePickerSpinner` for setting timer duration. This pull request introduces manual time entry functionality to enhance user experience and provide an alternative input method.

### Proposed Changes
- **Manual Time Entry:**
    - Implemented `InkWell` to switch between TimePickerSpinner and manual input.
    - Implemented text fields for individual input of hours, minutes, and seconds.
    - Validated user input to ensure valid time values (0-23 hours, 0-59 minutes, 0-59 seconds).
    - Updated timer duration based on user-entered values.
- I have implemented the required methods and properties in the `InputTimeController`, similar to the approach used in `AddOrUpdateAlarmView`.

## Fixes #293 

## Screenshots

https://github.com/CCExtractor/ultimate_alarm_clock/assets/92971894/be1386a6-4be2-493c-b40c-5a15d9cae66c

## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [ ] All tests are passing