### PR TITLE
fix: overflow of timer button

### DIFF
--- a/lib/app/modules/timer/views/timer_animation.dart
+++ b/lib/app/modules/timer/views/timer_animation.dart
@@ -26,6 +26,8 @@ class _TimerAnimatedCardState extends State<TimerAnimatedCard>
     with SingleTickerProviderStateMixin, AutomaticKeepAliveClientMixin {
   TimerController controller = Get.find<TimerController>();
   ThemeController themeController = Get.find<ThemeController>();
+  var width = Get.width;
+  var height = Get.height;
 
   Timer? _timerCounter;
   void startTimer() {
@@ -257,8 +259,8 @@ class _TimerAnimatedCardState extends State<TimerAnimatedCard>
                                                   color: kprimaryColor,
                                                   borderRadius:
                                                       BorderRadius.circular(80)),
-                                              width: 80,
-                                              height: 80,
+                                              width: width * 0.14,
+                                              height: width * 0.14,
                                               child: Icon(
                                                 widget.timer.isPaused == 0
                                                     ? Icons.pause


### PR DESCRIPTION
### Description
There was an overflow of play and pause timer button.
### Proposed Changes
- got the dimensions and
- reduced the button size accordingly for all screens.
## Fixes #737 

## Screenshots
<img src="https://github.com/user-attachments/assets/8015d1b1-f44f-412c-83f4-45c6e7bee3d3" width="300">
<img src="https://github.com/user-attachments/assets/dc760482-cf5f-4b5a-aa83-5b87a8f81443" width="300">

### Before
<img src="https://github.com/user-attachments/assets/cf689f15-cdcb-4db3-aeee-f6ee26765343" width="300">


## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing