### PR TITLE
styling: Timer icon

### DIFF
--- a/lib/app/modules/bottomNavigationBar/views/bottom_navigation_bar_view.dart
+++ b/lib/app/modules/bottomNavigationBar/views/bottom_navigation_bar_view.dart
@@ -29,7 +29,7 @@ class BottomNavigationBarView extends GetView<BottomNavigationBarController> {
               label: 'StopWatch'.tr,
             ),
             BottomNavigationBarItem(
-              icon: Icon(Icons.timer),
+              icon: Icon(Icons.timelapse_outlined),
               label: 'Timer'.tr,
             ),
           ],


### PR DESCRIPTION
### Description
We can add a timelapse icon to look like the 'time is running out' icon, which is the point of the timer.

## Fixes #453 

## Screenshots
![Screenshot_20240221_143436](https://github.com/CCExtractor/ultimate_alarm_clock/assets/22213675/c5c564bd-b263-4c3f-81cf-ca34375f763e)


## Checklist
<!-- Mark the completed tasks with [x] -->
- [x] Code follows the established coding style guidelines