### PR TITLE
Add Duplicate Button and Functionality to home_view.dart

### DIFF
--- a/lib/app/data/models/alarm_model.dart
+++ b/lib/app/data/models/alarm_model.dart
@@ -5,6 +5,7 @@ import 'package:cloud_firestore/cloud_firestore.dart' as firestore;
 import 'package:isar/isar.dart';
 import 'package:ultimate_alarm_clock/app/data/models/user_model.dart';
 import 'package:ultimate_alarm_clock/app/utils/utils.dart';
+import 'package:uuid/uuid.dart';
 
 part 'alarm_model.g.dart';
 
@@ -418,5 +419,57 @@ class AlarmModel {
     final rotatedString = s.substring(1) + s[0];
     // Convert the rotated string to a list of boolean values
     return rotatedString.split('').map((c) => c == '1').toList();
+  }
+
+  AlarmModel clone() {
+    return AlarmModel(
+      alarmTime: alarmTime,
+      alarmID: Uuid().v4(), // Generate a new unique ID
+      sharedUserIds: sharedUserIds,
+      ownerId: ownerId,
+      ownerName: ownerName,
+      lastEditedUserId: lastEditedUserId,
+      mutexLock: mutexLock,
+      isEnabled: isEnabled,
+      days: List<bool>.from(days),
+      intervalToAlarm: intervalToAlarm,
+      isActivityEnabled: isActivityEnabled,
+      minutesSinceMidnight: minutesSinceMidnight,
+      isLocationEnabled: isLocationEnabled,
+      isSharedAlarmEnabled: isSharedAlarmEnabled,
+      isWeatherEnabled: isWeatherEnabled,
+      location: location,
+      weatherTypes: List<int>.from(weatherTypes),
+      isMathsEnabled: isMathsEnabled,
+      mathsDifficulty: mathsDifficulty,
+      numMathsQuestions: numMathsQuestions,
+      isShakeEnabled: isShakeEnabled,
+      shakeTimes: shakeTimes,
+      isQrEnabled: isQrEnabled,
+      qrValue: qrValue,
+      isPedometerEnabled: isPedometerEnabled,
+      numberOfSteps: numberOfSteps,
+      activityInterval: activityInterval,
+      offsetDetails: offsetDetails != null ? Map.from(offsetDetails!) : null,
+      mainAlarmTime: mainAlarmTime,
+      label: '$label (Copy)', // Append "(Copy)" to the label
+      isOneTime: isOneTime,
+      snoozeDuration: snoozeDuration,
+      gradient: gradient,
+      ringtoneName: ringtoneName,
+      note: note,
+      deleteAfterGoesOff: deleteAfterGoesOff,
+      showMotivationalQuote: showMotivationalQuote,
+      volMax: volMax,
+      volMin: volMin,
+      activityMonitor: activityMonitor,
+      alarmDate: alarmDate,
+      profile: profile,
+      isGuardian: isGuardian,
+      guardianTimer: guardianTimer,
+      guardian: guardian,
+      isCall: isCall,
+      ringOn: ringOn,
+    );
   }
 }

--- a/lib/app/modules/home/controllers/home_controller.dart
+++ b/lib/app/modules/home/controllers/home_controller.dart
@@ -19,6 +19,7 @@ import 'package:ultimate_alarm_clock/app/data/providers/secure_storage_provider.
 import 'package:ultimate_alarm_clock/app/modules/settings/controllers/theme_controller.dart';
 import 'package:ultimate_alarm_clock/app/utils/constants.dart';
 import 'package:ultimate_alarm_clock/app/utils/utils.dart';
+import 'package:uuid/uuid.dart';
 
 import '../../../data/models/profile_model.dart';
 import '../../../data/providers/google_cloud_api_provider.dart';
@@ -734,5 +735,30 @@ class HomeController extends GetxController {
         guardian: profileModel.value.guardian,
         isCall: profileModel.value.isCall,
         ringOn: false);
+  }
+
+  void duplicateAlarm(AlarmModel alarm) {
+    // Clone the alarm
+    var newAlarm = alarm.clone();
+    // Assign a new unique ID
+    newAlarm.alarmID = Uuid().v4();
+    // Add the new alarm to the database
+    if (newAlarm.isSharedAlarmEnabled) {
+      FirestoreDb.addAlarm(userModel.value, newAlarm);
+    } else {
+      IsarDb.addAlarm(newAlarm);
+    }
+    // Refresh the list of alarms
+    refreshUpcomingAlarms();
+    Get.snackbar(
+      'Alarm duplicated',
+      'The alarm has been duplicated.',
+      duration: const Duration(seconds: 4),
+      snackPosition: SnackPosition.BOTTOM,
+      margin: const EdgeInsets.symmetric(
+        horizontal: 10,
+        vertical: 15,
+      ),
+    );
   }
 }

--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -99,7 +99,9 @@ class HomeView extends GetView<HomeController> {
                                                   .textTheme
                                                   .displaySmall!
                                                   .copyWith(
-                                                    color: themeController.primaryDisabledTextColor.value,
+                                                    color: themeController
+                                                        .primaryDisabledTextColor
+                                                        .value,
                                                     fontSize: 16 *
                                                         controller.scalingFactor
                                                             .value,
@@ -112,10 +114,12 @@ class HomeView extends GetView<HomeController> {
                                                     .textTheme
                                                     .displaySmall!
                                                     .copyWith(
-                                                      color: themeController.primaryTextColor.value
-                                                              .withOpacity(
-                                                              0.75,
-                                                            ),
+                                                      color: themeController
+                                                          .primaryTextColor
+                                                          .value
+                                                          .withOpacity(
+                                                        0.75,
+                                                      ),
                                                       fontSize: 14 *
                                                           controller
                                                               .scalingFactor
@@ -174,10 +178,12 @@ class HomeView extends GetView<HomeController> {
                                                 icon: const Icon(
                                                   Icons.menu,
                                                 ),
-                                                color: themeController.primaryTextColor.value
-                                                        .withOpacity(0.75),
+                                                color: themeController
+                                                    .primaryTextColor.value
+                                                    .withOpacity(0.75),
                                                 iconSize: 27 *
-                                                    controller.scalingFactor.value,
+                                                    controller
+                                                        .scalingFactor.value,
                                               ),
 
                                               //   PopupMenuButton(
@@ -282,8 +288,9 @@ class HomeView extends GetView<HomeController> {
                                                   .clear();
                                             },
                                             icon: const Icon(Icons.close),
-                                            color: themeController.primaryTextColor.value
-                                                    .withOpacity(0.75),
+                                            color: themeController
+                                                .primaryTextColor.value
+                                                .withOpacity(0.75),
                                             iconSize: 27 *
                                                 controller.scalingFactor.value,
                                           ),
@@ -303,7 +310,9 @@ class HomeView extends GetView<HomeController> {
                                                       .textTheme
                                                       .displaySmall!
                                                       .copyWith(
-                                                        color: themeController.primaryDisabledTextColor.value,
+                                                        color: themeController
+                                                            .primaryDisabledTextColor
+                                                            .value,
                                                         fontSize: 16 *
                                                             controller
                                                                 .scalingFactor
@@ -312,7 +321,10 @@ class HomeView extends GetView<HomeController> {
                                                 ),
                                                 Container(
                                                   height: 35,
-                                                  width: MediaQuery.of(context).size.width / 1.2,
+                                                  width: MediaQuery.of(context)
+                                                          .size
+                                                          .width /
+                                                      1.2,
                                                   child: Row(
                                                     children: [
                                                       Obx(() {
@@ -337,10 +349,12 @@ class HomeView extends GetView<HomeController> {
                                                                   .textTheme
                                                                   .displaySmall!
                                                                   .copyWith(
-                                                                    color: themeController.primaryTextColor.value
-                                                                            .withOpacity(
-                                                                            0.75,
-                                                                          ),
+                                                                    color: themeController
+                                                                        .primaryTextColor
+                                                                        .value
+                                                                        .withOpacity(
+                                                                      0.75,
+                                                                    ),
                                                                     fontSize: 14 *
                                                                         controller
                                                                             .scalingFactor
@@ -361,12 +375,14 @@ class HomeView extends GetView<HomeController> {
 
                                                           // Delete button
                                                           SizedBox(
-                                                            width: 30 * controller.scalingFactor.value,
+                                                            width: 30 *
+                                                                controller
+                                                                    .scalingFactor
+                                                                    .value,
                                                           ),
                                                           Obx(
                                                             () => InkWell(
-                                                              onTap:
-                                                                  () async {
+                                                              onTap: () async {
                                                                 // Deleting the alarms
                                                                 await controller
                                                                     .deleteAlarms();
@@ -394,16 +410,19 @@ class HomeView extends GetView<HomeController> {
                                                                 controller
                                                                     .refreshUpcomingAlarms();
                                                               },
-                                                              child:  Icon(
+                                                              child: Icon(
                                                                 Icons.delete,
                                                                 color: controller
-                                                                    .numberOfAlarmsSelected
-                                                                    .value >
-                                                                    0
+                                                                            .numberOfAlarmsSelected
+                                                                            .value >
+                                                                        0
                                                                     ? Colors.red
-                                                                    : themeController.primaryTextColor.value.withOpacity(
-                                                                  0.75,
-                                                                ),
+                                                                    : themeController
+                                                                        .primaryTextColor
+                                                                        .value
+                                                                        .withOpacity(
+                                                                        0.75,
+                                                                      ),
                                                                 size: 27 *
                                                                     controller
                                                                         .scalingFactor
@@ -497,7 +516,9 @@ class HomeView extends GetView<HomeController> {
                                                   .textTheme
                                                   .displaySmall!
                                                   .copyWith(
-                                                    color: themeController.primaryDisabledTextColor.value,
+                                                    color: themeController
+                                                        .primaryDisabledTextColor
+                                                        .value,
                                                   ),
                                             ),
                                           ],
@@ -606,359 +627,335 @@ class HomeView extends GetView<HomeController> {
                                                         ),
                                                       );
 
-                                                Utils.hapticFeedback();
-                                              },
-                                              onLongPressEnd: (details) {
-                                                controller
-                                                    .isAnyAlarmHolded
-                                                    .value = false;
-                                              },
-                                              child: AnimatedContainer(
-                                                duration: const Duration(
-                                                  milliseconds: 600,
-                                                ),
-                                                curve: Curves.easeInOut,
-                                                margin: EdgeInsets.all(
-                                                  controller
-                                                      .isAnyAlarmHolded
-                                                          .value
-                                                      ? 10
-                                                      : 0,
-                                                ),
-                                                child: Center(
-                                                  child: Padding(
-                                                    padding:
-                                                    const EdgeInsets
-                                                        .symmetric(
-                                                      horizontal: 10.0,
-                                                    ),
-                                                    child: Card(
-                                                      color: themeController.secondaryBackgroundColor.value,
-                                                      shape:
-                                                          RoundedRectangleBorder(
-                                                        borderRadius:
-                                                            BorderRadius
-                                                                .circular(
-                                                          18,
-                                                        ),
+                                                      Utils.hapticFeedback();
+                                                    },
+                                                    onLongPressEnd: (details) {
+                                                      controller
+                                                          .isAnyAlarmHolded
+                                                          .value = false;
+                                                    },
+                                                    child: AnimatedContainer(
+                                                      duration: const Duration(
+                                                        milliseconds: 600,
+                                                      ),
+                                                      curve: Curves.easeInOut,
+                                                      margin: EdgeInsets.all(
+                                                        controller
+                                                                .isAnyAlarmHolded
+                                                                .value
+                                                            ? 10
+                                                            : 0,
                                                       ),
                                                       child: Center(
                                                         child: Padding(
                                                           padding:
-                                                              EdgeInsets
-                                                                  .only(
-                                                            left: 25.0,
-                                                            right: controller
-                                                                    .inMultipleSelectMode
-                                                                    .value
-                                                                ? 10.0
-                                                                : 0.0,
-                                                            top: controller
-                                                                    .inMultipleSelectMode
-                                                                    .value
-                                                                ? Utils.isChallengeEnabled(
-                                                                          alarm,
-                                                                        ) ||
-                                                                        Utils.isAutoDismissalEnabled(
-                                                                          alarm,
-                                                                        )
-                                                                    ? 15.0
-                                                                    : 18.0
-                                                                : Utils.isChallengeEnabled(
-                                                                          alarm,
-                                                                        ) ||
-                                                                        Utils.isAutoDismissalEnabled(
-                                                                          alarm,
-                                                                        )
-                                                                    ? 8.0
-                                                                    : 0.0,
-                                                            bottom: controller
-                                                                    .inMultipleSelectMode
-                                                                    .value
-                                                                ? Utils.isChallengeEnabled(
-                                                                          alarm,
-                                                                        ) ||
-                                                                        Utils.isAutoDismissalEnabled(
-                                                                          alarm,
-                                                                        )
-                                                                    ? 15.0
-                                                                    : 18.0
-                                                                : Utils.isChallengeEnabled(
-                                                                          alarm,
-                                                                        ) ||
-                                                                        Utils.isAutoDismissalEnabled(
-                                                                          alarm,
-                                                                        )
-                                                                    ? 8.0
-                                                                    : 0.0,
+                                                              const EdgeInsets
+                                                                  .symmetric(
+                                                            horizontal: 10.0,
                                                           ),
-                                                          child: Row(
-                                                            mainAxisAlignment:
-                                                                MainAxisAlignment
-                                                                    .start,
-                                                            children: [
-                                                              Expanded(
-                                                                flex: 3,
-                                                                child:
-                                                                Column(
+                                                          child: Card(
+                                                            color: themeController
+                                                                .secondaryBackgroundColor
+                                                                .value,
+                                                            shape:
+                                                                RoundedRectangleBorder(
+                                                              borderRadius:
+                                                                  BorderRadius
+                                                                      .circular(
+                                                                18,
+                                                              ),
+                                                            ),
+                                                            child: Center(
+                                                              child: Padding(
+                                                                padding:
+                                                                    EdgeInsets
+                                                                        .only(
+                                                                  left: 25.0,
+                                                                  right: controller
+                                                                          .inMultipleSelectMode
+                                                                          .value
+                                                                      ? 10.0
+                                                                      : 0.0,
+                                                                  top: controller
+                                                                          .inMultipleSelectMode
+                                                                          .value
+                                                                      ? Utils.isChallengeEnabled(
+                                                                                alarm,
+                                                                              ) ||
+                                                                              Utils.isAutoDismissalEnabled(
+                                                                                alarm,
+                                                                              )
+                                                                          ? 15.0
+                                                                          : 18.0
+                                                                      : Utils.isChallengeEnabled(
+                                                                                alarm,
+                                                                              ) ||
+                                                                              Utils.isAutoDismissalEnabled(
+                                                                                alarm,
+                                                                              )
+                                                                          ? 8.0
+                                                                          : 0.0,
+                                                                  bottom: controller
+                                                                          .inMultipleSelectMode
+                                                                          .value
+                                                                      ? Utils.isChallengeEnabled(
+                                                                                alarm,
+                                                                              ) ||
+                                                                              Utils.isAutoDismissalEnabled(
+                                                                                alarm,
+                                                                              )
+                                                                          ? 15.0
+                                                                          : 18.0
+                                                                      : Utils.isChallengeEnabled(
+                                                                                alarm,
+                                                                              ) ||
+                                                                              Utils.isAutoDismissalEnabled(
+                                                                                alarm,
+                                                                              )
+                                                                          ? 8.0
+                                                                          : 0.0,
+                                                                ),
+                                                                child: Row(
                                                                   mainAxisAlignment:
-                                                                      MainAxisAlignment.center,
-                                                                  crossAxisAlignment:
-                                                                      CrossAxisAlignment.start,
+                                                                      MainAxisAlignment
+                                                                          .start,
                                                                   children: [
-                                                                    IntrinsicHeight(
+                                                                    Expanded(
+                                                                      flex: 3,
                                                                       child:
-                                                                          Row(
+                                                                          Column(
+                                                                        mainAxisAlignment:
+                                                                            MainAxisAlignment.center,
+                                                                        crossAxisAlignment:
+                                                                            CrossAxisAlignment.start,
                                                                         children: [
-                                                                          Text(
-                                                                            repeatDays.replaceAll(
-                                                                              'Never'.tr,
-                                                                              'One Time'.tr,
-                                                                            ),
-                                                                            style: Theme.of(context).textTheme.bodySmall!.copyWith(
-                                                                                  fontWeight: FontWeight.w500,
-                                                                                  color: alarm.isEnabled == true
-                                                                                      ? kprimaryColor
-                                                                                      : themeController.primaryDisabledTextColor.value,
+                                                                          IntrinsicHeight(
+                                                                            child:
+                                                                                Row(
+                                                                              children: [
+                                                                                Text(
+                                                                                  repeatDays.replaceAll(
+                                                                                    'Never'.tr,
+                                                                                    'One Time'.tr,
+                                                                                  ),
+                                                                                  style: Theme.of(context).textTheme.bodySmall!.copyWith(
+                                                                                        fontWeight: FontWeight.w500,
+                                                                                        color: alarm.isEnabled == true ? kprimaryColor : themeController.primaryDisabledTextColor.value,
+                                                                                      ),
                                                                                 ),
-                                                                          ),
-                                                                          if (alarm.label.isNotEmpty)
-                                                                            VerticalDivider(
-                                                                              color: alarm.isEnabled == true
-                                                                                  ? kprimaryColor
-                                                                                  : themeController.primaryDisabledTextColor.value,
-                                                                              thickness: 1.4,
-                                                                              width: 6,
-                                                                              indent: 3.1,
-                                                                              endIndent: 3.1,
+                                                                                if (alarm.label.isNotEmpty)
+                                                                                  VerticalDivider(
+                                                                                    color: alarm.isEnabled == true ? kprimaryColor : themeController.primaryDisabledTextColor.value,
+                                                                                    thickness: 1.4,
+                                                                                    width: 6,
+                                                                                    indent: 3.1,
+                                                                                    endIndent: 3.1,
+                                                                                  ),
+                                                                                Expanded(
+                                                                                  child: Container(
+                                                                                    child: Text(
+                                                                                      alarm.label,
+                                                                                      overflow: TextOverflow.ellipsis,
+                                                                                      // Set overflow property here
+                                                                                      style: Theme.of(context).textTheme.bodySmall!.copyWith(
+                                                                                            fontWeight: FontWeight.w500,
+                                                                                            color: alarm.isEnabled == true ? kprimaryColor : themeController.primaryDisabledTextColor.value,
+                                                                                          ),
+                                                                                    ),
+                                                                                  ),
+                                                                                ),
+                                                                              ],
                                                                             ),
-                                                                          Expanded(
-                                                                            child: Container(
-                                                                              child: Text(
-                                                                                alarm.label,
-                                                                                overflow: TextOverflow.ellipsis,
-                                                                                // Set overflow property here
-                                                                                style: Theme.of(context).textTheme.bodySmall!.copyWith(
-                                                                                      fontWeight: FontWeight.w500,
-                                                                                      color: alarm.isEnabled == true
-                                                                                          ? kprimaryColor
-                                                                                          : themeController.primaryDisabledTextColor.value,
+                                                                          ),
+                                                                          Row(
+                                                                            children: [
+                                                                              Text(
+                                                                                (settingsController.is24HrsEnabled.value
+                                                                                    ? Utils.split24HourFormat(alarm.alarmTime)
+                                                                                    : Utils.convertTo12HourFormat(
+                                                                                        alarm.alarmTime,
+                                                                                      ))[0],
+                                                                                style: Theme.of(
+                                                                                  context,
+                                                                                ).textTheme.displayLarge!.copyWith(
+                                                                                      color: alarm.isEnabled == true ? themeController.primaryTextColor.value : themeController.primaryDisabledTextColor.value,
                                                                                     ),
                                                                               ),
-                                                                            ),
-                                                                          ),
-                                                                        ],
-                                                                      ),
-                                                                    ),
-                                                                    Row(
-                                                                      children: [
-                                                                        Text(
-                                                                          (settingsController.is24HrsEnabled.value
-                                                                              ? Utils.split24HourFormat(alarm.alarmTime)
-                                                                              : Utils.convertTo12HourFormat(
-                                                                                  alarm.alarmTime,
-                                                                                ))[0],
-                                                                          style: Theme.of(
-                                                                            context,
-                                                                          ).textTheme.displayLarge!.copyWith(
-                                                                                color: alarm.isEnabled == true
-                                                                                    ? themeController.primaryTextColor.value
-                                                                                    : themeController.primaryDisabledTextColor.value,
-                                                                              ),
-                                                                        ),
-                                                                        Padding(
-                                                                          padding: const EdgeInsets.symmetric(
-                                                                            horizontal: 3.0,
-                                                                          ),
-                                                                          child: Text(
-                                                                            (settingsController.is24HrsEnabled.value
-                                                                                ? Utils.split24HourFormat(alarm.alarmTime)
-                                                                                : Utils.convertTo12HourFormat(
-                                                                                    alarm.alarmTime,
-                                                                                  ))[1],
-                                                                            style: Theme.of(context).textTheme.displayMedium!.copyWith(
-                                                                                  color: alarm.isEnabled == true
-                                                                                      ? themeController.primaryTextColor.value
-                                                                                      : themeController.primaryDisabledTextColor.value,
+                                                                              Padding(
+                                                                                padding: const EdgeInsets.symmetric(
+                                                                                  horizontal: 3.0,
                                                                                 ),
+                                                                                child: Text(
+                                                                                  (settingsController.is24HrsEnabled.value
+                                                                                      ? Utils.split24HourFormat(alarm.alarmTime)
+                                                                                      : Utils.convertTo12HourFormat(
+                                                                                          alarm.alarmTime,
+                                                                                        ))[1],
+                                                                                  style: Theme.of(context).textTheme.displayMedium!.copyWith(
+                                                                                        color: alarm.isEnabled == true ? themeController.primaryTextColor.value : themeController.primaryDisabledTextColor.value,
+                                                                                      ),
+                                                                                ),
+                                                                              ),
+                                                                            ],
                                                                           ),
-                                                                        ),
-                                                                      ],
-                                                                    ),
-                                                                    if (Utils.isChallengeEnabled(
-                                                                          alarm,
-                                                                        ) ||
-                                                                        Utils.isAutoDismissalEnabled(
-                                                                          alarm,
-                                                                        ) ||
-                                                                        alarm.isSharedAlarmEnabled)
-                                                                      Row(
-                                                                        mainAxisAlignment: MainAxisAlignment.start,
-                                                                        children: [
-                                                                          if (alarm.isSharedAlarmEnabled)
-                                                                            Padding(
-                                                                              padding: const EdgeInsets.symmetric(
-                                                                                horizontal: 3.0,
-                                                                              ),
-                                                                              child: Icon(
-                                                                                Icons.share_arrival_time,
-                                                                                size: 24,
-                                                                                color: alarm.isEnabled == true
-                                                                                    ? themeController.primaryTextColor.value.withOpacity(0.5)
-                                                                                    : themeController.primaryDisabledTextColor.value,
-                                                                              ),
-                                                                            ),
-                                                                          if (alarm.isLocationEnabled)
-                                                                            Padding(
-                                                                              padding: const EdgeInsets.symmetric(
-                                                                                horizontal: 3.0,
-                                                                              ),
-                                                                              child: Icon(
-                                                                                Icons.location_pin,
-                                                                                size: 24,
-                                                                                color: alarm.isEnabled == true
-                                                                                    ? themeController.primaryTextColor.value.withOpacity(0.5)
-                                                                                    : themeController.primaryDisabledTextColor.value,
-                                                                              ),
-                                                                            ),
-                                                                          if (alarm.isActivityEnabled)
-                                                                            Padding(
-                                                                              padding: const EdgeInsets.symmetric(
-                                                                                horizontal: 3.0,
-                                                                              ),
-                                                                              child: Icon(
-                                                                                Icons.screen_lock_portrait,
-                                                                                size: 24,
-                                                                                color: alarm.isEnabled == true
-                                                                                    ? themeController.primaryTextColor.value.withOpacity(0.5)
-                                                                                    : themeController.primaryDisabledTextColor.value,
-                                                                              ),
-                                                                            ),
-                                                                          if (alarm.isWeatherEnabled)
-                                                                            Padding(
-                                                                              padding: const EdgeInsets.symmetric(
-                                                                                horizontal: 3.0,
-                                                                              ),
-                                                                              child: Icon(
-                                                                                Icons.cloudy_snowing,
-                                                                                size: 24,
-                                                                                color: alarm.isEnabled == true
-                                                                                    ? themeController.primaryTextColor.value.withOpacity(0.5)
-                                                                                    : themeController.primaryDisabledTextColor.value,
-                                                                              ),
-                                                                            ),
-                                                                          if (alarm.isQrEnabled)
-                                                                            Padding(
-                                                                              padding: const EdgeInsets.symmetric(
-                                                                                horizontal: 3.0,
-                                                                              ),
-                                                                              child: Icon(
-                                                                                Icons.qr_code_scanner,
-                                                                                size: 24,
-                                                                                color: alarm.isEnabled == true
-                                                                                    ? themeController.primaryTextColor.value.withOpacity(0.5)
-                                                                                    : themeController.primaryDisabledTextColor.value,
-                                                                              ),
-                                                                            ),
-                                                                          if (alarm.isShakeEnabled)
-                                                                            Padding(
-                                                                              padding: const EdgeInsets.symmetric(
-                                                                                horizontal: 3.0,
-                                                                              ),
-                                                                              child: Icon(
-                                                                                Icons.vibration,
-                                                                                size: 24,
-                                                                                color: alarm.isEnabled == true
-                                                                                    ? themeController.primaryTextColor.value.withOpacity(0.5)
-                                                                                    : themeController.primaryDisabledTextColor.value,
-                                                                              ),
-                                                                            ),
-                                                                          if (alarm.isMathsEnabled)
-                                                                            Padding(
-                                                                              padding: const EdgeInsets.symmetric(
-                                                                                horizontal: 3.0,
-                                                                              ),
-                                                                              child: Icon(
-                                                                                Icons.calculate,
-                                                                                size: 24,
-                                                                                color: alarm.isEnabled == true
-                                                                                    ? themeController.primaryTextColor.value.withOpacity(0.5)
-                                                                                    : themeController.primaryDisabledTextColor.value,
-                                                                              ),
-                                                                            ),
-                                                                          if (alarm.isPedometerEnabled)
-                                                                            Padding(
-                                                                              padding: const EdgeInsets.symmetric(
-                                                                                horizontal: 3.0,
-                                                                              ),
-                                                                              child: Icon(
-                                                                                Icons.directions_walk,
-                                                                                size: 24,
-                                                                                color: alarm.isEnabled == true
-                                                                                    ? themeController.primaryTextColor.value.withOpacity(0.5)
-                                                                                    : themeController.primaryDisabledTextColor.value,
-                                                                              ),
+                                                                          if (Utils.isChallengeEnabled(
+                                                                                alarm,
+                                                                              ) ||
+                                                                              Utils.isAutoDismissalEnabled(
+                                                                                alarm,
+                                                                              ) ||
+                                                                              alarm.isSharedAlarmEnabled)
+                                                                            Row(
+                                                                              mainAxisAlignment: MainAxisAlignment.start,
+                                                                              children: [
+                                                                                if (alarm.isSharedAlarmEnabled)
+                                                                                  Padding(
+                                                                                    padding: const EdgeInsets.symmetric(
+                                                                                      horizontal: 3.0,
+                                                                                    ),
+                                                                                    child: Icon(
+                                                                                      Icons.share_arrival_time,
+                                                                                      size: 24,
+                                                                                      color: alarm.isEnabled == true ? themeController.primaryTextColor.value.withOpacity(0.5) : themeController.primaryDisabledTextColor.value,
+                                                                                    ),
+                                                                                  ),
+                                                                                if (alarm.isLocationEnabled)
+                                                                                  Padding(
+                                                                                    padding: const EdgeInsets.symmetric(
+                                                                                      horizontal: 3.0,
+                                                                                    ),
+                                                                                    child: Icon(
+                                                                                      Icons.location_pin,
+                                                                                      size: 24,
+                                                                                      color: alarm.isEnabled == true ? themeController.primaryTextColor.value.withOpacity(0.5) : themeController.primaryDisabledTextColor.value,
+                                                                                    ),
+                                                                                  ),
+                                                                                if (alarm.isActivityEnabled)
+                                                                                  Padding(
+                                                                                    padding: const EdgeInsets.symmetric(
+                                                                                      horizontal: 3.0,
+                                                                                    ),
+                                                                                    child: Icon(
+                                                                                      Icons.screen_lock_portrait,
+                                                                                      size: 24,
+                                                                                      color: alarm.isEnabled == true ? themeController.primaryTextColor.value.withOpacity(0.5) : themeController.primaryDisabledTextColor.value,
+                                                                                    ),
+                                                                                  ),
+                                                                                if (alarm.isWeatherEnabled)
+                                                                                  Padding(
+                                                                                    padding: const EdgeInsets.symmetric(
+                                                                                      horizontal: 3.0,
+                                                                                    ),
+                                                                                    child: Icon(
+                                                                                      Icons.cloudy_snowing,
+                                                                                      size: 24,
+                                                                                      color: alarm.isEnabled == true ? themeController.primaryTextColor.value.withOpacity(0.5) : themeController.primaryDisabledTextColor.value,
+                                                                                    ),
+                                                                                  ),
+                                                                                if (alarm.isQrEnabled)
+                                                                                  Padding(
+                                                                                    padding: const EdgeInsets.symmetric(
+                                                                                      horizontal: 3.0,
+                                                                                    ),
+                                                                                    child: Icon(
+                                                                                      Icons.qr_code_scanner,
+                                                                                      size: 24,
+                                                                                      color: alarm.isEnabled == true ? themeController.primaryTextColor.value.withOpacity(0.5) : themeController.primaryDisabledTextColor.value,
+                                                                                    ),
+                                                                                  ),
+                                                                                if (alarm.isShakeEnabled)
+                                                                                  Padding(
+                                                                                    padding: const EdgeInsets.symmetric(
+                                                                                      horizontal: 3.0,
+                                                                                    ),
+                                                                                    child: Icon(
+                                                                                      Icons.vibration,
+                                                                                      size: 24,
+                                                                                      color: alarm.isEnabled == true ? themeController.primaryTextColor.value.withOpacity(0.5) : themeController.primaryDisabledTextColor.value,
+                                                                                    ),
+                                                                                  ),
+                                                                                if (alarm.isMathsEnabled)
+                                                                                  Padding(
+                                                                                    padding: const EdgeInsets.symmetric(
+                                                                                      horizontal: 3.0,
+                                                                                    ),
+                                                                                    child: Icon(
+                                                                                      Icons.calculate,
+                                                                                      size: 24,
+                                                                                      color: alarm.isEnabled == true ? themeController.primaryTextColor.value.withOpacity(0.5) : themeController.primaryDisabledTextColor.value,
+                                                                                    ),
+                                                                                  ),
+                                                                                if (alarm.isPedometerEnabled)
+                                                                                  Padding(
+                                                                                    padding: const EdgeInsets.symmetric(
+                                                                                      horizontal: 3.0,
+                                                                                    ),
+                                                                                    child: Icon(
+                                                                                      Icons.directions_walk,
+                                                                                      size: 24,
+                                                                                      color: alarm.isEnabled == true ? themeController.primaryTextColor.value.withOpacity(0.5) : themeController.primaryDisabledTextColor.value,
+                                                                                    ),
+                                                                                  ),
+                                                                              ],
                                                                             ),
                                                                         ],
                                                                       ),
-                                                                  ],
-                                                                ),
-                                                              ),
-                                                              Padding(
-                                                                padding:
-                                                                    const EdgeInsets
-                                                                        .symmetric(
-                                                                  horizontal:
-                                                                      10.0,
-                                                                ),
-                                                                child: controller
-                                                                        .inMultipleSelectMode
-                                                                        .value
-                                                                    ? Column(
-                                                                        // Showing the toggle button
-                                                                        mainAxisAlignment: MainAxisAlignment.center,
-                                                                        children: [
-                                                                          Expanded(
-                                                                            flex: 0,
-                                                                            child: ToggleButton(
-                                                                              controller: controller,
-                                                                              alarmIndex: index,
-                                                                            ),
-                                                                          ),
-                                                                        ],
-                                                                      )
-                                                                    : Column(
-                                                                        // Showing the switch and pop up menu button
-                                                                        mainAxisAlignment: MainAxisAlignment.center,
-                                                                        children: [
-                                                                          Expanded(
-                                                                            flex: 0,
-                                                                            child: Switch.adaptive(
-                                                                              activeColor: ksecondaryColor,
-                                                                              value: alarm.isEnabled,
-                                                                              onChanged: (bool value) async {
-                                                                                Utils.hapticFeedback();
-                                                                                alarm.isEnabled = value;
-                                                                                if (alarm.isSharedAlarmEnabled == true) {
-                                                                                  await FirestoreDb.updateAlarm(alarm.ownerId, alarm);
-                                                                                } else {
-                                                                                  await IsarDb.updateAlarm(alarm);
-                                                                                }
-                                                                                controller.refreshTimer = true;
-                                                                                controller.refreshUpcomingAlarms();
-                                                                              },
-                                                                            ),
-                                                                          ),
-                                                                          Expanded(
-                                                                            flex: 0,
-                                                                            child: PopupMenuButton(
-                                                                              onSelected: (value) async {
-                                                                                Utils.hapticFeedback();
-                                                                                if (value == 0) {
-                                                                                  Get.back();
-                                                                                  Get.offNamed('/alarm-ring', arguments: alarm);
-                                                                                } else if (value == 1) {
-                                                                                  debugPrint(alarm.isSharedAlarmEnabled.toString());
+                                                                    ),
+                                                                    Padding(
+                                                                      padding:
+                                                                          const EdgeInsets
+                                                                              .symmetric(
+                                                                        horizontal:
+                                                                            10.0,
+                                                                      ),
+                                                                      child: controller
+                                                                              .inMultipleSelectMode
+                                                                              .value
+                                                                          ? Column(
+                                                                              // Showing the toggle button
+                                                                              mainAxisAlignment: MainAxisAlignment.center,
+                                                                              children: [
+                                                                                Expanded(
+                                                                                  flex: 0,
+                                                                                  child: ToggleButton(
+                                                                                    controller: controller,
+                                                                                    alarmIndex: index,
+                                                                                  ),
+                                                                                ),
+                                                                              ],
+                                                                            )
+                                                                          : Column(
+                                                                              // Showing the switch and pop up menu button
+                                                                              mainAxisAlignment: MainAxisAlignment.center,
+                                                                              children: [
+                                                                                Expanded(
+                                                                                  flex: 0,
+                                                                                  child: Switch.adaptive(
+                                                                                    activeColor: ksecondaryColor,
+                                                                                    value: alarm.isEnabled,
+                                                                                    onChanged: (bool value) async {
+                                                                                      Utils.hapticFeedback();
+                                                                                      alarm.isEnabled = value;
+                                                                                      if (alarm.isSharedAlarmEnabled == true) {
+                                                                                        await FirestoreDb.updateAlarm(alarm.ownerId, alarm);
+                                                                                      } else {
+                                                                                        await IsarDb.updateAlarm(alarm);
+                                                                                      }
+                                                                                      controller.refreshTimer = true;
+                                                                                      controller.refreshUpcomingAlarms();
+                                                                                    },
+                                                                                  ),
+                                                                                ),
+                                                                                Expanded(
+                                                                                  flex: 0,
+                                                                                  child: PopupMenuButton(
+                                                                                    onSelected: (value) async {
+                                                                                      Utils.hapticFeedback();
+                                                                                      if (value == 0) {
+                                                                                        Get.back();
+                                                                                        Get.offNamed('/alarm-ring', arguments: alarm);
+                                                                                      } else if (value == 1) {
+                                                                                        debugPrint(alarm.isSharedAlarmEnabled.toString());
 
                                                                                         if (alarm.isSharedAlarmEnabled == true) {
                                                                                           await FirestoreDb.deleteAlarm(controller.userModel.value, alarm.firestoreId!);
@@ -998,55 +995,63 @@ class HomeView extends GetView<HomeController> {
                                                                                           counterUpdate: CounterUpdate.decrement,
                                                                                         );
 
-                                                                                  controller.refreshTimer = true;
-                                                                                  controller.refreshUpcomingAlarms();
-                                                                                }
-                                                                              },
-                                                                              color: themeController.primaryBackgroundColor.value,
-                                                                              icon: Icon(
-                                                                                Icons.more_vert,
-                                                                                color: alarm.isEnabled == true
-                                                                                    ? themeController.primaryTextColor.value
-                                                                                    : themeController.primaryDisabledTextColor.value,
-                                                                              ),
-                                                                              itemBuilder: (context) {
-                                                                                return [
-                                                                                  PopupMenuItem<int>(
-                                                                                    value: 0,
-                                                                                    child: Text(
-                                                                                      'Preview Alarm'.tr,
-                                                                                      style: Theme.of(context).textTheme.bodyMedium,
+                                                                                        controller.refreshTimer = true;
+                                                                                        controller.refreshUpcomingAlarms();
+                                                                                      } else if (value == 2) {
+                                                                                        // Duplicate Alarm option
+                                                                                        controller.duplicateAlarm(alarm);
+                                                                                      }
+                                                                                    },
+                                                                                    color: themeController.primaryBackgroundColor.value,
+                                                                                    icon: Icon(
+                                                                                      Icons.more_vert,
+                                                                                      color: alarm.isEnabled == true ? themeController.primaryTextColor.value : themeController.primaryDisabledTextColor.value,
                                                                                     ),
-                                                                                  ),
-                                                                                  if (alarm.isSharedAlarmEnabled == false || (alarm.isSharedAlarmEnabled == true && alarm.ownerId == controller.userModel.value!.id))
-                                                                                    PopupMenuItem<int>(
-                                                                                      value: 1,
-                                                                                      child: Text(
-                                                                                        'Delete Alarm'.tr,
-                                                                                        style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                                                                                              color: Colors.red,
+                                                                                    itemBuilder: (context) {
+                                                                                      return [
+                                                                                        PopupMenuItem<int>(
+                                                                                          value: 0,
+                                                                                          child: Text(
+                                                                                            'Preview Alarm'.tr,
+                                                                                            style: Theme.of(context).textTheme.bodyMedium,
+                                                                                          ),
+                                                                                        ),
+                                                                                        PopupMenuItem<int>(
+                                                                                          value: 2,
+                                                                                          child: Text(
+                                                                                            'Duplicate Alarm'.tr,
+                                                                                            style: Theme.of(context).textTheme.bodyMedium,
+                                                                                          ),
+                                                                                        ),
+                                                                                        if (alarm.isSharedAlarmEnabled == false || (alarm.isSharedAlarmEnabled == true && alarm.ownerId == controller.userModel.value!.id))
+                                                                                          PopupMenuItem<int>(
+                                                                                            value: 1,
+                                                                                            child: Text(
+                                                                                              'Delete Alarm'.tr,
+                                                                                              style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                                                                                                    color: Colors.red,
+                                                                                                  ),
                                                                                             ),
-                                                                                      ),
-                                                                                    ),
-                                                                                ];
-                                                                              },
+                                                                                          ),
+                                                                                      ];
+                                                                                    },
+                                                                                  ),
+                                                                                ),
+                                                                              ],
                                                                             ),
-                                                                          ),
-                                                                        ],
-                                                                      ),
+                                                                    ),
+                                                                  ],
+                                                                ),
                                                               ),
-                                                            ],
+                                                            ),
                                                           ),
                                                         ),
                                                       ),
                                                     ),
                                                   ),
                                                 ),
-                                              ),
-                                            ),
-                                          ),
-                                        )
-                                      : SizedBox();
+                                              )
+                                            : SizedBox();
                                       },
                                     );
                                   }

--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -99,9 +99,7 @@ class HomeView extends GetView<HomeController> {
                                                   .textTheme
                                                   .displaySmall!
                                                   .copyWith(
-                                                    color: themeController
-                                                        .primaryDisabledTextColor
-                                                        .value,
+                                                    color: themeController.primaryDisabledTextColor.value,
                                                     fontSize: 16 *
                                                         controller.scalingFactor
                                                             .value,
@@ -114,12 +112,10 @@ class HomeView extends GetView<HomeController> {
                                                     .textTheme
                                                     .displaySmall!
                                                     .copyWith(
-                                                      color: themeController
-                                                          .primaryTextColor
-                                                          .value
-                                                          .withOpacity(
-                                                        0.75,
-                                                      ),
+                                                      color: themeController.primaryTextColor.value
+                                                              .withOpacity(
+                                                              0.75,
+                                                            ),
                                                       fontSize: 14 *
                                                           controller
                                                               .scalingFactor
@@ -178,12 +174,10 @@ class HomeView extends GetView<HomeController> {
                                                 icon: const Icon(
                                                   Icons.menu,
                                                 ),
-                                                color: themeController
-                                                    .primaryTextColor.value
-                                                    .withOpacity(0.75),
+                                                color: themeController.primaryTextColor.value
+                                                        .withOpacity(0.75),
                                                 iconSize: 27 *
-                                                    controller
-                                                        .scalingFactor.value,
+                                                    controller.scalingFactor.value,
                                               ),
 
                                               //   PopupMenuButton(
@@ -288,9 +282,8 @@ class HomeView extends GetView<HomeController> {
                                                   .clear();
                                             },
                                             icon: const Icon(Icons.close),
-                                            color: themeController
-                                                .primaryTextColor.value
-                                                .withOpacity(0.75),
+                                            color: themeController.primaryTextColor.value
+                                                    .withOpacity(0.75),
                                             iconSize: 27 *
                                                 controller.scalingFactor.value,
                                           ),
@@ -310,9 +303,7 @@ class HomeView extends GetView<HomeController> {
                                                       .textTheme
                                                       .displaySmall!
                                                       .copyWith(
-                                                        color: themeController
-                                                            .primaryDisabledTextColor
-                                                            .value,
+                                                        color: themeController.primaryDisabledTextColor.value,
                                                         fontSize: 16 *
                                                             controller
                                                                 .scalingFactor
@@ -321,10 +312,7 @@ class HomeView extends GetView<HomeController> {
                                                 ),
                                                 Container(
                                                   height: 35,
-                                                  width: MediaQuery.of(context)
-                                                          .size
-                                                          .width /
-                                                      1.2,
+                                                  width: MediaQuery.of(context).size.width / 1.2,
                                                   child: Row(
                                                     children: [
                                                       Obx(() {
@@ -349,12 +337,10 @@ class HomeView extends GetView<HomeController> {
                                                                   .textTheme
                                                                   .displaySmall!
                                                                   .copyWith(
-                                                                    color: themeController
-                                                                        .primaryTextColor
-                                                                        .value
-                                                                        .withOpacity(
-                                                                      0.75,
-                                                                    ),
+                                                                    color: themeController.primaryTextColor.value
+                                                                            .withOpacity(
+                                                                            0.75,
+                                                                          ),
                                                                     fontSize: 14 *
                                                                         controller
                                                                             .scalingFactor
@@ -375,14 +361,12 @@ class HomeView extends GetView<HomeController> {
 
                                                           // Delete button
                                                           SizedBox(
-                                                            width: 30 *
-                                                                controller
-                                                                    .scalingFactor
-                                                                    .value,
+                                                            width: 30 * controller.scalingFactor.value,
                                                           ),
                                                           Obx(
                                                             () => InkWell(
-                                                              onTap: () async {
+                                                              onTap:
+                                                                  () async {
                                                                 // Deleting the alarms
                                                                 await controller
                                                                     .deleteAlarms();
@@ -410,19 +394,16 @@ class HomeView extends GetView<HomeController> {
                                                                 controller
                                                                     .refreshUpcomingAlarms();
                                                               },
-                                                              child: Icon(
+                                                              child:  Icon(
                                                                 Icons.delete,
                                                                 color: controller
-                                                                            .numberOfAlarmsSelected
-                                                                            .value >
-                                                                        0
+                                                                    .numberOfAlarmsSelected
+                                                                    .value >
+                                                                    0
                                                                     ? Colors.red
-                                                                    : themeController
-                                                                        .primaryTextColor
-                                                                        .value
-                                                                        .withOpacity(
-                                                                        0.75,
-                                                                      ),
+                                                                    : themeController.primaryTextColor.value.withOpacity(
+                                                                  0.75,
+                                                                ),
                                                                 size: 27 *
                                                                     controller
                                                                         .scalingFactor
@@ -516,9 +497,7 @@ class HomeView extends GetView<HomeController> {
                                                   .textTheme
                                                   .displaySmall!
                                                   .copyWith(
-                                                    color: themeController
-                                                        .primaryDisabledTextColor
-                                                        .value,
+                                                    color: themeController.primaryDisabledTextColor.value,
                                                   ),
                                             ),
                                           ],
@@ -627,335 +606,359 @@ class HomeView extends GetView<HomeController> {
                                                         ),
                                                       );
 
-                                                      Utils.hapticFeedback();
-                                                    },
-                                                    onLongPressEnd: (details) {
-                                                      controller
-                                                          .isAnyAlarmHolded
-                                                          .value = false;
-                                                    },
-                                                    child: AnimatedContainer(
-                                                      duration: const Duration(
-                                                        milliseconds: 600,
-                                                      ),
-                                                      curve: Curves.easeInOut,
-                                                      margin: EdgeInsets.all(
-                                                        controller
-                                                                .isAnyAlarmHolded
-                                                                .value
-                                                            ? 10
-                                                            : 0,
+                                                Utils.hapticFeedback();
+                                              },
+                                              onLongPressEnd: (details) {
+                                                controller
+                                                    .isAnyAlarmHolded
+                                                    .value = false;
+                                              },
+                                              child: AnimatedContainer(
+                                                duration: const Duration(
+                                                  milliseconds: 600,
+                                                ),
+                                                curve: Curves.easeInOut,
+                                                margin: EdgeInsets.all(
+                                                  controller
+                                                      .isAnyAlarmHolded
+                                                          .value
+                                                      ? 10
+                                                      : 0,
+                                                ),
+                                                child: Center(
+                                                  child: Padding(
+                                                    padding:
+                                                    const EdgeInsets
+                                                        .symmetric(
+                                                      horizontal: 10.0,
+                                                    ),
+                                                    child: Card(
+                                                      color: themeController.secondaryBackgroundColor.value,
+                                                      shape:
+                                                          RoundedRectangleBorder(
+                                                        borderRadius:
+                                                            BorderRadius
+                                                                .circular(
+                                                          18,
+                                                        ),
                                                       ),
                                                       child: Center(
                                                         child: Padding(
                                                           padding:
-                                                              const EdgeInsets
-                                                                  .symmetric(
-                                                            horizontal: 10.0,
+                                                              EdgeInsets
+                                                                  .only(
+                                                            left: 25.0,
+                                                            right: controller
+                                                                    .inMultipleSelectMode
+                                                                    .value
+                                                                ? 10.0
+                                                                : 0.0,
+                                                            top: controller
+                                                                    .inMultipleSelectMode
+                                                                    .value
+                                                                ? Utils.isChallengeEnabled(
+                                                                          alarm,
+                                                                        ) ||
+                                                                        Utils.isAutoDismissalEnabled(
+                                                                          alarm,
+                                                                        )
+                                                                    ? 15.0
+                                                                    : 18.0
+                                                                : Utils.isChallengeEnabled(
+                                                                          alarm,
+                                                                        ) ||
+                                                                        Utils.isAutoDismissalEnabled(
+                                                                          alarm,
+                                                                        )
+                                                                    ? 8.0
+                                                                    : 0.0,
+                                                            bottom: controller
+                                                                    .inMultipleSelectMode
+                                                                    .value
+                                                                ? Utils.isChallengeEnabled(
+                                                                          alarm,
+                                                                        ) ||
+                                                                        Utils.isAutoDismissalEnabled(
+                                                                          alarm,
+                                                                        )
+                                                                    ? 15.0
+                                                                    : 18.0
+                                                                : Utils.isChallengeEnabled(
+                                                                          alarm,
+                                                                        ) ||
+                                                                        Utils.isAutoDismissalEnabled(
+                                                                          alarm,
+                                                                        )
+                                                                    ? 8.0
+                                                                    : 0.0,
                                                           ),
-                                                          child: Card(
-                                                            color: themeController
-                                                                .secondaryBackgroundColor
-                                                                .value,
-                                                            shape:
-                                                                RoundedRectangleBorder(
-                                                              borderRadius:
-                                                                  BorderRadius
-                                                                      .circular(
-                                                                18,
-                                                              ),
-                                                            ),
-                                                            child: Center(
-                                                              child: Padding(
-                                                                padding:
-                                                                    EdgeInsets
-                                                                        .only(
-                                                                  left: 25.0,
-                                                                  right: controller
-                                                                          .inMultipleSelectMode
-                                                                          .value
-                                                                      ? 10.0
-                                                                      : 0.0,
-                                                                  top: controller
-                                                                          .inMultipleSelectMode
-                                                                          .value
-                                                                      ? Utils.isChallengeEnabled(
-                                                                                alarm,
-                                                                              ) ||
-                                                                              Utils.isAutoDismissalEnabled(
-                                                                                alarm,
-                                                                              )
-                                                                          ? 15.0
-                                                                          : 18.0
-                                                                      : Utils.isChallengeEnabled(
-                                                                                alarm,
-                                                                              ) ||
-                                                                              Utils.isAutoDismissalEnabled(
-                                                                                alarm,
-                                                                              )
-                                                                          ? 8.0
-                                                                          : 0.0,
-                                                                  bottom: controller
-                                                                          .inMultipleSelectMode
-                                                                          .value
-                                                                      ? Utils.isChallengeEnabled(
-                                                                                alarm,
-                                                                              ) ||
-                                                                              Utils.isAutoDismissalEnabled(
-                                                                                alarm,
-                                                                              )
-                                                                          ? 15.0
-                                                                          : 18.0
-                                                                      : Utils.isChallengeEnabled(
-                                                                                alarm,
-                                                                              ) ||
-                                                                              Utils.isAutoDismissalEnabled(
-                                                                                alarm,
-                                                                              )
-                                                                          ? 8.0
-                                                                          : 0.0,
-                                                                ),
-                                                                child: Row(
+                                                          child: Row(
+                                                            mainAxisAlignment:
+                                                                MainAxisAlignment
+                                                                    .start,
+                                                            children: [
+                                                              Expanded(
+                                                                flex: 3,
+                                                                child:
+                                                                Column(
                                                                   mainAxisAlignment:
-                                                                      MainAxisAlignment
-                                                                          .start,
+                                                                      MainAxisAlignment.center,
+                                                                  crossAxisAlignment:
+                                                                      CrossAxisAlignment.start,
                                                                   children: [
-                                                                    Expanded(
-                                                                      flex: 3,
+                                                                    IntrinsicHeight(
                                                                       child:
-                                                                          Column(
-                                                                        mainAxisAlignment:
-                                                                            MainAxisAlignment.center,
-                                                                        crossAxisAlignment:
-                                                                            CrossAxisAlignment.start,
-                                                                        children: [
-                                                                          IntrinsicHeight(
-                                                                            child:
-                                                                                Row(
-                                                                              children: [
-                                                                                Text(
-                                                                                  repeatDays.replaceAll(
-                                                                                    'Never'.tr,
-                                                                                    'One Time'.tr,
-                                                                                  ),
-                                                                                  style: Theme.of(context).textTheme.bodySmall!.copyWith(
-                                                                                        fontWeight: FontWeight.w500,
-                                                                                        color: alarm.isEnabled == true ? kprimaryColor : themeController.primaryDisabledTextColor.value,
-                                                                                      ),
-                                                                                ),
-                                                                                if (alarm.label.isNotEmpty)
-                                                                                  VerticalDivider(
-                                                                                    color: alarm.isEnabled == true ? kprimaryColor : themeController.primaryDisabledTextColor.value,
-                                                                                    thickness: 1.4,
-                                                                                    width: 6,
-                                                                                    indent: 3.1,
-                                                                                    endIndent: 3.1,
-                                                                                  ),
-                                                                                Expanded(
-                                                                                  child: Container(
-                                                                                    child: Text(
-                                                                                      alarm.label,
-                                                                                      overflow: TextOverflow.ellipsis,
-                                                                                      // Set overflow property here
-                                                                                      style: Theme.of(context).textTheme.bodySmall!.copyWith(
-                                                                                            fontWeight: FontWeight.w500,
-                                                                                            color: alarm.isEnabled == true ? kprimaryColor : themeController.primaryDisabledTextColor.value,
-                                                                                          ),
-                                                                                    ),
-                                                                                  ),
-                                                                                ),
-                                                                              ],
-                                                                            ),
-                                                                          ),
                                                                           Row(
-                                                                            children: [
-                                                                              Text(
-                                                                                (settingsController.is24HrsEnabled.value
-                                                                                    ? Utils.split24HourFormat(alarm.alarmTime)
-                                                                                    : Utils.convertTo12HourFormat(
-                                                                                        alarm.alarmTime,
-                                                                                      ))[0],
-                                                                                style: Theme.of(
-                                                                                  context,
-                                                                                ).textTheme.displayLarge!.copyWith(
-                                                                                      color: alarm.isEnabled == true ? themeController.primaryTextColor.value : themeController.primaryDisabledTextColor.value,
-                                                                                    ),
-                                                                              ),
-                                                                              Padding(
-                                                                                padding: const EdgeInsets.symmetric(
-                                                                                  horizontal: 3.0,
-                                                                                ),
-                                                                                child: Text(
-                                                                                  (settingsController.is24HrsEnabled.value
-                                                                                      ? Utils.split24HourFormat(alarm.alarmTime)
-                                                                                      : Utils.convertTo12HourFormat(
-                                                                                          alarm.alarmTime,
-                                                                                        ))[1],
-                                                                                  style: Theme.of(context).textTheme.displayMedium!.copyWith(
-                                                                                        color: alarm.isEnabled == true ? themeController.primaryTextColor.value : themeController.primaryDisabledTextColor.value,
-                                                                                      ),
-                                                                                ),
-                                                                              ),
-                                                                            ],
-                                                                          ),
-                                                                          if (Utils.isChallengeEnabled(
-                                                                                alarm,
-                                                                              ) ||
-                                                                              Utils.isAutoDismissalEnabled(
-                                                                                alarm,
-                                                                              ) ||
-                                                                              alarm.isSharedAlarmEnabled)
-                                                                            Row(
-                                                                              mainAxisAlignment: MainAxisAlignment.start,
-                                                                              children: [
-                                                                                if (alarm.isSharedAlarmEnabled)
-                                                                                  Padding(
-                                                                                    padding: const EdgeInsets.symmetric(
-                                                                                      horizontal: 3.0,
-                                                                                    ),
-                                                                                    child: Icon(
-                                                                                      Icons.share_arrival_time,
-                                                                                      size: 24,
-                                                                                      color: alarm.isEnabled == true ? themeController.primaryTextColor.value.withOpacity(0.5) : themeController.primaryDisabledTextColor.value,
-                                                                                    ),
-                                                                                  ),
-                                                                                if (alarm.isLocationEnabled)
-                                                                                  Padding(
-                                                                                    padding: const EdgeInsets.symmetric(
-                                                                                      horizontal: 3.0,
-                                                                                    ),
-                                                                                    child: Icon(
-                                                                                      Icons.location_pin,
-                                                                                      size: 24,
-                                                                                      color: alarm.isEnabled == true ? themeController.primaryTextColor.value.withOpacity(0.5) : themeController.primaryDisabledTextColor.value,
-                                                                                    ),
-                                                                                  ),
-                                                                                if (alarm.isActivityEnabled)
-                                                                                  Padding(
-                                                                                    padding: const EdgeInsets.symmetric(
-                                                                                      horizontal: 3.0,
-                                                                                    ),
-                                                                                    child: Icon(
-                                                                                      Icons.screen_lock_portrait,
-                                                                                      size: 24,
-                                                                                      color: alarm.isEnabled == true ? themeController.primaryTextColor.value.withOpacity(0.5) : themeController.primaryDisabledTextColor.value,
-                                                                                    ),
-                                                                                  ),
-                                                                                if (alarm.isWeatherEnabled)
-                                                                                  Padding(
-                                                                                    padding: const EdgeInsets.symmetric(
-                                                                                      horizontal: 3.0,
-                                                                                    ),
-                                                                                    child: Icon(
-                                                                                      Icons.cloudy_snowing,
-                                                                                      size: 24,
-                                                                                      color: alarm.isEnabled == true ? themeController.primaryTextColor.value.withOpacity(0.5) : themeController.primaryDisabledTextColor.value,
-                                                                                    ),
-                                                                                  ),
-                                                                                if (alarm.isQrEnabled)
-                                                                                  Padding(
-                                                                                    padding: const EdgeInsets.symmetric(
-                                                                                      horizontal: 3.0,
-                                                                                    ),
-                                                                                    child: Icon(
-                                                                                      Icons.qr_code_scanner,
-                                                                                      size: 24,
-                                                                                      color: alarm.isEnabled == true ? themeController.primaryTextColor.value.withOpacity(0.5) : themeController.primaryDisabledTextColor.value,
-                                                                                    ),
-                                                                                  ),
-                                                                                if (alarm.isShakeEnabled)
-                                                                                  Padding(
-                                                                                    padding: const EdgeInsets.symmetric(
-                                                                                      horizontal: 3.0,
-                                                                                    ),
-                                                                                    child: Icon(
-                                                                                      Icons.vibration,
-                                                                                      size: 24,
-                                                                                      color: alarm.isEnabled == true ? themeController.primaryTextColor.value.withOpacity(0.5) : themeController.primaryDisabledTextColor.value,
-                                                                                    ),
-                                                                                  ),
-                                                                                if (alarm.isMathsEnabled)
-                                                                                  Padding(
-                                                                                    padding: const EdgeInsets.symmetric(
-                                                                                      horizontal: 3.0,
-                                                                                    ),
-                                                                                    child: Icon(
-                                                                                      Icons.calculate,
-                                                                                      size: 24,
-                                                                                      color: alarm.isEnabled == true ? themeController.primaryTextColor.value.withOpacity(0.5) : themeController.primaryDisabledTextColor.value,
-                                                                                    ),
-                                                                                  ),
-                                                                                if (alarm.isPedometerEnabled)
-                                                                                  Padding(
-                                                                                    padding: const EdgeInsets.symmetric(
-                                                                                      horizontal: 3.0,
-                                                                                    ),
-                                                                                    child: Icon(
-                                                                                      Icons.directions_walk,
-                                                                                      size: 24,
-                                                                                      color: alarm.isEnabled == true ? themeController.primaryTextColor.value.withOpacity(0.5) : themeController.primaryDisabledTextColor.value,
-                                                                                    ),
-                                                                                  ),
-                                                                              ],
+                                                                        children: [
+                                                                          Text(
+                                                                            repeatDays.replaceAll(
+                                                                              'Never'.tr,
+                                                                              'One Time'.tr,
                                                                             ),
+                                                                            style: Theme.of(context).textTheme.bodySmall!.copyWith(
+                                                                                  fontWeight: FontWeight.w500,
+                                                                                  color: alarm.isEnabled == true
+                                                                                      ? kprimaryColor
+                                                                                      : themeController.primaryDisabledTextColor.value,
+                                                                                ),
+                                                                          ),
+                                                                          if (alarm.label.isNotEmpty)
+                                                                            VerticalDivider(
+                                                                              color: alarm.isEnabled == true
+                                                                                  ? kprimaryColor
+                                                                                  : themeController.primaryDisabledTextColor.value,
+                                                                              thickness: 1.4,
+                                                                              width: 6,
+                                                                              indent: 3.1,
+                                                                              endIndent: 3.1,
+                                                                            ),
+                                                                          Expanded(
+                                                                            child: Container(
+                                                                              child: Text(
+                                                                                alarm.label,
+                                                                                overflow: TextOverflow.ellipsis,
+                                                                                // Set overflow property here
+                                                                                style: Theme.of(context).textTheme.bodySmall!.copyWith(
+                                                                                      fontWeight: FontWeight.w500,
+                                                                                      color: alarm.isEnabled == true
+                                                                                          ? kprimaryColor
+                                                                                          : themeController.primaryDisabledTextColor.value,
+                                                                                    ),
+                                                                              ),
+                                                                            ),
+                                                                          ),
                                                                         ],
                                                                       ),
                                                                     ),
-                                                                    Padding(
-                                                                      padding:
-                                                                          const EdgeInsets
-                                                                              .symmetric(
-                                                                        horizontal:
-                                                                            10.0,
+                                                                    Row(
+                                                                      children: [
+                                                                        Text(
+                                                                          (settingsController.is24HrsEnabled.value
+                                                                              ? Utils.split24HourFormat(alarm.alarmTime)
+                                                                              : Utils.convertTo12HourFormat(
+                                                                                  alarm.alarmTime,
+                                                                                ))[0],
+                                                                          style: Theme.of(
+                                                                            context,
+                                                                          ).textTheme.displayLarge!.copyWith(
+                                                                                color: alarm.isEnabled == true
+                                                                                    ? themeController.primaryTextColor.value
+                                                                                    : themeController.primaryDisabledTextColor.value,
+                                                                              ),
+                                                                        ),
+                                                                        Padding(
+                                                                          padding: const EdgeInsets.symmetric(
+                                                                            horizontal: 3.0,
+                                                                          ),
+                                                                          child: Text(
+                                                                            (settingsController.is24HrsEnabled.value
+                                                                                ? Utils.split24HourFormat(alarm.alarmTime)
+                                                                                : Utils.convertTo12HourFormat(
+                                                                                    alarm.alarmTime,
+                                                                                  ))[1],
+                                                                            style: Theme.of(context).textTheme.displayMedium!.copyWith(
+                                                                                  color: alarm.isEnabled == true
+                                                                                      ? themeController.primaryTextColor.value
+                                                                                      : themeController.primaryDisabledTextColor.value,
+                                                                                ),
+                                                                          ),
+                                                                        ),
+                                                                      ],
+                                                                    ),
+                                                                    if (Utils.isChallengeEnabled(
+                                                                          alarm,
+                                                                        ) ||
+                                                                        Utils.isAutoDismissalEnabled(
+                                                                          alarm,
+                                                                        ) ||
+                                                                        alarm.isSharedAlarmEnabled)
+                                                                      Row(
+                                                                        mainAxisAlignment: MainAxisAlignment.start,
+                                                                        children: [
+                                                                          if (alarm.isSharedAlarmEnabled)
+                                                                            Padding(
+                                                                              padding: const EdgeInsets.symmetric(
+                                                                                horizontal: 3.0,
+                                                                              ),
+                                                                              child: Icon(
+                                                                                Icons.share_arrival_time,
+                                                                                size: 24,
+                                                                                color: alarm.isEnabled == true
+                                                                                    ? themeController.primaryTextColor.value.withOpacity(0.5)
+                                                                                    : themeController.primaryDisabledTextColor.value,
+                                                                              ),
+                                                                            ),
+                                                                          if (alarm.isLocationEnabled)
+                                                                            Padding(
+                                                                              padding: const EdgeInsets.symmetric(
+                                                                                horizontal: 3.0,
+                                                                              ),
+                                                                              child: Icon(
+                                                                                Icons.location_pin,
+                                                                                size: 24,
+                                                                                color: alarm.isEnabled == true
+                                                                                    ? themeController.primaryTextColor.value.withOpacity(0.5)
+                                                                                    : themeController.primaryDisabledTextColor.value,
+                                                                              ),
+                                                                            ),
+                                                                          if (alarm.isActivityEnabled)
+                                                                            Padding(
+                                                                              padding: const EdgeInsets.symmetric(
+                                                                                horizontal: 3.0,
+                                                                              ),
+                                                                              child: Icon(
+                                                                                Icons.screen_lock_portrait,
+                                                                                size: 24,
+                                                                                color: alarm.isEnabled == true
+                                                                                    ? themeController.primaryTextColor.value.withOpacity(0.5)
+                                                                                    : themeController.primaryDisabledTextColor.value,
+                                                                              ),
+                                                                            ),
+                                                                          if (alarm.isWeatherEnabled)
+                                                                            Padding(
+                                                                              padding: const EdgeInsets.symmetric(
+                                                                                horizontal: 3.0,
+                                                                              ),
+                                                                              child: Icon(
+                                                                                Icons.cloudy_snowing,
+                                                                                size: 24,
+                                                                                color: alarm.isEnabled == true
+                                                                                    ? themeController.primaryTextColor.value.withOpacity(0.5)
+                                                                                    : themeController.primaryDisabledTextColor.value,
+                                                                              ),
+                                                                            ),
+                                                                          if (alarm.isQrEnabled)
+                                                                            Padding(
+                                                                              padding: const EdgeInsets.symmetric(
+                                                                                horizontal: 3.0,
+                                                                              ),
+                                                                              child: Icon(
+                                                                                Icons.qr_code_scanner,
+                                                                                size: 24,
+                                                                                color: alarm.isEnabled == true
+                                                                                    ? themeController.primaryTextColor.value.withOpacity(0.5)
+                                                                                    : themeController.primaryDisabledTextColor.value,
+                                                                              ),
+                                                                            ),
+                                                                          if (alarm.isShakeEnabled)
+                                                                            Padding(
+                                                                              padding: const EdgeInsets.symmetric(
+                                                                                horizontal: 3.0,
+                                                                              ),
+                                                                              child: Icon(
+                                                                                Icons.vibration,
+                                                                                size: 24,
+                                                                                color: alarm.isEnabled == true
+                                                                                    ? themeController.primaryTextColor.value.withOpacity(0.5)
+                                                                                    : themeController.primaryDisabledTextColor.value,
+                                                                              ),
+                                                                            ),
+                                                                          if (alarm.isMathsEnabled)
+                                                                            Padding(
+                                                                              padding: const EdgeInsets.symmetric(
+                                                                                horizontal: 3.0,
+                                                                              ),
+                                                                              child: Icon(
+                                                                                Icons.calculate,
+                                                                                size: 24,
+                                                                                color: alarm.isEnabled == true
+                                                                                    ? themeController.primaryTextColor.value.withOpacity(0.5)
+                                                                                    : themeController.primaryDisabledTextColor.value,
+                                                                              ),
+                                                                            ),
+                                                                          if (alarm.isPedometerEnabled)
+                                                                            Padding(
+                                                                              padding: const EdgeInsets.symmetric(
+                                                                                horizontal: 3.0,
+                                                                              ),
+                                                                              child: Icon(
+                                                                                Icons.directions_walk,
+                                                                                size: 24,
+                                                                                color: alarm.isEnabled == true
+                                                                                    ? themeController.primaryTextColor.value.withOpacity(0.5)
+                                                                                    : themeController.primaryDisabledTextColor.value,
+                                                                              ),
+                                                                            ),
+                                                                        ],
                                                                       ),
-                                                                      child: controller
-                                                                              .inMultipleSelectMode
-                                                                              .value
-                                                                          ? Column(
-                                                                              // Showing the toggle button
-                                                                              mainAxisAlignment: MainAxisAlignment.center,
-                                                                              children: [
-                                                                                Expanded(
-                                                                                  flex: 0,
-                                                                                  child: ToggleButton(
-                                                                                    controller: controller,
-                                                                                    alarmIndex: index,
-                                                                                  ),
-                                                                                ),
-                                                                              ],
-                                                                            )
-                                                                          : Column(
-                                                                              // Showing the switch and pop up menu button
-                                                                              mainAxisAlignment: MainAxisAlignment.center,
-                                                                              children: [
-                                                                                Expanded(
-                                                                                  flex: 0,
-                                                                                  child: Switch.adaptive(
-                                                                                    activeColor: ksecondaryColor,
-                                                                                    value: alarm.isEnabled,
-                                                                                    onChanged: (bool value) async {
-                                                                                      Utils.hapticFeedback();
-                                                                                      alarm.isEnabled = value;
-                                                                                      if (alarm.isSharedAlarmEnabled == true) {
-                                                                                        await FirestoreDb.updateAlarm(alarm.ownerId, alarm);
-                                                                                      } else {
-                                                                                        await IsarDb.updateAlarm(alarm);
-                                                                                      }
-                                                                                      controller.refreshTimer = true;
-                                                                                      controller.refreshUpcomingAlarms();
-                                                                                    },
-                                                                                  ),
-                                                                                ),
-                                                                                Expanded(
-                                                                                  flex: 0,
-                                                                                  child: PopupMenuButton(
-                                                                                    onSelected: (value) async {
-                                                                                      Utils.hapticFeedback();
-                                                                                      if (value == 0) {
-                                                                                        Get.back();
-                                                                                        Get.offNamed('/alarm-ring', arguments: alarm);
-                                                                                      } else if (value == 1) {
-                                                                                        debugPrint(alarm.isSharedAlarmEnabled.toString());
+                                                                  ],
+                                                                ),
+                                                              ),
+                                                              Padding(
+                                                                padding:
+                                                                    const EdgeInsets
+                                                                        .symmetric(
+                                                                  horizontal:
+                                                                      10.0,
+                                                                ),
+                                                                child: controller
+                                                                        .inMultipleSelectMode
+                                                                        .value
+                                                                    ? Column(
+                                                                        // Showing the toggle button
+                                                                        mainAxisAlignment: MainAxisAlignment.center,
+                                                                        children: [
+                                                                          Expanded(
+                                                                            flex: 0,
+                                                                            child: ToggleButton(
+                                                                              controller: controller,
+                                                                              alarmIndex: index,
+                                                                            ),
+                                                                          ),
+                                                                        ],
+                                                                      )
+                                                                    : Column(
+                                                                        // Showing the switch and pop up menu button
+                                                                        mainAxisAlignment: MainAxisAlignment.center,
+                                                                        children: [
+                                                                          Expanded(
+                                                                            flex: 0,
+                                                                            child: Switch.adaptive(
+                                                                              activeColor: ksecondaryColor,
+                                                                              value: alarm.isEnabled,
+                                                                              onChanged: (bool value) async {
+                                                                                Utils.hapticFeedback();
+                                                                                alarm.isEnabled = value;
+                                                                                if (alarm.isSharedAlarmEnabled == true) {
+                                                                                  await FirestoreDb.updateAlarm(alarm.ownerId, alarm);
+                                                                                } else {
+                                                                                  await IsarDb.updateAlarm(alarm);
+                                                                                }
+                                                                                controller.refreshTimer = true;
+                                                                                controller.refreshUpcomingAlarms();
+                                                                              },
+                                                                            ),
+                                                                          ),
+                                                                          Expanded(
+                                                                            flex: 0,
+                                                                            child: PopupMenuButton(
+                                                                              onSelected: (value) async {
+                                                                                Utils.hapticFeedback();
+                                                                                if (value == 0) {
+                                                                                  Get.back();
+                                                                                  Get.offNamed('/alarm-ring', arguments: alarm);
+                                                                                } else if (value == 1) {
+                                                                                  debugPrint(alarm.isSharedAlarmEnabled.toString());
 
                                                                                         if (alarm.isSharedAlarmEnabled == true) {
                                                                                           await FirestoreDb.deleteAlarm(controller.userModel.value, alarm.firestoreId!);
@@ -995,63 +998,55 @@ class HomeView extends GetView<HomeController> {
                                                                                           counterUpdate: CounterUpdate.decrement,
                                                                                         );
 
-                                                                                        controller.refreshTimer = true;
-                                                                                        controller.refreshUpcomingAlarms();
-                                                                                      } else if (value == 2) {
-                                                                                        // Duplicate Alarm option
-                                                                                        controller.duplicateAlarm(alarm);
-                                                                                      }
-                                                                                    },
-                                                                                    color: themeController.primaryBackgroundColor.value,
-                                                                                    icon: Icon(
-                                                                                      Icons.more_vert,
-                                                                                      color: alarm.isEnabled == true ? themeController.primaryTextColor.value : themeController.primaryDisabledTextColor.value,
+                                                                                  controller.refreshTimer = true;
+                                                                                  controller.refreshUpcomingAlarms();
+                                                                                }
+                                                                              },
+                                                                              color: themeController.primaryBackgroundColor.value,
+                                                                              icon: Icon(
+                                                                                Icons.more_vert,
+                                                                                color: alarm.isEnabled == true
+                                                                                    ? themeController.primaryTextColor.value
+                                                                                    : themeController.primaryDisabledTextColor.value,
+                                                                              ),
+                                                                              itemBuilder: (context) {
+                                                                                return [
+                                                                                  PopupMenuItem<int>(
+                                                                                    value: 0,
+                                                                                    child: Text(
+                                                                                      'Preview Alarm'.tr,
+                                                                                      style: Theme.of(context).textTheme.bodyMedium,
                                                                                     ),
-                                                                                    itemBuilder: (context) {
-                                                                                      return [
-                                                                                        PopupMenuItem<int>(
-                                                                                          value: 0,
-                                                                                          child: Text(
-                                                                                            'Preview Alarm'.tr,
-                                                                                            style: Theme.of(context).textTheme.bodyMedium,
-                                                                                          ),
-                                                                                        ),
-                                                                                        PopupMenuItem<int>(
-                                                                                          value: 2,
-                                                                                          child: Text(
-                                                                                            'Duplicate Alarm'.tr,
-                                                                                            style: Theme.of(context).textTheme.bodyMedium,
-                                                                                          ),
-                                                                                        ),
-                                                                                        if (alarm.isSharedAlarmEnabled == false || (alarm.isSharedAlarmEnabled == true && alarm.ownerId == controller.userModel.value!.id))
-                                                                                          PopupMenuItem<int>(
-                                                                                            value: 1,
-                                                                                            child: Text(
-                                                                                              'Delete Alarm'.tr,
-                                                                                              style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                                                                                                    color: Colors.red,
-                                                                                                  ),
-                                                                                            ),
-                                                                                          ),
-                                                                                      ];
-                                                                                    },
                                                                                   ),
-                                                                                ),
-                                                                              ],
+                                                                                  if (alarm.isSharedAlarmEnabled == false || (alarm.isSharedAlarmEnabled == true && alarm.ownerId == controller.userModel.value!.id))
+                                                                                    PopupMenuItem<int>(
+                                                                                      value: 1,
+                                                                                      child: Text(
+                                                                                        'Delete Alarm'.tr,
+                                                                                        style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                                                                                              color: Colors.red,
+                                                                                            ),
+                                                                                      ),
+                                                                                    ),
+                                                                                ];
+                                                                              },
                                                                             ),
-                                                                    ),
-                                                                  ],
-                                                                ),
+                                                                          ),
+                                                                        ],
+                                                                      ),
                                                               ),
-                                                            ),
+                                                            ],
                                                           ),
                                                         ),
                                                       ),
                                                     ),
                                                   ),
                                                 ),
-                                              )
-                                            : SizedBox();
+                                              ),
+                                            ),
+                                          ),
+                                        )
+                                      : SizedBox();
                                       },
                                     );
                                   }


### PR DESCRIPTION
### Description
This PR adds a "Duplicate Alarm" button to the home_view.dart file alongside the existing "Preview Alarm" and "Delete Alarm" buttons. The duplicate button allows users to create a new alarm with the same settings as the selected alarm. The necessary functionality is implemented in the HomeController.

### Proposed Changes
AlarmModel (alarm_model.dart):

Added the clone method.
HomeController (home_controller.dart):

Added the duplicateAlarm method.
HomeView (home_view.dart):

Updated the PopupMenuButton to include the "Duplicate Alarm" option and linked it to the duplicateAlarm method in the HomeController.

## Fixes #(issue_no)

Replace #650  with the issue number which is fixed in this PR

## Screenshots

https://github.com/user-attachments/assets/0dc6dcfb-af20-4d83-8116-669faff65172



## Checklist

<!-- Mark the completed tasks with [x] -->
- [ x] Tests have been added or updated to cover the changes
- [ x] Documentation has been updated to reflect the changes
- [ x] Code follows the established coding style guidelines
- [ x] All tests are passing