### PR TITLE
Bottom Overflow in Repeat Tile UI on Small Screen Devices

### DIFF
--- a/lib/app/modules/addOrUpdateAlarm/views/repeat_tile.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/repeat_tile.dart
@@ -31,9 +31,10 @@ class RepeatTile extends StatelessWidget {
               },
               backgroundColor: themeController.secondaryBackgroundColor.value,
               builder: (BuildContext context) {
-                return Container(
-                  height: height * 0.45,
+                return SingleChildScrollView(
+                  scrollDirection: Axis.vertical,
                   child: Column(
+                    mainAxisSize: MainAxisSize.min,
                     children: [
                       buildDailyTile(),
                       Container(
@@ -61,6 +62,7 @@ class RepeatTile extends StatelessWidget {
                           padding: const EdgeInsets.only(
                             left: 25,
                             right: 25,
+                            bottom: 25
                           ),
                           child: TextButton(
                             style: ButtonStyle(


### PR DESCRIPTION
### Description

This overflow occurs on small screens only.

### Proposed Changes

This is resolved by:
- Wrapping repeat tile contents in `SingleChildScrollView` and putting `mainAxisSize: MainAxisSize.min` in its child i.e. Column.

## Fixes #434 

## Screenshots

Small Screen Devices   |     Normal Devices
------------------------------- | ------------------------------
<video src="https://github.com/user-attachments/assets/e57ee551-7bd3-4c52-9f72-d7e3a890c07d" width=50%> | <img src="https://github.com/user-attachments/assets/28d75463-8e45-4c6c-bddb-dcf9b2cd093a" width=60%>

## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing