### PR TITLE
Fix: Alarm displays incorrect time format while ringing

### DIFF
--- a/lib/app/modules/alarmRing/controllers/alarm_ring_controller.dart
+++ b/lib/app/modules/alarmRing/controllers/alarm_ring_controller.dart
@@ -15,6 +15,7 @@ import 'package:ultimate_alarm_clock/app/data/models/user_model.dart';
 import 'package:ultimate_alarm_clock/app/data/providers/firestore_provider.dart';
 import 'package:ultimate_alarm_clock/app/data/providers/isar_provider.dart';
 import 'package:ultimate_alarm_clock/app/data/providers/secure_storage_provider.dart';
+import 'package:ultimate_alarm_clock/app/modules/settings/controllers/settings_controller.dart';
 import 'package:ultimate_alarm_clock/app/utils/audio_utils.dart';
 
 import 'package:ultimate_alarm_clock/app/utils/utils.dart';
@@ -33,10 +34,13 @@ class AlarmControlController extends GetxController {
   RxInt seconds = 0.obs;
   RxBool showButton = false.obs;
   HomeController homeController = Get.find<HomeController>();
+  SettingsController settingsController = Get.find<SettingsController>();
+  RxBool get is24HourFormat => settingsController.is24HrsEnabled;
   Rx<AlarmModel> currentlyRingingAlarm = Utils.alarmModelInit.obs;
   final formattedDate = Utils.getFormattedDate(DateTime.now()).obs;
   final timeNow =
       Utils.convertTo12HourFormat(Utils.timeOfDayToString(TimeOfDay.now())).obs;
+  final timeNow24Hr = Utils.timeOfDayToString(TimeOfDay.now()).obs;
   Timer? _currentTimeTimer;
   bool isAlarmActive = true;
   late double initialVolume;

--- a/lib/app/modules/alarmRing/views/alarm_ring_view.dart
+++ b/lib/app/modules/alarmRing/views/alarm_ring_view.dart
@@ -78,10 +78,10 @@ class AlarmControlView extends GetView<AlarmControlController> {
                           Text(
                             (controller.isSnoozing.value)
                                 ? "${controller.minutes.toString().padLeft(2, '0')}"
-                                    // ignore: lines_longer_than_80_chars
                                     ":${controller.seconds.toString().padLeft(2, '0')}"
-                                : '${controller.timeNow[0]} '
-                                    '${controller.timeNow[1]}',
+                                : (controller.is24HourFormat.value)
+                                    ? '${controller.timeNow24Hr}'
+                                    : '${controller.timeNow[0]} ${controller.timeNow[1]}',
                             style: Theme.of(context)
                                 .textTheme
                                 .displayLarge!
@@ -141,7 +141,8 @@ class AlarmControlView extends GetView<AlarmControlController> {
                               child: TextButton(
                                 style: ButtonStyle(
                                   backgroundColor: MaterialStateProperty.all(
-                                    themeController.secondaryBackgroundColor.value,
+                                    themeController
+                                        .secondaryBackgroundColor.value,
                                   ),
                                 ),
                                 child: Text(
@@ -150,7 +151,8 @@ class AlarmControlView extends GetView<AlarmControlController> {
                                       .textTheme
                                       .bodyMedium!
                                       .copyWith(
-                                        color: themeController.primaryTextColor.value,
+                                        color: themeController
+                                            .primaryTextColor.value,
                                         fontWeight: FontWeight.w600,
                                       ),
                                 ),
@@ -167,12 +169,10 @@ class AlarmControlView extends GetView<AlarmControlController> {
                   ],
                 ),
               ),
-
-              
               Positioned(
-                bottom: 80, 
-                left: width * 0.1, 
-                right: width * 0.1, 
+                bottom: 80,
+                left: width * 0.1,
+                right: width * 0.1,
                 child: Obx(
                   () => Visibility(
                     visible: controller.showButton.value,
@@ -182,12 +182,13 @@ class AlarmControlView extends GetView<AlarmControlController> {
                       child: TextButton(
                         style: ButtonStyle(
                           backgroundColor: MaterialStateProperty.all(
-                            kprimaryColor, 
+                            kprimaryColor,
                           ),
                         ),
                         onPressed: () {
                           Utils.hapticFeedback();
-                          if (controller.currentlyRingingAlarm.value.isGuardian) {
+                          if (controller
+                              .currentlyRingingAlarm.value.isGuardian) {
                             controller.guardianTimer.cancel();
                           }
                           if (Utils.isChallengeEnabled(
@@ -223,20 +224,18 @@ class AlarmControlView extends GetView<AlarmControlController> {
                   ),
                 ),
               ),
-
-              
               Positioned(
                 bottom: 0,
                 left: 0,
                 right: 0,
                 child: Container(
                   width: double.infinity,
-                  height: 60, 
-                  color: Colors.red, 
+                  height: 60,
+                  color: Colors.red,
                   child: TextButton(
                     onPressed: () {
                       Utils.hapticFeedback();
-                      Get.offNamed('/bottom-navigation-bar'); 
+                      Get.offNamed('/bottom-navigation-bar');
                     },
                     child: Text(
                       'Exit Preview'.tr,


### PR DESCRIPTION
### Description
This PR fixes an issue where the alarm ringing screen always displayed the time in 12-hour format, even when the 24-hour format was selected in the settings. The time now properly reflects the user’s chosen format.

### Proposed Changes
- Used SettingsController to check if 24-hour format is enabled.
- Updated AlarmControlView to display controller.timeNow24Hr when 24-hour format is selected.

## Fixes #629 



## Screenshots

https://github.com/user-attachments/assets/10cd84b2-2b03-4c98-8473-bb18c9a58a55


**the red color is only used for testing purpose!**
## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing