### PR TITLE
fix: incorrect weekdays & 'Daily' checkbox in `repeat_tile` widget

### DIFF
--- a/lib/app/modules/addOrUpdateAlarm/views/repeat_tile.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/repeat_tile.dart
@@ -364,9 +364,9 @@ class RepeatTile extends StatelessWidget {
 
             // Update repeatDays based on isWeekdaysSelected value
             for (int i = 0; i < controller.repeatDays.length; i++) {
-              // Assuming weekdays are from Monday to Friday (index 0 to 5)
+              // Assuming weekdays are from Monday to Friday (index 0 to 4)
               controller.repeatDays[i] =
-                  controller.isWeekdaysSelected.value && i >= 0 && i < 5;
+                  controller.isWeekdaysSelected.value && i >= 0 && i <= 4;
             }
           },
           child: Padding(
@@ -394,11 +394,11 @@ class RepeatTile extends StatelessWidget {
 
                     // Update repeatDays based on isWeekdaysSelected value
                     for (int i = 0; i < controller.repeatDays.length; i++) {
-                      // Assuming weekdays are from Monday to Friday (index 1 to 5)
+                      // Assuming weekdays are from Monday to Friday (index 0 to 4)
                       controller.repeatDays[i] =
                           controller.isWeekdaysSelected.value &&
-                              i >= 1 &&
-                              i <= 5;
+                              i >= 0 &&
+                              i <= 4;
                     }
                   },
                 ),

--- a/lib/app/modules/addOrUpdateAlarm/views/repeat_tile.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/repeat_tile.dart
@@ -22,7 +22,6 @@ class RepeatTile extends StatelessWidget {
     var height = Get.height;
     var width = Get.width;
 
-
     return Obx(
       () => InkWell(
         onTap: () {
@@ -172,7 +171,15 @@ class RepeatTile extends StatelessWidget {
                   activeColor: kprimaryColor.withOpacity(0.8),
                   value: controller.isDailySelected.value,
                   onChanged: (value) {
-                    // This onChanged can be empty, as we handle the tap in InkWell
+                    Utils.hapticFeedback();
+                    controller
+                        .setIsDailySelected(!controller.isDailySelected.value);
+
+                    // Update repeatDays based on isDailySelected value
+                    for (int i = 0; i < controller.repeatDays.length; i++) {
+                      controller.repeatDays[i] =
+                          controller.isDailySelected.value;
+                    }
                   },
                 ),
               ],


### PR DESCRIPTION
### Description
#### The following two issues were solved:
- When creating a new alarm and setting the repeat to `Weekdays`, it incorrectly selects 'Tue, Wed, Thu, Fri & Sat'
- In the same section the repeat to `Daily` checkbox was not doing anything when clicked.

### Fixes #679 & #678
fixes #678 
fixes #679 

### Screenshots

https://github.com/user-attachments/assets/ff002b19-daaa-42c7-853f-93af0113518b



## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing