### PR TITLE
Fix Exit Preview Button Visibility During Alarm Ringing

### DIFF
--- a/lib/app/data/models/alarm_model.dart
+++ b/lib/app/data/models/alarm_model.dart
@@ -61,6 +61,8 @@ class AlarmModel {
   late bool isCall;
   @ignore
   Map? offsetDetails;
+  @ignore
+  bool preview = false;
 
   AlarmModel(
       {required this.alarmTime,

--- a/lib/app/data/models/alarm_model.dart
+++ b/lib/app/data/models/alarm_model.dart
@@ -61,8 +61,6 @@ class AlarmModel {
   late bool isCall;
   @ignore
   Map? offsetDetails;
-  @ignore
-  bool preview = false;
 
   AlarmModel(
       {required this.alarmTime,

--- a/lib/app/modules/alarmRing/controllers/alarm_ring_controller.dart
+++ b/lib/app/modules/alarmRing/controllers/alarm_ring_controller.dart
@@ -48,6 +48,7 @@ class AlarmControlController extends GetxController {
   late double initialVolume;
   late Timer guardianTimer;
   RxInt guardianCoundown = 120.obs;
+  RxBool isPreviewMode = false.obs;
 
 
 
@@ -173,6 +174,8 @@ class AlarmControlController extends GetxController {
     super.onInit();
     startListeningToFlip();
 
+    // Check if this is preview mode - when user clicks "Preview Alarm" in menu
+    isPreviewMode.value = Get.arguments?.preview == true;
     currentlyRingingAlarm.value = Get.arguments;
     print('hwyooo ${currentlyRingingAlarm.value.isGuardian}');
      IsarDb()

--- a/lib/app/modules/alarmRing/controllers/alarm_ring_controller.dart
+++ b/lib/app/modules/alarmRing/controllers/alarm_ring_controller.dart
@@ -174,9 +174,16 @@ class AlarmControlController extends GetxController {
     super.onInit();
     startListeningToFlip();
 
-    // Check if this is preview mode - when user clicks "Preview Alarm" in menu
-    isPreviewMode.value = Get.arguments?.preview == true;
-    currentlyRingingAlarm.value = Get.arguments;
+    // Extract alarm and preview flag from arguments
+    final args = Get.arguments;
+    if (args is Map) {
+      currentlyRingingAlarm.value = args['alarm'];
+      isPreviewMode.value = args['preview'] ?? false;
+    } else {
+      currentlyRingingAlarm.value = args;
+      isPreviewMode.value = false;
+    }
+
     print('hwyooo ${currentlyRingingAlarm.value.isGuardian}');
      IsarDb()
         .insertLog('Alarm ringing ${currentlyRingingAlarm.value.alarmTime}');

--- a/lib/app/modules/alarmRing/views/alarm_ring_view.dart
+++ b/lib/app/modules/alarmRing/views/alarm_ring_view.dart
@@ -224,29 +224,31 @@ class AlarmControlView extends GetView<AlarmControlController> {
                   ),
                 ),
               ),
-              Positioned(
-                bottom: 0,
-                left: 0,
-                right: 0,
-                child: Container(
-                  width: double.infinity,
-                  height: 60,
-                  color: Colors.red,
-                  child: TextButton(
-                    onPressed: () {
-                      Utils.hapticFeedback();
-                      Get.offNamed('/bottom-navigation-bar');
-                    },
-                    child: Text(
-                      'Exit Preview'.tr,
-                      style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                            color: Colors.white,
-                            fontWeight: FontWeight.bold,
-                          ),
+              // Exit Preview button - only show in preview mode
+              if (controller.isPreviewMode.value)
+                Positioned(
+                  bottom: 0,
+                  left: 0,
+                  right: 0,
+                  child: Container(
+                    width: double.infinity,
+                    height: 60,
+                    color: Colors.red,
+                    child: TextButton(
+                      onPressed: () {
+                        Utils.hapticFeedback();
+                        Get.offNamed('/bottom-navigation-bar');
+                      },
+                      child: Text(
+                        'Exit Preview'.tr,
+                        style: Theme.of(context).textTheme.bodyLarge!.copyWith(
+                              color: Colors.white,
+                              fontWeight: FontWeight.bold,
+                            ),
+                      ),
                     ),
                   ),
                 ),
-              ),
             ],
           ),
         ),

--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -973,9 +973,10 @@ class HomeView extends GetView<HomeController> {
                                                                               onSelected: (value) async {
                                                                                 Utils.hapticFeedback();
                                                                                 if (value == 0) {
-                                                                                  alarm.preview = true;  
-                                                                                  Get.back();
-                                                                                  Get.offNamed('/alarm-ring', arguments: alarm);
+                                                                                  Get.toNamed('/alarm-ring', arguments: {
+                                                                                    'alarm': alarm,
+                                                                                    'preview': true
+                                                                                  });
                                                                                 } else if (value == 1) {
                                                                                   debugPrint(alarm.isSharedAlarmEnabled.toString());
 

--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -973,7 +973,7 @@ class HomeView extends GetView<HomeController> {
                                                                               onSelected: (value) async {
                                                                                 Utils.hapticFeedback();
                                                                                 if (value == 0) {
-                                                                                  alarm.preview = true;  // Add this line
+                                                                                  alarm.preview = true;  
                                                                                   Get.back();
                                                                                   Get.offNamed('/alarm-ring', arguments: alarm);
                                                                                 } else if (value == 1) {

--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -973,6 +973,7 @@ class HomeView extends GetView<HomeController> {
                                                                               onSelected: (value) async {
                                                                                 Utils.hapticFeedback();
                                                                                 if (value == 0) {
+                                                                                  alarm.preview = true;  // Add this line
                                                                                   Get.back();
                                                                                   Get.offNamed('/alarm-ring', arguments: alarm);
                                                                                 } else if (value == 1) {


### PR DESCRIPTION
## **Description**  
This PR fixes an issue where the **Exit Preview** button was incorrectly visible during both the alarm **preview** and when the alarm was actively **ringing**. This unintended behavior has now been corrected.  

Now, the **Exit Preview** button is **only visible in preview mode** and is **hidden** when the alarm is ringing. This improves the user experience by ensuring that the button does not appear in unnecessary situations.  

## **Proposed Changes**  
✅ The **Exit Preview** button now appears **only** in preview mode.  
❌ It is **no longer visible** when the alarm is ringing.  
🛠 Updated the UI logic to properly manage button visibility.  

## **Fixes**  
Fixes #778  

## **Screen Recordings**  
Below are the screen recordings demonstrating the issue **before and after** the fix:  

### **Before (Issue Present):**  
[🔗 Video Link](https://github.com/user-attachments/assets/f1c0992a-006a-4397-86f5-e48e82751da4)  

### **After (Fixed):**  
[🔗 Video Link](https://github.com/user-attachments/assets/40fe11b6-6fc7-46f6-83d8-2643356c3e7c)  

## **Testing**  
- [x] Verified that the **Exit Preview** button appears **only** in preview mode.  
- [x] Verified that the button **does not** appear when the alarm is ringing.  
- [x] Manually tested on different alarm states to confirm expected behavior.  

## **Additional Notes**  
- No breaking changes introduced.  
- UI behavior now aligns with the intended design.  