### PR TITLE
feat: Migrate to Plugin DSL syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .history
 .svn/
 migrate_working_dir/
+**/.cxx/
 
 # IntelliJ related
 *.iml

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "cmake.sourceDirectory": "E:/ultimate_alarm_clock/linux"
+    "cmake.sourceDirectory": "E:/ultimate_alarm_clock/linux",
+    "java.configuration.updateBuildConfiguration": "interactive"
 }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,14 +1,16 @@
+plugins {
+    id "com.android.application"
+    id "kotlin-android"
+    id "dev.flutter.flutter-gradle-plugin"
+    id "com.google.gms.google-services"
+}
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
     localPropertiesFile.withReader('UTF-8') { reader ->
         localProperties.load(reader)
     }
-}
-
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new Exception("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
 }
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
@@ -21,11 +23,6 @@ if (flutterVersionName == null) {
     flutterVersionName = '0.2.1'
 }
 
-apply plugin: 'com.android.application'
-apply plugin: 'com.google.gms.google-services'
-apply plugin: 'kotlin-android'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
-
 def keystoreProperties = new Properties()
 def keystorePropertiesFile = rootProject.file('key.properties')
 if (keystorePropertiesFile.exists()) {
@@ -33,7 +30,8 @@ if (keystorePropertiesFile.exists()) {
 }
 
 android {
-    compileSdkVersion 34
+    namespace "com.ccextractor.ultimate_alarm_clock"
+    compileSdkVersion 35
     ndkVersion flutter.ndkVersion
 
     defaultConfig {
@@ -93,9 +91,6 @@ flutter {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.7.10"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.10"
     implementation platform('com.google.firebase:firebase-bom:32.0.0') // Updated Firebase BOM to latest
     implementation 'com.google.firebase:protolite-well-known-types:18.0.0'
     implementation("com.android.volley:volley:1.2.1")

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,21 +1,3 @@
-buildscript {
-    ext.kotlin_version = '1.7.10' 
-    ext {
-        compileSdkVersion   = 34   
-        targetSdkVersion    = 34    
-        appCompatVersion    = "1.6.1"
-    }
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.google.gms:google-services:4.3.15'
-    }
-}
-
 allprojects {
     repositories {
         google()
@@ -26,6 +8,15 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
+    // afterEvaluate { project ->
+    //     if (project.hasProperty('android')) {
+    //         project.android {
+    //             if (namespace == null) {
+    //                 namespace project.group
+    //             }
+    //         }
+    //     }
+    // }
 }
 subprojects {
     project.evaluationDependsOn(':app')

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,11 +1,26 @@
-include ':app'
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
 
-def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-def properties = new Properties()
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-assert localPropertiesFile.exists()
-localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 
-def flutterSdkPath = properties.getProperty("flutter.sdk")
-assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "8.1.0" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.10" apply false
+    id "com.google.gms.google-services" version "4.3.15" apply false
+}
+
+include ":app"

--- a/lib/app/data/models/alarm_model.g.dart
+++ b/lib/app/data/models/alarm_model.g.dart
@@ -264,7 +264,7 @@ const AlarmModelSchema = CollectionSchema(
   getId: _alarmModelGetId,
   getLinks: _alarmModelGetLinks,
   attach: _alarmModelAttach,
-  version: '3.1.0+1',
+  version: '3.1.8',
 );
 
 int _alarmModelEstimateSize(

--- a/lib/app/data/models/profile_model.g.dart
+++ b/lib/app/data/models/profile_model.g.dart
@@ -249,7 +249,7 @@ const ProfileModelSchema = CollectionSchema(
   getId: _profileModelGetId,
   getLinks: _profileModelGetLinks,
   attach: _profileModelAttach,
-  version: '3.1.0+1',
+  version: '3.1.8',
 );
 
 int _profileModelEstimateSize(

--- a/lib/app/data/models/ringtone_model.g.dart
+++ b/lib/app/data/models/ringtone_model.g.dart
@@ -44,7 +44,7 @@ const RingtoneModelSchema = CollectionSchema(
   getId: _ringtoneModelGetId,
   getLinks: _ringtoneModelGetLinks,
   attach: _ringtoneModelAttach,
-  version: '3.1.0+1',
+  version: '3.1.8',
 );
 
 int _ringtoneModelEstimateSize(

--- a/lib/app/data/models/saved_emails.g.dart
+++ b/lib/app/data/models/saved_emails.g.dart
@@ -39,7 +39,7 @@ const Saved_EmailsSchema = CollectionSchema(
   getId: _saved_EmailsGetId,
   getLinks: _saved_EmailsGetLinks,
   attach: _saved_EmailsAttach,
-  version: '3.1.0+1',
+  version: '3.1.8',
 );
 
 int _saved_EmailsEstimateSize(

--- a/lib/app/data/models/timer_model.g.dart
+++ b/lib/app/data/models/timer_model.g.dart
@@ -59,7 +59,7 @@ const TimerModelSchema = CollectionSchema(
   getId: _timerModelGetId,
   getLinks: _timerModelGetLinks,
   attach: _timerModelAttach,
-  version: '3.1.0+1',
+  version: '3.1.8',
 );
 
 int _timerModelEstimateSize(

--- a/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
+++ b/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
@@ -758,7 +758,7 @@ class AddOrUpdateAlarmController extends GetxController {
       markersList.add(
         Marker(
           point: selectedPoint.value,
-          builder: (ctx) => const Icon(
+          child: const Icon(
             Icons.location_on,
             size: 35,
             color: Colors.black,
@@ -941,7 +941,7 @@ class AddOrUpdateAlarmController extends GetxController {
         markersList.add(
           Marker(
             point: selectedPoint.value,
-            builder: (ctx) => const Icon(
+            child: const Icon(
               Icons.location_on,
               size: 35,
               color: Colors.black,

--- a/lib/app/modules/addOrUpdateAlarm/views/guardian_angel.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/guardian_angel.dart
@@ -6,7 +6,6 @@ import 'package:ultimate_alarm_clock/app/modules/settings/controllers/theme_cont
 import 'package:ultimate_alarm_clock/app/utils/constants.dart';
 import 'package:ultimate_alarm_clock/app/utils/utils.dart';
 import 'package:permission_handler/permission_handler.dart';
-import 'package:telephony/telephony.dart';
 
 class GuardianAngel extends StatelessWidget {
   const GuardianAngel({

--- a/lib/app/modules/addOrUpdateAlarm/views/location_activity_tile.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/location_activity_tile.dart
@@ -118,8 +118,8 @@ class LocationTile extends StatelessWidget {
                             controller.selectedPoint.value = point;
                           },
                           // screenSize: Size(width * 0.3, height * 0.8),
-                          center: controller.selectedPoint.value,
-                          zoom: 15,
+                          initialCenter: controller.selectedPoint.value,
+                          initialZoom: 15,
                         ),
                         children: [
                           TileLayer(

--- a/lib/app/modules/alarmChallenge/controllers/alarm_challenge_controller.dart
+++ b/lib/app/modules/alarmChallenge/controllers/alarm_challenge_controller.dart
@@ -5,7 +5,8 @@ import 'package:get/get.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 import 'package:pedometer/pedometer.dart';
 import 'package:permission_handler/permission_handler.dart';
-import 'package:shake/shake.dart';
+import 'package:shake_gesture/shake_gesture.dart';
+
 import 'package:ultimate_alarm_clock/app/data/models/alarm_model.dart';
 import 'package:ultimate_alarm_clock/app/utils/audio_utils.dart';
 import 'package:ultimate_alarm_clock/app/utils/constants.dart';
@@ -18,7 +19,6 @@ class AlarmChallengeController extends GetxController {
 
   final RxInt shakedCount = 0.obs;
   final isShakeOngoing = Status.initialized.obs;
-  ShakeDetector? _shakeDetector;
   MobileScannerController? qrController;
 
   final qrValue = ''.obs;
@@ -97,12 +97,10 @@ class AlarmChallengeController extends GetxController {
     if (alarmRecord.isShakeEnabled) {
       isShakeOngoing.listen((value) {
         if (value == Status.ongoing) {
-          _shakeDetector = ShakeDetector.autoStart(
-            onPhoneShake: () {
-              shakedCount.value -= 1;
-              restartTimer();
-            },
-          );
+          ShakeGesture.registerCallback(onShake: () {
+            shakedCount.value -= 1;
+            restartTimer();
+          });
         }
       });
 
@@ -111,7 +109,10 @@ class AlarmChallengeController extends GetxController {
           isShakeOngoing.value = Status.completed;
           alarmRecord.isShakeEnabled = false;
           Get.back();
-          _shakeDetector!.stopListening();
+          ShakeGesture.unregisterCallback(onShake: () {
+            shakedCount.value -= 1;
+            restartTimer();
+          });
           isChallengesComplete();
         }
       });
@@ -246,13 +247,11 @@ class AlarmChallengeController extends GetxController {
       AudioUtils.playAlarm(alarmRecord: alarmRecord);
     }
   }
+
   void removeDigit() {
-  if (displayValue.value.isNotEmpty) {
-    displayValue.value = displayValue.value.substring(
-      0, 
-      displayValue.value.length - 1
-    );
+    if (displayValue.value.isNotEmpty) {
+      displayValue.value =
+          displayValue.value.substring(0, displayValue.value.length - 1);
+    }
   }
 }
-}
-

--- a/lib/app/modules/alarmRing/controllers/alarm_ring_controller.dart
+++ b/lib/app/modules/alarmRing/controllers/alarm_ring_controller.dart
@@ -195,7 +195,7 @@ class AlarmControlController extends GetxController {
     });
 
     // Preventing app from being minimized!
-    _subscription = FGBGEvents.stream.listen((event) {
+    _subscription = FGBGEvents.instance.stream.listen((event) {
       if (event == FGBGType.background) {
         alarmChannel.invokeMethod('bringAppToForeground');
       }

--- a/lib/app/modules/timerRing/controllers/timer_ring_controller.dart
+++ b/lib/app/modules/timerRing/controllers/timer_ring_controller.dart
@@ -22,7 +22,7 @@ class TimerRingController extends GetxController {
     super.onInit();
 
     // Preventing app from being minimized!
-    _subscription = FGBGEvents.stream.listen((event) {
+    _subscription = FGBGEvents.instance.stream.listen((event) {
       if (event == FGBGType.background) {
         timerChannel.invokeMethod('bringAppToForeground');
       }

--- a/lib/app/utils/utils.dart
+++ b/lib/app/utils/utils.dart
@@ -8,8 +8,7 @@ import 'package:intl/intl.dart';
 import 'package:latlong2/latlong.dart';
 import 'dart:math';
 
-import 'package:telephony/telephony.dart';
-
+import 'package:flutter_background_messenger/flutter_background_messenger.dart';
 import 'package:ultimate_alarm_clock/app/data/models/alarm_model.dart';
 import 'package:ultimate_alarm_clock/app/data/models/quote_model.dart';
 import 'package:ultimate_alarm_clock/app/data/models/timer_model.dart';
@@ -100,12 +99,12 @@ class Utils {
     return TimeOfDay(hour: hour, minute: minute);
   }
 
-  static DateTime stringToDate(String date){
+  static DateTime stringToDate(String date) {
     final parts = date.split('-');
     final day = int.parse(parts[2]);
     final month = int.parse(parts[1]);
     final year = int.parse(parts[0]);
-    return DateTime(year,month,day);
+    return DateTime(year, month, day);
   }
 
   static DateTime? stringToDateTime(String timeString) {
@@ -799,12 +798,21 @@ class Utils {
   }
 
   static sendSMS(String phoneNo, String text) async {
-    final Telephony telephony = Telephony.instance;
-    await telephony.requestPhoneAndSmsPermissions.then((value) {
-      if (value == true) {
-        telephony.sendSms(to: phoneNo, message: text);
+    final messenger = FlutterBackgroundMessenger();
+    try {
+      final success = await messenger.sendSMS(
+        phoneNumber: phoneNo,
+        message: text,
+      );
+
+      if (success) {
+        print('SMS sent successfully');
+      } else {
+        print('Failed to send SMS');
       }
-    });
+    } catch (e) {
+      print('Error sending SMS: $e');
+    }
   }
 
   static String _twoDigits(int n) => n.toString().padLeft(2, '0');
@@ -826,6 +834,7 @@ class Utils {
       return parts[0].substring(0, 2);
     }
   }
+
   static double getFontSize(BuildContext context) {
     final width = MediaQuery.of(context).size.width;
     return width < 360 ? 14 : 30;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,7 +33,7 @@ void main() async {
   final ThemeController themeController = Get.put(ThemeController());
 
   AudioPlayer.global.setAudioContext(
-    const AudioContext(
+    AudioContext(
       android: AudioContextAndroid(
         audioMode: AndroidAudioMode.ringtone,
         contentType: AndroidContentType.music,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,37 +7,43 @@ environment:
   flutter: 3.22.2
 
 dependencies:
-  firebase_core: ^2.27.0
+  firebase_core: ^3.12.1
 
   screen_state: ^4.0.0
   cupertino_icons: ^1.0.2
   win32: ^5.2.0
-  get: 4.6.6
+  get: ^4.7.2
   get_storage: ^2.1.1
   flutter_time_picker_spinner: ^2.0.0
-  cloud_firestore: ^4.4.5
-  intl: ^0.18.0
-  latlong2: ^0.8.1
-  flutter_map: ^4.0.0
-  fl_location: ^2.0.0+1
-  flutter_fgbg: ^0.3.0
+  cloud_firestore: ^5.6.5
+  intl: ^0.20.2
+  latlong2: ^0.9.1
+  flutter_map: ^8.1.0
+  fl_location: ^5.0.0
+  flutter_fgbg: ^0.7.1
   flutter_svg: ^2.0.4
-  isar: ^3.1.0+1
-  isar_flutter_libs: ^3.1.0+1
+  # isar: ^3.1.0+1
+  # isar_flutter_libs: ^3.1.0+1
+  isar: 
+    version: ^3.1.0+1
+    hosted: https://pub.isar-community.dev/
+  isar_flutter_libs:
+    version: ^3.1.0+1
+    hosted: https://pub.isar-community.dev/
   async: ^2.10.0
-  flutter_secure_storage: ^8.0.0
-  weather: ^2.0.1
-  shake: ^2.2.0
+  flutter_secure_storage: ^9.2.4
+  weather: ^3.1.1
+  shake_gesture: ^1.1.0
   numberpicker: ^2.1.2
-  mobile_scanner: 3.5.5
+  mobile_scanner: ^6.0.6
   permission_handler: ^11.0.1
   google_sign_in: ^6.2.1
   url_launcher: ^6.3.0
-  flutter_expandable_fab: ^1.8.1
-  vibration: ^1.8.1
-  file_picker: ^6.1.1
-  audioplayers: ^5.2.1
-  rxdart: ^0.27.7
+  flutter_expandable_fab: ^2.3.0
+  vibration: ^3.1.3
+  file_picker: ^9.0.2
+  audioplayers: ^6.2.0
+  rxdart: ^0.28.0
   flutter:
     sdk: flutter
   flutter_native_splash: ^2.3.8
@@ -50,17 +56,21 @@ dependencies:
   sqflite: ^2.3.2
   googleapis: ^13.1.0
   googleapis_auth: ^1.4.1
-  firebase_auth: ^4.17.8
+  firebase_auth: ^5.5.1
   extension_google_sign_in_as_googleapis_auth: ^2.0.12
   android_intent_plus: ^5.0.2
-  telephony: ^0.2.0
+  # telephony: ^0.2.0
+  flutter_background_messenger: ^0.0.2
   intl_phone_number_input: ^0.7.4
-  firebase_messaging: ^14.7.19
+  firebase_messaging: ^15.2.4
   shared_preferences: ^2.2.3
 
 dev_dependencies:
-  flutter_lints: ^4.0.0
-  isar_generator: ^3.1.0+1
+  flutter_lints: ^5.0.0
+  # isar_generator: ^3.1.0+1
+  isar_generator: 
+    version: ^3.1.0+1
+    hosted: https://pub.isar-community.dev/
   build_runner: ^2.0.0
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
### Description
Makes the project support new syntax of gradle and build with newer flutter versions.

### Proposed Changes
- Upgraded Gradle syntax to new Plugin DSL syntax
- Bumped AGP to 8.1.0, and kotlin version to 1.9.10
- Declared namespace "com.ccextractor.ultimate_alarm_clock"
- Upgraded outdated packages (`flutter pub upgrade --major-versions`)
- [isar is starting to update currently](https://github.com/isar/isar/issues/1686); switching to [community fork version](https://github.com/isar-community/isar) can be later switched back
- Shake is [not maintained ](https://github.com/deven98/shake/issues/34), used  [shake_gesture](https://pub.dev/packages/shake_gesture) instead
- [Telephony](https://github.com/shounakmulay/Telephony) not maintained; Shifted to [flutter_background_messenger](https://pub.dev/packages/flutter_background_messenger)

## Fixes #693 

## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [ ] All tests are passing