### PR TITLE
fiexes #611: fixed timer input overflow

### DIFF
--- a/lib/app/modules/timer/views/timer_view.dart
+++ b/lib/app/modules/timer/views/timer_view.dart
@@ -215,7 +215,6 @@ class TimerView extends GetView<TimerController> {
 
   void timerSelector(BuildContext context, double width, double height) {
     showDialog(
-      
       context: context,
       barrierDismissible: true,
       builder: (BuildContext context) {
@@ -557,7 +556,7 @@ class TimerView extends GetView<TimerController> {
                                           height: height * 0.008,
                                         ),
                                         SizedBox(
-                                          width: width * 0.2,
+                                          width: width * 0.18,
                                           child: TextField(
                                             onChanged: (_) {
                                               inputTimeController
@@ -628,7 +627,7 @@ class TimerView extends GetView<TimerController> {
                                           height: height * 0.008,
                                         ),
                                         SizedBox(
-                                          width: width * 0.2,
+                                          width: width * 0.18,
                                           child: TextField(
                                             onChanged: (_) {
                                               inputTimeController
@@ -699,7 +698,7 @@ class TimerView extends GetView<TimerController> {
                                           height: height * 0.008,
                                         ),
                                         SizedBox(
-                                          width: width * 0.2,
+                                          width: width * 0.18,
                                           child: TextField(
                                             onChanged: (_) {
                                               inputTimeController
@@ -864,13 +863,14 @@ class TimerView extends GetView<TimerController> {
       },
     );
   }
+
   double calculateTopPosition() {
-  final RenderBox? renderBox = dialogKey.currentContext?.findRenderObject() as RenderBox?;
-  if (renderBox != null) {
-    
-    final position = renderBox.localToGlobal(Offset.zero);
-    return position.dy - 100;
+    final RenderBox? renderBox =
+        dialogKey.currentContext?.findRenderObject() as RenderBox?;
+    if (renderBox != null) {
+      final position = renderBox.localToGlobal(Offset.zero);
+      return position.dy - 100;
+    }
+    return 160;
   }
-  return 160; 
-}
 }


### PR DESCRIPTION
### Description  
This PR fixes a **minor overflow issue** in the "Add Timer" dialog, where the input fields slightly exceeded the available space. The issue was caused by the field width being slightly larger than the container.  

### Proposed Changes  
✅ Slightly **reduced the width** of the input fields to prevent UI overflow.  
✅ Ensured that the layout remains responsive and aligned correctly.  

## Fixes #611  
This PR resolves **Issue #611** by ensuring that all input fields fit within the available space properly.  

## Screenshots  
🖼 **Before Fix**: 

![timer](https://github.com/user-attachments/assets/557c11e9-46fc-4c75-893b-27b71ab79fab)

🖼 **After Fix**: 

![after](https://github.com/user-attachments/assets/5b34f8f2-0048-499d-862a-ec82dae3ff41)


## Checklist  
- [x] UI layout issue resolved  
- [x] Tested across different screen sizes  
- [ ] Tests have been added or updated to cover the changes  
- [ ] Documentation has been updated to reflect the changes  
- [x] Code follows the established coding style guidelines  
- [x] All tests are passing  
