### PR TITLE
Fix: Updated `weather_tile` and `location_activity_tile`

### DIFF
--- a/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
+++ b/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
@@ -330,7 +330,7 @@ class AddOrUpdateAlarmController extends GetxController {
   }
 
   Future<void> getLocation() async {
-    if (await _checkAndRequestPermission()) {
+    if (await checkAndRequestPermission()) {
       const timeLimit = Duration(seconds: 10);
       await FlLocation.getLocation(
         timeLimit: timeLimit,
@@ -343,7 +343,7 @@ class AddOrUpdateAlarmController extends GetxController {
     }
   }
 
-  Future<bool> _checkAndRequestPermission({bool? background}) async {
+  Future<bool> checkAndRequestPermission({bool? background}) async {
     if (!await FlLocation.isLocationServicesEnabled) {
       // Location services are disabled.
       return false;

--- a/lib/app/modules/addOrUpdateAlarm/views/location_activity_tile.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/location_activity_tile.dart
@@ -98,10 +98,6 @@ class LocationTile extends StatelessWidget {
             if (value == 0) {
               controller.isLocationEnabled.value = false;
             } else if (value == 1) {
-              if (controller.isLocationEnabled.value == false) {
-                await controller.getLocation();
-              }
-
               Get.defaultDialog(
                 backgroundColor: themeController.secondaryBackgroundColor.value,
                 title: 'Set location to automatically cancel alarm!',
@@ -152,6 +148,11 @@ class LocationTile extends StatelessWidget {
                   ],
                 ),
               );
+
+              if (controller.isLocationEnabled.value == false) {
+                await controller.getLocation();
+                controller.mapController.move(controller.selectedPoint.value, 15);
+              }
             }
           });
         },

--- a/lib/app/modules/addOrUpdateAlarm/views/weather_tile.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/weather_tile.dart
@@ -26,7 +26,7 @@ class WeatherTile extends StatelessWidget {
         child:  ListTile(
                 onTap: () async {
                   Utils.hapticFeedback();
-                  await controller.getLocation();
+                  await controller.checkAndRequestPermission();
                   Get.defaultDialog(
                     titlePadding: const EdgeInsets.symmetric(vertical: 20),
                     backgroundColor: themeController.secondaryBackgroundColor.value,

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -182,7 +182,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					33CC10EC2044A3C60003C045 = {

--- a/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
### Description
This PR solves the following issues while adding/updating an alarm:
- When selecting `Weather Condition`, the app first finds the location and then opens the popup. Since retrieving location can take some time, the app seems to be stuck, and the popup does not appear. (There is no need for getting the location at this point; location is only needed when the alarm is about to ring.)
- When selecting `Location Based`, the same happens; the app first retrieves the location and then open the popup.

### Proposed Changes
After the changes, when selecting;
- `Weather Condition`: There is a check for location access only.
- `Location Based`: The popup opens, then the location is retrieved.

These changes just make the app more responsive and fast.

## Fixes
fixes #699 

## Screenshots
### Before
https://github.com/user-attachments/assets/63ca76ee-b3b4-4f55-9b97-429cbfe3d9dd

### After

https://github.com/user-attachments/assets/8dd47718-9c45-4196-97a7-1d832ecd751a



## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing