### PR TITLE
Fixes PageState not loading using the correct index after closing the app.

### DIFF
--- a/lib/app/modules/bottomNavigationBar/controllers/bottom_navigation_bar_controller.dart
+++ b/lib/app/modules/bottomNavigationBar/controllers/bottom_navigation_bar_controller.dart
@@ -10,6 +10,7 @@ class BottomNavigationBarController extends GetxController
     with WidgetsBindingObserver {
   RxInt activeTabIndex = 0.obs;
   RxBool isTimerRunning = false.obs;
+  RxBool hasloaded = false.obs;
 
   final _secureStorageProvider = SecureStorageProvider();
 
@@ -44,8 +45,15 @@ class BottomNavigationBarController extends GetxController
     }
   }
 
-  void _loadSavedState() async {
-    activeTabIndex.value = await _secureStorageProvider.readTabIndex();
+  Future<int> getSavedState() async {
+    return await _secureStorageProvider.readTabIndex();
+  }
+
+  Future<void> _loadSavedState() async {
+    getSavedState().then((value) {
+      activeTabIndex.value = value;
+      hasloaded.value = true;
+    });
   }
 
   void _saveState() async {

--- a/lib/app/modules/bottomNavigationBar/controllers/bottom_navigation_bar_controller.dart
+++ b/lib/app/modules/bottomNavigationBar/controllers/bottom_navigation_bar_controller.dart
@@ -26,7 +26,7 @@ class BottomNavigationBarController extends GetxController
   void onInit() {
     super.onInit();
     WidgetsBinding.instance.addObserver(this);
-    _loadSavedState();
+    loadSavedState();
   }
 
   @override
@@ -45,15 +45,10 @@ class BottomNavigationBarController extends GetxController
     }
   }
 
-  Future<int> getSavedState() async {
-    return await _secureStorageProvider.readTabIndex();
-  }
-
-  Future<void> _loadSavedState() async {
-    getSavedState().then((value) {
-      activeTabIndex.value = value;
-      hasloaded.value = true;
-    });
+  Future<void> loadSavedState() async {
+    int value = await _secureStorageProvider.readTabIndex();
+    activeTabIndex.value = value;
+    hasloaded.value = true;
   }
 
   void _saveState() async {

--- a/lib/app/modules/bottomNavigationBar/views/bottom_navigation_bar_view.dart
+++ b/lib/app/modules/bottomNavigationBar/views/bottom_navigation_bar_view.dart
@@ -6,20 +6,40 @@ import 'package:ultimate_alarm_clock/app/utils/constants.dart';
 import 'package:ultimate_alarm_clock/app/utils/utils.dart';
 
 class BottomNavigationBarView extends GetView<BottomNavigationBarController> {
-  final PageController pageController = PageController();
+  PageController pageController = PageController();
   final ThemeController themeController = Get.find<ThemeController>();
 
   BottomNavigationBarView({super.key});
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: PageView(
-        controller: pageController,
-        children: controller.pages,
-        onPageChanged: (index) {
-          controller.changeTab(index);
-        },
-      ),
+      body: Obx(() {
+        return FutureBuilder(
+          future: controller.getSavedState(),
+          builder: (context, snapshot) {
+            if (controller.hasloaded.value != false) {
+              pageController =
+                  PageController(initialPage: controller.activeTabIndex.value);
+              return PageView(
+                controller: pageController,
+                children: controller.pages,
+                onPageChanged: (index) {
+                  controller.changeTab(index);
+                },
+              );
+            } else {
+              return const Center(
+                child: CircularProgressIndicator.adaptive(
+                  backgroundColor: Colors.transparent,
+                  valueColor: AlwaysStoppedAnimation(
+                    kprimaryColor,
+                  ),
+                ),
+              );
+            }
+          },
+        );
+      }),
       bottomNavigationBar: Obx(
         () => BottomNavigationBar(
           useLegacyColorScheme: false,
@@ -40,10 +60,8 @@ class BottomNavigationBarView extends GetView<BottomNavigationBarController> {
           onTap: (index) {
             Utils.hapticFeedback();
             controller.changeTab(index);
-            pageController.animateToPage(
+            pageController.jumpToPage(
               index,
-              duration: const Duration(milliseconds: 300),
-              curve: Curves.easeInOut,
             );
           },
           currentIndex: controller.activeTabIndex.value,

--- a/lib/app/modules/bottomNavigationBar/views/bottom_navigation_bar_view.dart
+++ b/lib/app/modules/bottomNavigationBar/views/bottom_navigation_bar_view.dart
@@ -15,7 +15,7 @@ class BottomNavigationBarView extends GetView<BottomNavigationBarController> {
     return Scaffold(
       body: Obx(() {
         return FutureBuilder(
-          future: controller.getSavedState(),
+          future: controller.loadSavedState(),
           builder: (context, snapshot) {
             if (controller.hasloaded.value != false) {
               pageController =

--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -755,12 +755,16 @@ class HomeView extends GetView<HomeController> {
                                           Utils.getRepeatDays(alarm.days);
                                       // Main card
                                       return Dismissible(
-                                        direction: controller.isAnyAlarmHolded
-                                            .value ? DismissDirection.none : DismissDirection.startToEnd,
+                                        direction:
+                                            controller.isAnyAlarmHolded.value
+                                                ? DismissDirection.none
+                                                : DismissDirection.startToEnd,
                                         onDismissed: (direction) async {
-                                          if (!controller.isAnyAlarmHolded
-                                              .value) {
-                                            await controller.swipeToDeleteAlarm(controller.userModel.value, alarm);
+                                          if (!controller
+                                              .isAnyAlarmHolded.value) {
+                                            await controller.swipeToDeleteAlarm(
+                                                controller.userModel.value,
+                                                alarm);
                                           }
                                         },
                                         key: ValueKey(alarms[index]),


### PR DESCRIPTION
### Description
Introduces a `hasLoaded` variable in the bottombarcontroller to ensure the pageView is only loaded after the await method `_loadSavedState` returns

also removes the animation for navigating from 1 page to another

## Fixes #407

## Recording

https://github.com/CCExtractor/ultimate_alarm_clock/assets/72601105/b2bcfe69-903e-453b-b64b-d95a19720c0f

## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [ ] Code follows the established coding style guidelines
- [ ] All tests are passing