### PR TITLE
fix: track unsaved changes on add-or-update-alarm-view

### DIFF
--- a/android/app/google-services.json
+++ b/android/app/google-services.json
@@ -1,41 +1,70 @@
 {
   "project_info": {
-    "project_number": "951082036741",
-    "project_id": "ulticock-c13a2",
-    "storage_bucket": "ulticock-c13a2.appspot.com"
+    "project_number": "673861916247",
+    "project_id": "todo-c539f",
+    "storage_bucket": "todo-c539f.appspot.com"
   },
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "1:951082036741:android:45bc3756a62c480f71766c",
+        "mobilesdk_app_id": "1:673861916247:android:b02c93ad8c01d924d4b512",
         "android_client_info": {
-          "package_name": "com.example.ultimate_alarm_clock"
+          "package_name": "com.example.pacific_gym"
         }
       },
       "oauth_client": [
         {
-          "client_id": "951082036741-q9jfduqcvikipre5ubf7774o9b2l822h.apps.googleusercontent.com",
-          "client_type": 1,
-          "android_info": {
-            "package_name": "com.example.ultimate_alarm_clock",
-            "certificate_hash": "af289e1ac935477a575746d95dea1c78156db532"
-          }
-        },
-        {
-          "client_id": "951082036741-5c8vh71vidd27rjihimnemnbdquq1tp2.apps.googleusercontent.com",
+          "client_id": "673861916247-8g1nbf8emf5isukck11qgtg4h9hui01q.apps.googleusercontent.com",
           "client_type": 3
         }
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyCEgfAAOgj5oLlX7LtXn_vCoW7AkMj7Qv4"
+          "current_key": "AIzaSyDq0pIc8KfEZK6sZg8tK-0EBZO4CSjTip0"
         }
       ],
       "services": {
         "appinvite_service": {
           "other_platform_oauth_client": [
             {
-              "client_id": "951082036741-5c8vh71vidd27rjihimnemnbdquq1tp2.apps.googleusercontent.com",
+              "client_id": "673861916247-8g1nbf8emf5isukck11qgtg4h9hui01q.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:673861916247:android:7992060d606f452bd4b512",
+        "android_client_info": {
+          "package_name": "com.example.ultimate_alarm_clock"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "673861916247-la071r94tprf0j47p8pk941jb3vd65l2.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.example.ultimate_alarm_clock",
+            "certificate_hash": "e9b4d687e871c96662572a3108256c2c9626514f"
+          }
+        },
+        {
+          "client_id": "673861916247-8g1nbf8emf5isukck11qgtg4h9hui01q.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDq0pIc8KfEZK6sZg8tK-0EBZO4CSjTip0"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "673861916247-8g1nbf8emf5isukck11qgtg4h9hui01q.apps.googleusercontent.com",
               "client_type": 3
             }
           ]

--- a/android/app/google-services.json
+++ b/android/app/google-services.json
@@ -1,70 +1,41 @@
 {
   "project_info": {
-    "project_number": "673861916247",
-    "project_id": "todo-c539f",
-    "storage_bucket": "todo-c539f.appspot.com"
+    "project_number": "951082036741",
+    "project_id": "ulticock-c13a2",
+    "storage_bucket": "ulticock-c13a2.appspot.com"
   },
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "1:673861916247:android:b02c93ad8c01d924d4b512",
-        "android_client_info": {
-          "package_name": "com.example.pacific_gym"
-        }
-      },
-      "oauth_client": [
-        {
-          "client_id": "673861916247-8g1nbf8emf5isukck11qgtg4h9hui01q.apps.googleusercontent.com",
-          "client_type": 3
-        }
-      ],
-      "api_key": [
-        {
-          "current_key": "AIzaSyDq0pIc8KfEZK6sZg8tK-0EBZO4CSjTip0"
-        }
-      ],
-      "services": {
-        "appinvite_service": {
-          "other_platform_oauth_client": [
-            {
-              "client_id": "673861916247-8g1nbf8emf5isukck11qgtg4h9hui01q.apps.googleusercontent.com",
-              "client_type": 3
-            }
-          ]
-        }
-      }
-    },
-    {
-      "client_info": {
-        "mobilesdk_app_id": "1:673861916247:android:7992060d606f452bd4b512",
+        "mobilesdk_app_id": "1:951082036741:android:45bc3756a62c480f71766c",
         "android_client_info": {
           "package_name": "com.example.ultimate_alarm_clock"
         }
       },
       "oauth_client": [
         {
-          "client_id": "673861916247-la071r94tprf0j47p8pk941jb3vd65l2.apps.googleusercontent.com",
+          "client_id": "951082036741-q9jfduqcvikipre5ubf7774o9b2l822h.apps.googleusercontent.com",
           "client_type": 1,
           "android_info": {
             "package_name": "com.example.ultimate_alarm_clock",
-            "certificate_hash": "e9b4d687e871c96662572a3108256c2c9626514f"
+            "certificate_hash": "af289e1ac935477a575746d95dea1c78156db532"
           }
         },
         {
-          "client_id": "673861916247-8g1nbf8emf5isukck11qgtg4h9hui01q.apps.googleusercontent.com",
+          "client_id": "951082036741-5c8vh71vidd27rjihimnemnbdquq1tp2.apps.googleusercontent.com",
           "client_type": 3
         }
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyDq0pIc8KfEZK6sZg8tK-0EBZO4CSjTip0"
+          "current_key": "AIzaSyCEgfAAOgj5oLlX7LtXn_vCoW7AkMj7Qv4"
         }
       ],
       "services": {
         "appinvite_service": {
           "other_platform_oauth_client": [
             {
-              "client_id": "673861916247-8g1nbf8emf5isukck11qgtg4h9hui01q.apps.googleusercontent.com",
+              "client_id": "951082036741-5c8vh71vidd27rjihimnemnbdquq1tp2.apps.googleusercontent.com",
               "client_type": 3
             }
           ]

--- a/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
+++ b/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
@@ -229,6 +229,81 @@ class AddOrUpdateAlarmController extends GetxController {
     }
   }
 
+  void checkUnsavedChangesAndNavigate(BuildContext context) {
+    print(changedFields);
+    int numberOfChangesMade =
+        changedFields.entries.where((element) => element.value == true).length;
+    if (numberOfChangesMade >= 1) {
+      Get.defaultDialog(
+        titlePadding: const EdgeInsets.symmetric(
+          vertical: 20,
+        ),
+        backgroundColor: themeController.isLightMode.value
+            ? kLightSecondaryBackgroundColor
+            : ksecondaryBackgroundColor,
+        title: 'Discard Changes?'.tr,
+        titleStyle: Theme.of(context).textTheme.displaySmall,
+        content: Column(
+          children: [
+            Text(
+              'unsavedChanges'.tr,
+              style: Theme.of(context).textTheme.bodyMedium,
+              textAlign: TextAlign.center,
+            ),
+            Padding(
+              padding: const EdgeInsets.only(
+                top: 20,
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: [
+                  TextButton(
+                    onPressed: () {
+                      Get.back();
+                    },
+                    style: ButtonStyle(
+                      backgroundColor: MaterialStateProperty.all(kprimaryColor),
+                    ),
+                    child: Text(
+                      'Cancel'.tr,
+                      style: Theme.of(context).textTheme.displaySmall!.copyWith(
+                            color: kprimaryBackgroundColor,
+                          ),
+                    ),
+                  ),
+                  OutlinedButton(
+                    onPressed: () {
+                      Get.back(closeOverlays: true);
+                      Get.back();
+                    },
+                    style: OutlinedButton.styleFrom(
+                      side: BorderSide(
+                        color: themeController.isLightMode.value
+                            ? Colors.red.withOpacity(0.9)
+                            : Colors.red,
+                        width: 1,
+                      ),
+                    ),
+                    child: Text(
+                      'Leave'.tr,
+                      style: Theme.of(context).textTheme.displaySmall!.copyWith(
+                            color: themeController.isLightMode.value
+                                ? Colors.red.withOpacity(0.9)
+                                : Colors.red,
+                          ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      );
+    } else {
+      Get.back();
+    }
+  }
+
   Future<void> getLocation() async {
     if (await _checkAndRequestPermission()) {
       const timeLimit = Duration(seconds: 10);
@@ -701,7 +776,21 @@ class AddOrUpdateAlarmController extends GetxController {
       'deleteAfterGoesOff': deleteAfterGoesOff.value,
       'label': label.value,
       'note': note.value,
-      // 'ringtone' : ,
+      'customRingtoneName': customRingtoneName.value,
+      'volMin': volMin.value,
+      'volMax': volMax.value,
+      'gradient': gradient.value,
+      'showMotivationalQuote': showMotivationalQuote.value,
+      'activityInterval': activityInterval.value,
+      'weatherTypes': weatherTypes.value,
+      // 'location' : ,
+      'shakeTimes': shakeTimes.value,
+      'qrValue': qrValue.value,
+      'mathsDifficulty': mathsDifficulty.value,
+      'mathsSliderValue': mathsSliderValue.value,
+      'numberOfSteps': numberOfSteps.value,
+      'isSharedAlarmEnabled': isSharedAlarmEnabled.value,
+      'offsetDuration': offsetDuration.value
     });
 
     addListeners();
@@ -728,9 +817,14 @@ class AddOrUpdateAlarmController extends GetxController {
           Utils.timeUntilAlarm(TimeOfDay.fromDateTime(time), repeatDays);
     });
 
-    daysRepeating.listen((days) {
+    //Updating UI to show repeated days
+    repeatDays.listen((days) {
+      daysRepeating.value = Utils.getRepeatDays(days);
+
       if (initialValues.containsKey('daysRepeating') &&
-          ((initialValues['daysRepeating'] as String).compareTo(days)) == 0) {
+          ((initialValues['daysRepeating'] as String)
+                  .compareTo(daysRepeating.value)) ==
+              0) {
         changedFields['daysRepeating'] = false;
       } else {
         changedFields['daysRepeating'] = true;
@@ -773,6 +867,81 @@ class AddOrUpdateAlarmController extends GetxController {
       }
     });
 
+    customRingtoneName.listen((ringtone) {
+      if (initialValues.containsKey('customRingtoneName') &&
+          ((initialValues['customRingtoneName'] as String)
+                  .compareTo(ringtone) ==
+              0)) {
+        changedFields['customRingtoneName'] = false;
+      } else {
+        changedFields['customRingtoneName'] = true;
+      }
+    });
+
+    volMin.listen((vol) {
+      if (initialValues.containsKey('volMin') &&
+          ((initialValues['volMin'] as double).compareTo(vol) == 0)) {
+        changedFields['volMin'] = false;
+      } else {
+        changedFields['volMin'] = true;
+      }
+    });
+
+    volMax.listen((vol) {
+      if (initialValues.containsKey('volMax') &&
+          ((initialValues['volMax'] as double).compareTo(vol) == 0)) {
+        changedFields['volMax'] = false;
+      } else {
+        changedFields['volMax'] = true;
+      }
+    });
+
+    gradient.listen((value) {
+      if (initialValues.containsKey('gradient') &&
+          ((initialValues['gradient'] as int).compareTo(value) == 0)) {
+        changedFields['gradient'] = false;
+      } else {
+        changedFields['gradient'] = true;
+      }
+    });
+
+    showMotivationalQuote.listen((value) {
+      if (initialValues.containsKey('showMotivationalQuote') &&
+          ((initialValues['showMotivationalQuote'] == value))) {
+        changedFields['showMotivationalQuote'] = false;
+      } else {
+        changedFields['showMotivationalQuote'] = true;
+      }
+    });
+
+    activityInterval.listen((value) {
+      if (initialValues.containsKey('activityInterval') &&
+          ((initialValues['activityInterval'] as int).compareTo(value) == 0)) {
+        changedFields['activityInterval'] = false;
+      } else {
+        changedFields['activityInterval'] = true;
+      }
+    });
+
+    // Updating UI to show weather types
+    selectedWeather.listen((weather) {
+      if (weather.toList().isEmpty) {
+        isWeatherEnabled.value = false;
+      } else {
+        isWeatherEnabled.value = true;
+      }
+      weatherTypes.value = Utils.getFormattedWeatherTypes(weather);
+      if (initialValues.containsKey('weatherTypes') &&
+          ((initialValues['weatherTypes'] as String)
+                  .compareTo(weatherTypes.value) ==
+              0)) {
+        changedFields['weatherTypes'] = false;
+      } else {
+        changedFields['weatherTypes'] = true;
+      }
+    });
+
+    // TODO location
     // Adding to markers list, to display on map
     // (MarkersLayer takes only List<Marker>)
     selectedPoint.listen(
@@ -792,19 +961,69 @@ class AddOrUpdateAlarmController extends GetxController {
       },
     );
 
-    //Updating UI to show repeated days
-    repeatDays.listen((days) {
-      daysRepeating.value = Utils.getRepeatDays(days);
+    shakeTimes.listen((value) {
+      if (initialValues.containsKey('shakeTimes') &&
+          ((initialValues['shakeTimes'] as int).compareTo(value) == 0)) {
+        changedFields['shakeTimes'] = false;
+      } else {
+        changedFields['shakeTimes'] = true;
+      }
     });
 
-    // Updating UI to show weather types
-    selectedWeather.listen((weather) {
-      if (weather.toList().isEmpty) {
-        isWeatherEnabled.value = false;
+    qrValue.listen((type) {
+      if (initialValues.containsKey('qrValue') &&
+          ((initialValues['qrValue'] as String).compareTo(type) == 0)) {
+        changedFields['qrValue'] = false;
       } else {
-        isWeatherEnabled.value = true;
+        changedFields['qrValue'] = true;
       }
-      weatherTypes.value = Utils.getFormattedWeatherTypes(weather);
+    });
+
+    mathsSliderValue.listen((value) {
+      if (initialValues.containsKey('mathsSliderValue') &&
+          ((initialValues['mathsSliderValue'] as double).compareTo(value) ==
+              0)) {
+        changedFields['mathsSliderValue'] = false;
+      } else {
+        changedFields['mathsSliderValue'] = true;
+      }
+    });
+
+    mathsDifficulty.listen((value) {
+      if (initialValues.containsKey('mathsDifficulty') &&
+          ((initialValues['mathsDifficulty'] as Difficulty).name ==
+              value.name)) {
+        changedFields['mathsDifficulty'] = false;
+      } else {
+        changedFields['mathsDifficulty'] = true;
+      }
+    });
+
+    numberOfSteps.listen((steps) {
+      if (initialValues.containsKey('numberOfSteps') &&
+          ((initialValues['numberOfSteps'] as int).compareTo(steps) == 0)) {
+        changedFields['numberOfSteps'] = false;
+      } else {
+        changedFields['numberOfSteps'] = true;
+      }
+    });
+
+    isSharedAlarmEnabled.listen((value) {
+      if (initialValues.containsKey('isSharedAlarmEnabled') &&
+          ((initialValues['isSharedAlarmEnabled'] == value))) {
+        changedFields['isSharedAlarmEnabled'] = false;
+      } else {
+        changedFields['isSharedAlarmEnabled'] = true;
+      }
+    });
+
+    offsetDuration.listen((value) {
+      if (initialValues.containsKey('offsetDuration') &&
+          (((initialValues['offsetDuration'] as int).compareTo(value) == 0))) {
+        changedFields['offsetDuration'] = false;
+      } else {
+        changedFields['offsetDuration'] = true;
+      }
     });
   }
 

--- a/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
+++ b/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
@@ -108,6 +108,9 @@ class AddOrUpdateAlarmController extends GetxController {
   RxBool isCustomSelected = false.obs;
   RxBool isPlaying = false.obs; // Observable boolean to track playing state
 
+  Map<String, dynamic> initialValues = {};
+  Map<String, dynamic> changedFields = {};
+
   void toggleIsPlaying() {
     isPlaying.toggle();
   }
@@ -691,6 +694,85 @@ class AddOrUpdateAlarmController extends GetxController {
       repeatDays,
     );
 
+    initialValues.addAll({
+      'selectedTime': selectedTime.value,
+      'daysRepeating': daysRepeating.value,
+      'snoozeDuration': snoozeDuration.value,
+      'deleteAfterGoesOff': deleteAfterGoesOff.value,
+      'label': label.value,
+      'note': note.value,
+      // 'ringtone' : ,
+    });
+
+    addListeners();
+
+    if (await SecureStorageProvider().retrieveApiKey(ApiKeys.openWeatherMap) !=
+        null) {
+      weatherApiKeyExists.value = true;
+    }
+
+    // If there's an argument sent, we are in update mode
+  }
+
+  void addListeners() {
+    // Updating UI to show time to alarm
+    selectedTime.listen((time) {
+      debugPrint('CHANGED CHANGED CHANGED CHANGED');
+      if (initialValues.containsKey('selectedTime') &&
+          ((initialValues['selectedTime'] as DateTime).compareTo(time)) == 0) {
+        changedFields['selectedTime'] = false;
+      } else {
+        changedFields['selectedTime'] = true;
+      }
+      timeToAlarm.value =
+          Utils.timeUntilAlarm(TimeOfDay.fromDateTime(time), repeatDays);
+    });
+
+    daysRepeating.listen((days) {
+      if (initialValues.containsKey('daysRepeating') &&
+          ((initialValues['daysRepeating'] as String).compareTo(days)) == 0) {
+        changedFields['daysRepeating'] = false;
+      } else {
+        changedFields['daysRepeating'] = true;
+      }
+    });
+
+    snoozeDuration.listen((duration) {
+      if (initialValues.containsKey('snoozeDuration') &&
+          ((initialValues['snoozeDuration'] as int).compareTo(duration)) == 0) {
+        changedFields['snoozeDuration'] = false;
+      } else {
+        changedFields['snoozeDuration'] = true;
+      }
+    });
+
+    deleteAfterGoesOff.listen((value) {
+      if (initialValues.containsKey('deleteAfterGoesOff') &&
+          ((initialValues['deleteAfterGoesOff'] as bool) == (value))) {
+        changedFields['deleteAfterGoesOff'] = false;
+      } else {
+        changedFields['deleteAfterGoesOff'] = true;
+      }
+    });
+
+    label.listen((label) {
+      if (initialValues.containsKey('label') &&
+          ((initialValues['label'] as String).compareTo(label) == 0)) {
+        changedFields['label'] = false;
+      } else {
+        changedFields['label'] = true;
+      }
+    });
+
+    note.listen((note) {
+      if (initialValues.containsKey('note') &&
+          ((initialValues['note'] as String).compareTo(note) == 0)) {
+        changedFields['note'] = false;
+      } else {
+        changedFields['note'] = true;
+      }
+    });
+
     // Adding to markers list, to display on map
     // (MarkersLayer takes only List<Marker>)
     selectedPoint.listen(
@@ -710,14 +792,6 @@ class AddOrUpdateAlarmController extends GetxController {
       },
     );
 
-    // Updating UI to show time to alarm
-
-    selectedTime.listen((time) {
-      debugPrint('CHANGED CHANGED CHANGED CHANGED');
-      timeToAlarm.value =
-          Utils.timeUntilAlarm(TimeOfDay.fromDateTime(time), repeatDays);
-    });
-
     //Updating UI to show repeated days
     repeatDays.listen((days) {
       daysRepeating.value = Utils.getRepeatDays(days);
@@ -732,13 +806,6 @@ class AddOrUpdateAlarmController extends GetxController {
       }
       weatherTypes.value = Utils.getFormattedWeatherTypes(weather);
     });
-
-    if (await SecureStorageProvider().retrieveApiKey(ApiKeys.openWeatherMap) !=
-        null) {
-      weatherApiKeyExists.value = true;
-    }
-
-    // If there's an argument sent, we are in update mode
   }
 
   @override

--- a/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
+++ b/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
@@ -108,6 +108,7 @@ class AddOrUpdateAlarmController extends GetxController {
   RxBool isCustomSelected = false.obs;
   RxBool isPlaying = false.obs; // Observable boolean to track playing state
 
+  // to check whether alarm data is updated or not
   Map<String, dynamic> initialValues = {};
   Map<String, dynamic> changedFields = {};
 
@@ -230,7 +231,6 @@ class AddOrUpdateAlarmController extends GetxController {
   }
 
   void checkUnsavedChangesAndNavigate(BuildContext context) {
-    print(changedFields);
     int numberOfChangesMade =
         changedFields.entries.where((element) => element.value == true).length;
     if (numberOfChangesMade >= 1) {
@@ -769,6 +769,7 @@ class AddOrUpdateAlarmController extends GetxController {
       repeatDays,
     );
 
+    // store initial values of the variables
     initialValues.addAll({
       'selectedTime': selectedTime.value,
       'daysRepeating': daysRepeating.value,
@@ -783,14 +784,17 @@ class AddOrUpdateAlarmController extends GetxController {
       'showMotivationalQuote': showMotivationalQuote.value,
       'activityInterval': activityInterval.value,
       'weatherTypes': weatherTypes.value,
-      // 'location' : ,
+      'location':
+          '${selectedPoint.value.latitude} ${selectedPoint.value.longitude}',
       'shakeTimes': shakeTimes.value,
       'qrValue': qrValue.value,
       'mathsDifficulty': mathsDifficulty.value,
       'mathsSliderValue': mathsSliderValue.value,
+      'numMathsQuestions': numMathsQuestions.value,
       'numberOfSteps': numberOfSteps.value,
       'isSharedAlarmEnabled': isSharedAlarmEnabled.value,
-      'offsetDuration': offsetDuration.value
+      'offsetDuration': offsetDuration.value,
+      'isOffsetBefore': isOffsetBefore.value
     });
 
     addListeners();
@@ -807,121 +811,27 @@ class AddOrUpdateAlarmController extends GetxController {
     // Updating UI to show time to alarm
     selectedTime.listen((time) {
       debugPrint('CHANGED CHANGED CHANGED CHANGED');
-      if (initialValues.containsKey('selectedTime') &&
-          ((initialValues['selectedTime'] as DateTime).compareTo(time)) == 0) {
-        changedFields['selectedTime'] = false;
-      } else {
-        changedFields['selectedTime'] = true;
-      }
       timeToAlarm.value =
           Utils.timeUntilAlarm(TimeOfDay.fromDateTime(time), repeatDays);
+      _compareAndSetChange('selectedTime', time);
     });
 
     //Updating UI to show repeated days
     repeatDays.listen((days) {
       daysRepeating.value = Utils.getRepeatDays(days);
-
-      if (initialValues.containsKey('daysRepeating') &&
-          ((initialValues['daysRepeating'] as String)
-                  .compareTo(daysRepeating.value)) ==
-              0) {
-        changedFields['daysRepeating'] = false;
-      } else {
-        changedFields['daysRepeating'] = true;
-      }
+      _compareAndSetChange('daysRepeating', daysRepeating.value);
     });
 
-    snoozeDuration.listen((duration) {
-      if (initialValues.containsKey('snoozeDuration') &&
-          ((initialValues['snoozeDuration'] as int).compareTo(duration)) == 0) {
-        changedFields['snoozeDuration'] = false;
-      } else {
-        changedFields['snoozeDuration'] = true;
-      }
-    });
-
-    deleteAfterGoesOff.listen((value) {
-      if (initialValues.containsKey('deleteAfterGoesOff') &&
-          ((initialValues['deleteAfterGoesOff'] as bool) == (value))) {
-        changedFields['deleteAfterGoesOff'] = false;
-      } else {
-        changedFields['deleteAfterGoesOff'] = true;
-      }
-    });
-
-    label.listen((label) {
-      if (initialValues.containsKey('label') &&
-          ((initialValues['label'] as String).compareTo(label) == 0)) {
-        changedFields['label'] = false;
-      } else {
-        changedFields['label'] = true;
-      }
-    });
-
-    note.listen((note) {
-      if (initialValues.containsKey('note') &&
-          ((initialValues['note'] as String).compareTo(note) == 0)) {
-        changedFields['note'] = false;
-      } else {
-        changedFields['note'] = true;
-      }
-    });
-
-    customRingtoneName.listen((ringtone) {
-      if (initialValues.containsKey('customRingtoneName') &&
-          ((initialValues['customRingtoneName'] as String)
-                  .compareTo(ringtone) ==
-              0)) {
-        changedFields['customRingtoneName'] = false;
-      } else {
-        changedFields['customRingtoneName'] = true;
-      }
-    });
-
-    volMin.listen((vol) {
-      if (initialValues.containsKey('volMin') &&
-          ((initialValues['volMin'] as double).compareTo(vol) == 0)) {
-        changedFields['volMin'] = false;
-      } else {
-        changedFields['volMin'] = true;
-      }
-    });
-
-    volMax.listen((vol) {
-      if (initialValues.containsKey('volMax') &&
-          ((initialValues['volMax'] as double).compareTo(vol) == 0)) {
-        changedFields['volMax'] = false;
-      } else {
-        changedFields['volMax'] = true;
-      }
-    });
-
-    gradient.listen((value) {
-      if (initialValues.containsKey('gradient') &&
-          ((initialValues['gradient'] as int).compareTo(value) == 0)) {
-        changedFields['gradient'] = false;
-      } else {
-        changedFields['gradient'] = true;
-      }
-    });
-
-    showMotivationalQuote.listen((value) {
-      if (initialValues.containsKey('showMotivationalQuote') &&
-          ((initialValues['showMotivationalQuote'] == value))) {
-        changedFields['showMotivationalQuote'] = false;
-      } else {
-        changedFields['showMotivationalQuote'] = true;
-      }
-    });
-
-    activityInterval.listen((value) {
-      if (initialValues.containsKey('activityInterval') &&
-          ((initialValues['activityInterval'] as int).compareTo(value) == 0)) {
-        changedFields['activityInterval'] = false;
-      } else {
-        changedFields['activityInterval'] = true;
-      }
-    });
+    setupListener<int>(snoozeDuration, 'snoozeDuration');
+    setupListener<bool>(deleteAfterGoesOff, 'deleteAfterGoesOff');
+    setupListener<String>(label, 'label');
+    setupListener<String>(note, 'note');
+    setupListener<String>(customRingtoneName, 'customRingtoneName');
+    setupListener<double>(volMin, 'volMin');
+    setupListener<double>(volMax, 'volMax');
+    setupListener<int>(gradient, 'gradient');
+    setupListener<bool>(showMotivationalQuote, 'showMotivationalQuote');
+    setupListener<int>(activityInterval, 'activityInterval');
 
     // Updating UI to show weather types
     selectedWeather.listen((weather) {
@@ -931,17 +841,13 @@ class AddOrUpdateAlarmController extends GetxController {
         isWeatherEnabled.value = true;
       }
       weatherTypes.value = Utils.getFormattedWeatherTypes(weather);
-      if (initialValues.containsKey('weatherTypes') &&
-          ((initialValues['weatherTypes'] as String)
-                  .compareTo(weatherTypes.value) ==
-              0)) {
-        changedFields['weatherTypes'] = false;
-      } else {
-        changedFields['weatherTypes'] = true;
+      _compareAndSetChange('weatherTypes', weatherTypes.value);
+      // if location based is disabled and weather based is disabled, reset location
+      if (weatherTypes.value == 'Off' && !isLocationEnabled.value) {
+        selectedPoint.value = LatLng(0, 0);
       }
     });
 
-    // TODO location
     // Adding to markers list, to display on map
     // (MarkersLayer takes only List<Marker>)
     selectedPoint.listen(
@@ -958,73 +864,44 @@ class AddOrUpdateAlarmController extends GetxController {
             ),
           ),
         );
+        _compareAndSetChange(
+            'location', '${point.latitude} ${point.longitude}');
       },
     );
 
-    shakeTimes.listen((value) {
-      if (initialValues.containsKey('shakeTimes') &&
-          ((initialValues['shakeTimes'] as int).compareTo(value) == 0)) {
-        changedFields['shakeTimes'] = false;
-      } else {
-        changedFields['shakeTimes'] = true;
+    // reset selectedPoint to default value if isLocationEnabled is false and weather based is off
+    isLocationEnabled.listen((value) {
+      if (!value && weatherTypes.value == 'Off') {
+        selectedPoint.value = LatLng(0, 0);
       }
     });
 
-    qrValue.listen((type) {
-      if (initialValues.containsKey('qrValue') &&
-          ((initialValues['qrValue'] as String).compareTo(type) == 0)) {
-        changedFields['qrValue'] = false;
-      } else {
-        changedFields['qrValue'] = true;
-      }
-    });
+    setupListener<int>(shakeTimes, 'shakeTimes');
+    setupListener<String>(qrValue, 'qrValue');
+    setupListener<double>(mathsSliderValue, 'mathsSliderValue');
+    setupListener<Difficulty>(mathsDifficulty, 'mathsDifficulty');
+    setupListener<int>(numMathsQuestions, 'numMathsQuestions');
+    setupListener<int>(numberOfSteps, 'numberOfSteps');
 
-    mathsSliderValue.listen((value) {
-      if (initialValues.containsKey('mathsSliderValue') &&
-          ((initialValues['mathsSliderValue'] as double).compareTo(value) ==
-              0)) {
-        changedFields['mathsSliderValue'] = false;
-      } else {
-        changedFields['mathsSliderValue'] = true;
-      }
-    });
+    setupListener<bool>(isSharedAlarmEnabled, 'isSharedAlarmEnabled');
+    setupListener<int>(offsetDuration, 'offsetDuration');
+    setupListener<bool>(isOffsetBefore, 'isOffsetBefore');
+  }
 
-    mathsDifficulty.listen((value) {
-      if (initialValues.containsKey('mathsDifficulty') &&
-          ((initialValues['mathsDifficulty'] as Difficulty).name ==
-              value.name)) {
-        changedFields['mathsDifficulty'] = false;
-      } else {
-        changedFields['mathsDifficulty'] = true;
-      }
+  // adds listener to rxVar variable
+  void setupListener<T>(Rx<T> rxVar, String fieldName) {
+    rxVar.listen((value) {
+      _compareAndSetChange(fieldName, value);
     });
+  }
 
-    numberOfSteps.listen((steps) {
-      if (initialValues.containsKey('numberOfSteps') &&
-          ((initialValues['numberOfSteps'] as int).compareTo(steps) == 0)) {
-        changedFields['numberOfSteps'] = false;
-      } else {
-        changedFields['numberOfSteps'] = true;
-      }
-    });
-
-    isSharedAlarmEnabled.listen((value) {
-      if (initialValues.containsKey('isSharedAlarmEnabled') &&
-          ((initialValues['isSharedAlarmEnabled'] == value))) {
-        changedFields['isSharedAlarmEnabled'] = false;
-      } else {
-        changedFields['isSharedAlarmEnabled'] = true;
-      }
-    });
-
-    offsetDuration.listen((value) {
-      if (initialValues.containsKey('offsetDuration') &&
-          (((initialValues['offsetDuration'] as int).compareTo(value) == 0))) {
-        changedFields['offsetDuration'] = false;
-      } else {
-        changedFields['offsetDuration'] = true;
-      }
-    });
+  // if initialValues map contains fieldName and newValue is equal to currentValue
+  // then set changeFields map field to true
+  void _compareAndSetChange(String fieldName, dynamic currentValue) {
+    if (initialValues.containsKey(fieldName)) {
+      bool hasChanged = initialValues[fieldName] != currentValue;
+      changedFields[fieldName] = hasChanged;
+    }
   }
 
   @override

--- a/lib/app/modules/addOrUpdateAlarm/views/add_or_update_alarm_view.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/add_or_update_alarm_view.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -48,87 +50,7 @@ class AddOrUpdateAlarmView extends GetView<AddOrUpdateAlarmController> {
           if (didPop) {
             return;
           }
-          print(controller.changedFields);
-          int numberOfChangesMade = controller.changedFields.entries
-              .where((element) => element.value == true)
-              .length;
-          if (numberOfChangesMade >= 1) {
-            Get.defaultDialog(
-              titlePadding: const EdgeInsets.symmetric(
-                vertical: 20,
-              ),
-              backgroundColor: themeController.isLightMode.value
-                  ? kLightSecondaryBackgroundColor
-                  : ksecondaryBackgroundColor,
-              title: 'Discard Changes?'.tr,
-              titleStyle: Theme.of(context).textTheme.displaySmall,
-              content: Column(
-                children: [
-                  Text(
-                    'unsavedChanges'.tr,
-                    style: Theme.of(context).textTheme.bodyMedium,
-                    textAlign: TextAlign.center,
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.only(
-                      top: 20,
-                    ),
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                      children: [
-                        TextButton(
-                          onPressed: () {
-                            Get.back();
-                          },
-                          style: ButtonStyle(
-                            backgroundColor:
-                                MaterialStateProperty.all(kprimaryColor),
-                          ),
-                          child: Text(
-                            'Cancel'.tr,
-                            style: Theme.of(context)
-                                .textTheme
-                                .displaySmall!
-                                .copyWith(
-                                  color: kprimaryBackgroundColor,
-                                ),
-                          ),
-                        ),
-                        OutlinedButton(
-                          onPressed: () {
-                            Get.back(closeOverlays: true);
-                            Get.back();
-                          },
-                          style: OutlinedButton.styleFrom(
-                            side: BorderSide(
-                              color: themeController.isLightMode.value
-                                  ? Colors.red.withOpacity(0.9)
-                                  : Colors.red,
-                              width: 1,
-                            ),
-                          ),
-                          child: Text(
-                            'Leave'.tr,
-                            style: Theme.of(context)
-                                .textTheme
-                                .displaySmall!
-                                .copyWith(
-                                  color: themeController.isLightMode.value
-                                      ? Colors.red.withOpacity(0.9)
-                                      : Colors.red,
-                                ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-            );
-          } else {
-            Get.back(closeOverlays: true);
-            Get.back();
-          }
+          controller.checkUnsavedChangesAndNavigate(context);
         },
         child: Scaffold(
           floatingActionButtonLocation:

--- a/lib/app/modules/addOrUpdateAlarm/views/add_or_update_alarm_view.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/add_or_update_alarm_view.dart
@@ -48,79 +48,87 @@ class AddOrUpdateAlarmView extends GetView<AddOrUpdateAlarmController> {
           if (didPop) {
             return;
           }
-
-          Get.defaultDialog(
-            titlePadding: const EdgeInsets.symmetric(
-              vertical: 20,
-            ),
-            backgroundColor: themeController.isLightMode.value
-                ? kLightSecondaryBackgroundColor
-                : ksecondaryBackgroundColor,
-            title: 'Discard Changes?'.tr,
-            titleStyle: Theme.of(context).textTheme.displaySmall,
-            content: Column(
-              children: [
-                Text(
-                  'unsavedChanges'.tr,
-                  style: Theme.of(context).textTheme.bodyMedium,
-                  textAlign: TextAlign.center,
-                ),
-                Padding(
-                  padding: const EdgeInsets.only(
-                    top: 20,
+          print(controller.changedFields);
+          int numberOfChangesMade = controller.changedFields.entries
+              .where((element) => element.value == true)
+              .length;
+          if (numberOfChangesMade >= 1) {
+            Get.defaultDialog(
+              titlePadding: const EdgeInsets.symmetric(
+                vertical: 20,
+              ),
+              backgroundColor: themeController.isLightMode.value
+                  ? kLightSecondaryBackgroundColor
+                  : ksecondaryBackgroundColor,
+              title: 'Discard Changes?'.tr,
+              titleStyle: Theme.of(context).textTheme.displaySmall,
+              content: Column(
+                children: [
+                  Text(
+                    'unsavedChanges'.tr,
+                    style: Theme.of(context).textTheme.bodyMedium,
+                    textAlign: TextAlign.center,
                   ),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                    children: [
-                      TextButton(
-                        onPressed: () {
-                          Get.back();
-                        },
-                        style: ButtonStyle(
-                          backgroundColor:
-                              MaterialStateProperty.all(kprimaryColor),
-                        ),
-                        child: Text(
-                          'Cancel'.tr,
-                          style: Theme.of(context)
-                              .textTheme
-                              .displaySmall!
-                              .copyWith(
-                                color: kprimaryBackgroundColor,
-                              ),
-                        ),
-                      ),
-                      OutlinedButton(
-                        onPressed: () {
-                          Get.back(closeOverlays: true);
-                          Get.back();
-                        },
-                        style: OutlinedButton.styleFrom(
-                          side: BorderSide(
-                            color: themeController.isLightMode.value
-                                ? Colors.red.withOpacity(0.9)
-                                : Colors.red,
-                            width: 1,
+                  Padding(
+                    padding: const EdgeInsets.only(
+                      top: 20,
+                    ),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                      children: [
+                        TextButton(
+                          onPressed: () {
+                            Get.back();
+                          },
+                          style: ButtonStyle(
+                            backgroundColor:
+                                MaterialStateProperty.all(kprimaryColor),
+                          ),
+                          child: Text(
+                            'Cancel'.tr,
+                            style: Theme.of(context)
+                                .textTheme
+                                .displaySmall!
+                                .copyWith(
+                                  color: kprimaryBackgroundColor,
+                                ),
                           ),
                         ),
-                        child: Text(
-                          'Leave'.tr,
-                          style: Theme.of(context)
-                              .textTheme
-                              .displaySmall!
-                              .copyWith(
-                                color: themeController.isLightMode.value
-                                    ? Colors.red.withOpacity(0.9)
-                                    : Colors.red,
-                              ),
+                        OutlinedButton(
+                          onPressed: () {
+                            Get.back(closeOverlays: true);
+                            Get.back();
+                          },
+                          style: OutlinedButton.styleFrom(
+                            side: BorderSide(
+                              color: themeController.isLightMode.value
+                                  ? Colors.red.withOpacity(0.9)
+                                  : Colors.red,
+                              width: 1,
+                            ),
+                          ),
+                          child: Text(
+                            'Leave'.tr,
+                            style: Theme.of(context)
+                                .textTheme
+                                .displaySmall!
+                                .copyWith(
+                                  color: themeController.isLightMode.value
+                                      ? Colors.red.withOpacity(0.9)
+                                      : Colors.red,
+                                ),
+                          ),
                         ),
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
-                ),
-              ],
-            ),
-          );
+                ],
+              ),
+            );
+          } else {
+            Get.back(closeOverlays: true);
+            Get.back();
+          }
         },
         child: Scaffold(
           floatingActionButtonLocation:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -564,10 +564,10 @@ packages:
     dependency: "direct main"
     description:
       name: get
-      sha256: "2ba20a47c8f1f233bed775ba2dd0d3ac97b4cf32fc17731b3dfc672b06b0e92a"
+      sha256: e4e7335ede17452b391ed3b2ede016545706c01a02292a6c97619705e7d2a85e
       url: "https://pub.dev"
     source: hosted
-    version: "4.6.5"
+    version: "4.6.6"
   get_storage:
     dependency: "direct main"
     description:
@@ -752,6 +752,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.8.2"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -780,26 +804,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -844,10 +868,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   path_parsing:
     dependency: transitive
     description:
@@ -1341,6 +1365,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.8.4"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.0"
   watcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   firebase_core: ^2.8.0
   screen_state: ^2.0.0
   cupertino_icons: ^1.0.2
-  get: 4.6.5
+  get: 4.6.6
   get_storage: ^2.1.1
   flutter_time_picker_spinner: ^2.0.0
   cloud_firestore: ^4.4.5


### PR DESCRIPTION
### Description
When I enter an alarm tile and attempt to exit it, a dialog box appears even if no changes were made. This behaviour should be adjusted to only display a pop-up message if changes were made but not saved or updated.

### Proposed Changes
Created a map to store initial values and changed values. I added listeners to the required variables and compared the initial value and current value, storing them in the changed values map. In PopScope, check if the user has unsaved changes and pop the page.

## Fixes #405 

## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [ ] All tests are passing