### PR TITLE
fix/644-Guardian-Angel-light-mode-UI-fixed

### DIFF
--- a/lib/app/modules/addOrUpdateAlarm/views/guardian_angel.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/guardian_angel.dart
@@ -85,7 +85,8 @@ class GaurdianAngel extends StatelessWidget {
                             shape: RoundedRectangleBorder(
                               borderRadius: BorderRadius.circular(18),
                             ),
-                            backgroundColor: kprimaryBackgroundColor,
+                            backgroundColor: themeController
+                                .secondaryBackgroundColor.value,
                             child: Padding(
                               padding: const EdgeInsets.all(8.0),
                               child: Column(
@@ -160,7 +161,7 @@ class GaurdianAngel extends StatelessWidget {
                   color: (val == 0 && !controller.isCall.value) ||
                           (val == 1 && controller.isCall.value)
                       ? kprimaryColor
-                      : ksecondaryBackgroundColor,
+                      : kLightPrimaryDisabledTextColor,
                   borderRadius: BorderRadius.circular(20),
                 ),
                 child: Padding(
@@ -202,14 +203,14 @@ class GaurdianAngel extends StatelessWidget {
               },
               child: Container(
                 decoration: BoxDecoration(
-                  color: ksecondaryBackgroundColor,
+                  color: themeController.primaryColor.value,
                   borderRadius: BorderRadius.circular(20),
                 ),
                 child: const Padding(
                   padding: EdgeInsets.all(8.0),
                   child: Icon(
                     Icons.check,
-                    color: kprimaryColor,
+                    color: ksecondaryTextColor,
                   ),
                 ),
               ),


### PR DESCRIPTION
### Description
Fixed the inconsistency in the UI when the app is in light mode. Additionally, enhanced the dark mode UI for a better user experience.

### Proposed Changes

- Adjusted the dialog background color in the Guardian Angel feature to reflect the current theme (light or dark mode).

- Ensured that the text and icons are appropriately colored for both light and dark modes.

## Fixes #644 
Bug: Inconsistent UI in light mode while setting Guardian Angel 

## Screenshots

### Old Light Mode UI 
![light_mode_old_angel](https://github.com/user-attachments/assets/6f900086-e21a-4fd6-abe4-901ab459833c)


### New Light Mode UI 
![light_mode_updated_angel](https://github.com/user-attachments/assets/b6f33f84-6a7c-424e-8c6d-9779c3fb19d1)


### Old Dark Mode UI 
![dark_mode_old_angel](https://github.com/user-attachments/assets/6dddcc86-a410-4cd5-a4a4-d36243650520)


### New Dark Mode UI 
![dark_mode_updated_angel](https://github.com/user-attachments/assets/61883f43-cf66-4dc3-abf8-6966d1cf7dc6)
