### PR TITLE
Add fix: Timer Duration is now updated with Input Field

### DIFF
--- a/lib/app/modules/addOrUpdateAlarm/controllers/input_time_controller.dart
+++ b/lib/app/modules/addOrUpdateAlarm/controllers/input_time_controller.dart
@@ -34,9 +34,9 @@ class InputTimeController extends GetxController {
   void onInit() {
     isTimePicker.value = true;
     isTimePickerTimer.value = true;
-    inputHoursControllerTimer.text = '0';    //It sets the hour field to 0 initially
-    inputMinutesControllerTimer.text = '1';  //It sets the minutes field to 0 initially
-    inputSecondsControllerTimer.text = '0';  //It sets the seconds field to 0, for setting it to 1 minute timer initially
+    inputHoursControllerTimer.text = '0';
+    inputMinutesControllerTimer.text = '1';
+    inputSecondsControllerTimer.text = '0';
     super.onInit();
   }
 

--- a/lib/app/modules/addOrUpdateAlarm/controllers/input_time_controller.dart
+++ b/lib/app/modules/addOrUpdateAlarm/controllers/input_time_controller.dart
@@ -34,6 +34,9 @@ class InputTimeController extends GetxController {
   void onInit() {
     isTimePicker.value = true;
     isTimePickerTimer.value = true;
+    inputHoursControllerTimer.text = '0';    //It sets the hour field to 0 initially
+    inputMinutesControllerTimer.text = '1';  //It sets the minutes field to 0 initially
+    inputSecondsControllerTimer.text = '0';  //It sets the seconds field to 0, for setting it to 1 minute timer initially
     super.onInit();
   }
 

--- a/lib/app/modules/timer/views/timer_view.dart
+++ b/lib/app/modules/timer/views/timer_view.dart
@@ -785,8 +785,7 @@ class TimerView extends GetView<TimerController> {
                                 controller.hours.value = 0;
                                 controller.minutes.value = 1;
                                 controller.seconds.value = 0;
-                                inputTimeController.setTextFieldTimerTime(); //Sets the input field to initial 1 minute, 
-                                                                             //after setting the timer
+                                inputTimeController.setTextFieldTimerTime(); 
 
                                 Get.back();
                               },

--- a/lib/app/modules/timer/views/timer_view.dart
+++ b/lib/app/modules/timer/views/timer_view.dart
@@ -785,6 +785,8 @@ class TimerView extends GetView<TimerController> {
                                 controller.hours.value = 0;
                                 controller.minutes.value = 1;
                                 controller.seconds.value = 0;
+                                inputTimeController.setTextFieldTimerTime(); //Sets the input field to initial 1 minute, 
+                                                                             //after setting the timer
 
                                 Get.back();
                               },


### PR DESCRIPTION
### Description
Now, The input text field is getting updated after setting the timer

### Proposed Changes
 - Updating the Input Field after a timer is created
 - Setting the timer initially to 1 minute which is same as the number picker

## Fixes #721 


## Screenshots

https://github.com/user-attachments/assets/3bdfd61e-bff9-48a8-8293-b360a5dcdc56

## Checklist

- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing