### PR TITLE
Styling: Making the settings Page consistent.

### DIFF
--- a/lib/app/modules/settings/views/customize_undo_duration.dart
+++ b/lib/app/modules/settings/views/customize_undo_duration.dart
@@ -98,12 +98,7 @@ class CustomizeUndoDuration extends StatelessWidget{
                   : ksecondaryBackgroundColor,
               title: Text(
                 'Undo Duration'.tr,
-                style: TextStyle(
-                  color: themeController.isLightMode.value
-                      ? kLightPrimaryTextColor
-                      : kprimaryTextColor,
-                  fontSize: 15
-                ),
+                style: Theme.of(context).textTheme.bodyLarge,
               ),
               trailing: Wrap(
                 crossAxisAlignment: WrapCrossAlignment.center,


### PR DESCRIPTION
### Description
Making the settings Page consistent. Undo Text was not matching with the styles of rest of the buttons.

## Fixes #553 

## Screenshots

![Screenshot_20240414_235742](https://github.com/CCExtractor/ultimate_alarm_clock/assets/22213675/25d247b8-a402-4140-9d94-2d558073b30b)

## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Code follows the established coding style guidelines
- [x] All tests are passing