### PR TITLE
fix: Next alarm showing 'No Upcoming alarm' instead of countdown on iOS device

### DIFF
--- a/lib/app/modules/home/controllers/home_controller.dart
+++ b/lib/app/modules/home/controllers/home_controller.dart
@@ -273,20 +273,20 @@ class HomeController extends GetxController {
       debugPrint('Fire: ${firestoreLatestAlarm.alarmTime}');
 
       if (!latestAlarm.isTimer) {
-        String timeToAlarm = Utils.timeUntilAlarm(
-          Utils.stringToTimeOfDay(latestAlarm.alarmTime),
-          latestAlarm.days,
-        );
-        alarmTime.value = 'Rings in $timeToAlarm';
-        // This function is necessary when alarms are deleted/enabled
-        await scheduleNextAlarm(
-          alarmRecord,
-          isarLatestAlarm,
-          firestoreLatestAlarm,
-          latestAlarm,
-        );
-
         if (latestAlarm.minutesSinceMidnight > -1) {
+          String timeToAlarm = Utils.timeUntilAlarm(
+            Utils.stringToTimeOfDay(latestAlarm.alarmTime),
+            latestAlarm.days,
+          );
+          alarmTime.value = 'Rings in $timeToAlarm';
+          // This function is necessary when alarms are deleted/enabled
+          await scheduleNextAlarm(
+            alarmRecord,
+            isarLatestAlarm,
+            firestoreLatestAlarm,
+            latestAlarm,
+          );
+
           // To account for difference between seconds upto the next minute
           DateTime now = DateTime.now();
           DateTime nextMinute =


### PR DESCRIPTION
### Description
This PR resolves an issue where the message "No upcoming alarms" was not displayed correctly on iOS devices. Previously, the message was being displayed as "Rings in 23 hours 59 minutes" on iOS, whereas it correctly displayed "No upcoming alarms" on Android devices.

### Proposed Changes
- Modified the logic in the refreshUpcomingAlarms() method to ensure that when there are no alarms scheduled, the alarmTime value is set to "No upcoming alarms" for both Android and iOS platforms.
- Tested the modified code on both Android and iOS devices to ensure consistent behavior.

## Fixes #480 

## Screenshots
<img width="441" alt="Screenshot 2024-03-02 at 3 10 28 PM" src="https://github.com/CCExtractor/ultimate_alarm_clock/assets/83498152/80d558a6-2744-4b84-b96e-6232355103e5">

## Checklist
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [ ] All tests are passing