### PR TITLE
Styling: Layout of Undo Tile

### DIFF
--- a/lib/app/modules/settings/views/customize_undo_duration.dart
+++ b/lib/app/modules/settings/views/customize_undo_duration.dart
@@ -91,7 +91,7 @@ class CustomizeUndoDuration extends StatelessWidget{
         ),
         child: Center(
           child: Padding(
-            padding: EdgeInsets.only(left: 10, right: 10),
+            padding: EdgeInsets.only(left: 15, right: 10),
             child: ListTile(
               tileColor: themeController.isLightMode.value
                   ? kLightSecondaryBackgroundColor


### PR DESCRIPTION
### Description
The content in Undo tile is not aligned properly with the rest of the items in the page.

## Fixes #557 

## Screenshots
![Screenshot_20240415_002908](https://github.com/CCExtractor/ultimate_alarm_clock/assets/22213675/14fe7128-63d0-4060-981f-c66d8951074b)


## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Code follows the established coding style guidelines
- [x] All tests are passing