### PR TITLE
Add fix #606: Overflow Issue Resolved 

### DIFF
--- a/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
+++ b/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
@@ -72,7 +72,7 @@ class AddOrUpdateAlarmController extends GetxController {
   final mathsSliderValue = 0.0.obs;
   final mathsDifficulty = Difficulty.Easy.obs;
   final isMathsEnabled = false.obs;
-  final numMathsQuestions = 1.obs;
+  final numMathsQuestions = 0.obs;
   final MapController mapController = MapController();
   final selectedPoint = LatLng(0, 0).obs;
   final RxList markersList = [].obs;

--- a/lib/app/modules/addOrUpdateAlarm/views/maths_challenge_tile.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/maths_challenge_tile.dart
@@ -111,15 +111,15 @@ class MathsChallenge extends StatelessWidget {
                     ],
                   ),
                   Obx(
-                    () => Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 10.0),
+                        () => Padding(
+                      padding: const EdgeInsets.only(bottom: 10.0),
                       child: Row(
                         mainAxisAlignment: MainAxisAlignment.center,
                         crossAxisAlignment: CrossAxisAlignment.center,
                         children: [
                           NumberPicker(
                             value: controller.numMathsQuestions.value,
-                            minValue: 1,
+                            minValue: 0,
                             maxValue: 100,
                             onChanged: (value) {
                               Utils.hapticFeedback();
@@ -152,7 +152,11 @@ class MathsChallenge extends StatelessWidget {
                         ),
                         onPressed: () async {
                           Utils.hapticFeedback();
-                          controller.isMathsEnabled.value = true;
+                          if (controller.numMathsQuestions.value != 0) {
+                            controller.isMathsEnabled.value = true;
+                          } else {
+                            controller.isMathsEnabled.value = false;
+                          }
                           Get.back();
                         },
                       ),
@@ -191,7 +195,7 @@ class MathsChallenge extends StatelessWidget {
             children: [
               Obx(
                 () => Text(
-                  controller.isMathsEnabled == true
+                  controller.isMathsEnabled.value == true
                       ? Utils.getDifficultyLabel(controller.mathsDifficulty.value)
                           .tr
                       : 'Off'.tr,


### PR DESCRIPTION
### Description
This overflow issue was due to `NumberPicker` widget, when the `min` and `value` arguments of this widget were 1 or greater, then it shows this overflow error.

### Proposed Changes
<!-- List the proposed changes introduced by this pull request -->

How I resolved?

- I changed the `min` and default value of `numMathsQuestions` as `0` and `0.obs`, respectively.
- Then, in `Save` button of dialog, it will check for condition, that for setting `controller.isMathsEnabled.value` to `true` the number of questions should be greater than 0. 
- Else, it will remain `false` by default and Maths Challenge will not be enabled until you select number questions to be greater than 0.

## Fixes #606 

## Screenshots
<img src = "https://github.com/user-attachments/assets/2686cbad-c7fc-4241-b8f7-8d8a6ee87c33" width=40%>

## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing