### PR TITLE
Fix: changed the height of container from 3.3 to 3.0

### DIFF
--- a/lib/app/modules/timer/views/timer_animation.dart
+++ b/lib/app/modules/timer/views/timer_animation.dart
@@ -85,7 +85,7 @@ class _TimerAnimatedCardState extends State<TimerAnimatedCard>
         horizontal: 10.0,
       ),
       child: Container(
-        height: context.height / 3.3,
+        height: context.height / 3.0, // changed from 3.3 to 3.0
         width: context.width,
         child: Obx(
           () => Card(
@@ -118,7 +118,7 @@ class _TimerAnimatedCardState extends State<TimerAnimatedCard>
                         left: 25.0,
                         right: 20.0,
                         top: 20.0,
-                        bottom: 20.0,
+                        bottom: 30.0,
                       ),
                       child: Row(
                         mainAxisAlignment: MainAxisAlignment.start,


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this pull request -->
This pull request fixes the "bottom overflowed" issue in the TimerAnimatedCard component of the Flutter timer application by adjusting the height of the container.

### Proposed Changes
<!-- List the proposed changes introduced by this pull request -->
Changed the height calculation of the container in the TimerAnimatedCard widget from context.height / 3.3 to context.height / 3.0.

## Fixes #622 


## Screenshots
![Screenshot 2025-01-21 at 22-08-53 400674248-f805d119-7b23-417c-ab61-db7859b9cc5e jpg (JPEG Image 540 × 1200 pixels) — Scaled (48%)](https://github.com/user-attachments/assets/26fc6286-3272-4123-aa88-6e87c9b791a1)

![Screenshot_2025-01-24-10-39-47-28_a53a7893e903efe7d38a33066bfd52df](https://github.com/user-attachments/assets/8f728f4d-0fe2-4488-920f-f4ce91ff2f0d)


<!-- If applicable, add screenshots or images demonstrating the changes made -->

## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [ ] Code follows the established coding style guidelines
- [ ] All tests are passing