### PR TITLE
Fixed Bottom nav visibility issue

### DIFF
--- a/lib/app/modules/bottomNavigationBar/views/bottom_navigation_bar_view.dart
+++ b/lib/app/modules/bottomNavigationBar/views/bottom_navigation_bar_view.dart
@@ -1,48 +1,120 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:ultimate_alarm_clock/app/modules/bottomNavigationBar/controllers/bottom_navigation_bar_controller.dart';
+import 'package:ultimate_alarm_clock/app/modules/settings/controllers/theme_controller.dart';
+import 'package:ultimate_alarm_clock/app/utils/constants.dart';
 import 'package:ultimate_alarm_clock/app/utils/utils.dart';
 
 class BottomNavigationBarView extends GetView<BottomNavigationBarController> {
   final PageController pageController = PageController();
-
+  final ThemeController themeController = Get.find<ThemeController>();
+  BottomNavigationBarView({super.key});
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: PageView(
-        controller: pageController,
-        children: controller.pages,
-        onPageChanged: (index) {
-          controller.changeTab(index);
-        },
-      ),
-      bottomNavigationBar: Obx(
-        () => BottomNavigationBar(
-          useLegacyColorScheme: false,
-          items: [
-            BottomNavigationBarItem(
-              icon: Icon(Icons.alarm),
-              label: 'Alarm'.tr,
+    return GetBuilder<ThemeController>(
+      builder: (themeController) {
+        return Scaffold(
+          body: PageView(
+            controller: pageController,
+            children: controller.pages,
+            onPageChanged: (index) {
+              controller.changeTab(index);
+            },
+          ),
+          bottomNavigationBar: Obx(
+            () => CustomNavigationBar(
+              value: themeController.isLightMode.value,
+              currentIndex: controller.activeTabIndex.value,
+              onTap: (index) {
+                Utils.hapticFeedback();
+                controller.changeTab(index);
+                pageController.animateToPage(
+                  index,
+                  duration: const Duration(milliseconds: 300),
+                  curve: Curves.easeInOut,
+                );
+              },
             ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.timer_outlined),
-              label: 'StopWatch'.tr,
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.timelapse_outlined),
-              label: 'Timer'.tr,
-            ),
-          ],
-          onTap: (index) {
-            Utils.hapticFeedback();
-            controller.changeTab(index);
-            pageController.animateToPage(index,
-                duration: Duration(milliseconds: 300), curve: Curves.easeInOut);
-          },
-          currentIndex: controller.activeTabIndex.value,
-        ),
-      ),
+          ),
+        );
+      },
     );
   }
 }
 
+class CustomNavigationBar extends StatelessWidget {
+  final int currentIndex;
+  final Function(int) onTap;
+  final bool value;
+
+  const CustomNavigationBar({
+    super.key,
+    required this.currentIndex,
+    required this.onTap,
+    required this.value,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 60,
+      decoration: BoxDecoration(
+        color: value ? Colors.white : kprimaryBackgroundColor,
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceAround,
+        children: [
+          buildNavItem(Icons.alarm, 0, 'Alarm'),
+          buildNavItem(
+            Icons.timer_outlined,
+            1,
+            'StopWatch',
+          ),
+          buildNavItem(
+            Icons.timelapse_outlined,
+            2,
+            'Timer',
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget buildNavItem(
+    IconData icon,
+    int index,
+    String label,
+  ) {
+    return GestureDetector(
+      onTap: () => onTap(index),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            icon,
+            color: currentIndex == index ? kprimaryColor : Colors.grey,
+            size: currentIndex == index ? 30 : 25,
+          ),
+          Container(
+            decoration: BoxDecoration(
+              border: Border.all(
+                color: value ? Colors.black : Colors.white,
+                width: 0.2,
+              ),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.only(left: 3, right: 3),
+              child: Text(
+                label.tr,
+                style: TextStyle(
+                  color: currentIndex == index ? kprimaryColor : Colors.grey,
+                  fontSize: currentIndex == index ? 13 : 12,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Description

As mentioned in Feature Request,If you check the bottom nav, when it is selected, the readability of the green font is less. So, for that we add a text border to the selected text. In this case, let's add a very thin black border. A thin border because the fluorescent green is the entire essence of the app. So, the expected output would be to have a green font with a slight black border.

Inorder to match this in dark mode, we can give a white thin border to the selected bottom nav option.

Proposed Changes

![Screenshot (78)](https://github.com/CCExtractor/ultimate_alarm_clock/assets/131900819/da571617-795c-49dc-904e-8f356da5cbbe)

![Screenshot (79)](https://github.com/CCExtractor/ultimate_alarm_clock/assets/131900819/cb97617d-4237-41fe-be63-a2a454cfe48c)

code for adding a border to text is implemented by modifying bottom_navigation_bar_view.dart


Fixes https://github.com/CCExtractor/ultimate_alarm_clock/issues/442
