### PR TITLE
Update bottom_navigation_bar_controller.dart

### DIFF
--- a/lib/app/modules/bottomNavigationBar/controllers/bottom_navigation_bar_controller.dart
+++ b/lib/app/modules/bottomNavigationBar/controllers/bottom_navigation_bar_controller.dart
@@ -21,12 +21,12 @@ class BottomNavigationBarController extends GetxController
     TimerView(),
   ];
 
-  @override
-  void onInit() {
-    super.onInit();
-    WidgetsBinding.instance.addObserver(this);
-    _loadSavedState();
-  }
+  // @override
+  // void onInit() {
+  //   super.onInit();
+  //   WidgetsBinding.instance.addObserver(this);
+  //   _loadSavedState();
+  // }
 
   @override
   void onClose() {
@@ -44,9 +44,9 @@ class BottomNavigationBarController extends GetxController
     }
   }
 
-  void _loadSavedState() async {
-    activeTabIndex.value = await _secureStorageProvider.readTabIndex();
-  }
+  // void _loadSavedState() async {
+  //   activeTabIndex.value = await _secureStorageProvider.readTabIndex();
+  // }
 
   void _saveState() async {
     await _secureStorageProvider.writeTabIndex(


### PR DESCRIPTION

### Description
The issue with bottom navbar is now solved as the screen is showing home on opening the app but bottom navbar locally storing data of navbar used before so if we want to show the home page on start so i remove the local storage of navbar which solved the problem

## Fixes #460

## Screenshots


## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing