### PR TITLE
fix: Layout shift of timer hover buttons

### DIFF
--- a/lib/app/modules/timer/views/timer_view.dart
+++ b/lib/app/modules/timer/views/timer_view.dart
@@ -817,7 +817,7 @@ class TimerView extends GetView<TimerController> {
             Visibility(
               visible: controller.timerList.length > 2,
               child: Positioned(
-                top: calculateTopPosition(),
+                top: 60,
                 child: Material(
                   elevation: 5.0,
                   color: Colors.transparent,
@@ -862,15 +862,5 @@ class TimerView extends GetView<TimerController> {
         );
       },
     );
-  }
-
-  double calculateTopPosition() {
-    final RenderBox? renderBox =
-        dialogKey.currentContext?.findRenderObject() as RenderBox?;
-    if (renderBox != null) {
-      final position = renderBox.localToGlobal(Offset.zero);
-      return position.dy - 100;
-    }
-    return 160;
   }
 }


### PR DESCRIPTION
### Description
The hover buttons on the Timer tab shifts its layout when switched to keyboard type Input

### Proposed Changes
- Fixed the position of the buttons from Top by 60.
- works for all screens
- removed extra code used previously 

## Fixes #739 

## Screenshots
<img src="https://github.com/user-attachments/assets/eeaa5470-52d7-4ac1-83c3-21e8ea4d6458" width="300">

<img src="https://github.com/user-attachments/assets/21011ef4-fc57-420e-8fcb-2966a686fd16" width="300">


## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing