### PR TITLE
Fixed issue #652,Timer start preset text cropping solved.

### DIFF
--- a/lib/app/utils/preset_button.dart
+++ b/lib/app/utils/preset_button.dart
@@ -24,7 +24,7 @@ Widget presetButton(BuildContext context, String label, Duration duration) {
       ),
       backgroundColor: Colors.transparent,
       shadowColor: Colors.transparent,
-      fixedSize: Size(
+      minimumSize: Size(
         width * 0.02,
         height * 0.01,
       ),


### PR DESCRIPTION
## Description
This PR addresses the fix for issue #652 where the text used as a preset for starting a new timer (+1:00, +5:00 etc.) were being cropped off from bottom in some devices due to a different attribute (fixedSize) used in Elevated button's style causing this issue.

### Proposed Changes

- Changed the 'fixedSize' attribute which used the Size() property to define the button to 'minimumSize'.
- This new attribute makes sure the button's size adjusts to a minimum size so it does not get cropped by the screen dimensions and the widget dynamically takes up its space.
- Tested the changes on virtual and physical devices.

### Checklist

- [☑️] Tests have been added or updated to cover the changes
- [☑️] Documentation has been updated to reflect the changes
- [☑️] Code follows the established coding style guidelines
- [☑️] All tests are passing