### PR TITLE
Fix: Snooze duration scroll issue solved

### DIFF
--- a/lib/app/modules/addOrUpdateAlarm/views/snooze_duration_tile.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/snooze_duration_tile.dart
@@ -48,22 +48,25 @@ class SnoozeDurationTile extends StatelessWidget {
                         mainAxisAlignment: MainAxisAlignment.center,
                         crossAxisAlignment: CrossAxisAlignment.center,
                         children: [
-                          NumberPicker(
-                            value: controller.snoozeDuration.value <= 0
-                                ? 1
-                                : controller.snoozeDuration
-                                    .value, 
-                            minValue: 1,
-                            maxValue: 1440,
-                            onChanged: (value) {
-                              Utils.hapticFeedback();
-                              controller.snoozeDuration.value = value;
-                            },
+                          Obx(
+                            () => NumberPicker(
+                              value: controller.snoozeDuration.value <= 0
+                                  ? 1
+                                  : controller.snoozeDuration.value,
+                              minValue: 1,
+                              maxValue: 60,
+                              onChanged: (value) {
+                                Utils.hapticFeedback();
+                                controller.snoozeDuration.value = value;
+                              },
+                            ),
                           ),
-                          Text(
-                            controller.snoozeDuration.value > 1
-                                ? 'minutes'.tr
-                                : 'minute'.tr,
+                          Obx(
+                            () => Text(
+                              controller.snoozeDuration.value > 1
+                                  ? 'minutes'.tr
+                                  : 'minute'.tr,
+                            ),
                           ),
                         ],
                       ),


### PR DESCRIPTION
### Description
Solved the malfunction of scroll view while setting snooze duration feature for an alarm 
Also changed the max possible snooze duration from 1440 minutes to 60 minutes which seems much more sensible.

## Fixes #766 

## Screen Recording

https://github.com/user-attachments/assets/ed6549d4-e5c0-4931-9e97-95bae6a02832

