### PR TITLE
Changes Made : UI updates after selecting weather in the profile section

### DIFF
--- a/lib/app/modules/home/views/profile_config.dart
+++ b/lib/app/modules/home/views/profile_config.dart
@@ -102,7 +102,7 @@ class _ProfileSelectState extends State<ProfileSelect> {
                                   controller.selectedProfile.value,))!;
                           controller.isProfileUpdate.value = false;
                           Get.toNamed(
-                            '/add-update-alarm',
+                            '/add-update-alarm',arguments: controller.genFakeAlarmModel(),
                           );
                         },
                         child: const Padding(


### PR DESCRIPTION
### Description

This PR fixes the issue where weather selection in the Profile section was not updating after closing the dialog. The issue was caused because profileModel was not passed as an argument when navigating to /add-update-alarm, leading to an incomplete state update.

### Proposed Changes

- Passed profileModel as an argument in Get.toNamed('/add-update-alarm').
- Ensured weatherTypes correctly updates from profileModel.value.weatherTypes.
- UI now reflects selected weather types after closing the dialog.

## Fixes #674

## Screenshots
![Screenshot_2025-03-10-19-09-23-48_a53a7893e903efe7d38a33066bfd52df](https://github.com/user-attachments/assets/9f629d06-add6-4772-a436-0b84bbcfefc0)
![Screenshot_2025-03-10-19-09-31-95_a53a7893e903efe7d38a33066bfd52df](https://github.com/user-attachments/assets/b9734265-4cbf-49c7-9629-c00920a9344f)


## Checklist

<!-- Mark the completed tasks with [x] -->
- [X] Tests have been added or updated to cover the changes
- [X] Documentation has been updated to reflect the changes
- [X] Code follows the established coding style guidelines
- [X] All tests are passing