### PR TITLE
solve over flow error in enable shared alarm dialog

### DIFF
--- a/lib/app/modules/addOrUpdateAlarm/views/shared_alarm_tile.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/shared_alarm_tile.dart
@@ -172,8 +172,7 @@ class SharedAlarm extends StatelessWidget {
                               crossAxisAlignment: CrossAxisAlignment.center,
                               mainAxisAlignment: MainAxisAlignment.center,
                               children: [
-                                SizedBox(
-                                  width: width * 0.37,
+                                Expanded(
                                   child: TextButton(
                                     style: ButtonStyle(
                                       backgroundColor:
@@ -207,8 +206,7 @@ class SharedAlarm extends StatelessWidget {
                                 SizedBox(
                                   width: width * 0.05,
                                 ),
-                                SizedBox(
-                                  width: width * 0.3,
+                                Expanded(
                                   child: TextButton(
                                     style: ButtonStyle(
                                       backgroundColor:


### PR DESCRIPTION
### Description
solve over flow error in enable shared alarm in settings for every alarm ,using expanded widget instead of Sized box that defines fixed size. 



## Fixes [Bug: over flow error in enable shared alarm dialog #509](https://github.com/CCExtractor/ultimate_alarm_clock/issues/509)


## Screenshots

![photo_2024-03-12_11-13-45](https://github.com/CCExtractor/ultimate_alarm_clock/assets/86882938/7b8633b4-c3c4-432c-a4c8-286096aad7b3)
 
