### PR TITLE
🚀 Fix: Navigation Error When Exiting Preview  

### DIFF
--- a/lib/app/modules/alarmRing/views/alarm_ring_view.dart
+++ b/lib/app/modules/alarmRing/views/alarm_ring_view.dart
@@ -251,7 +251,7 @@ class AlarmControlView extends GetView<AlarmControlController> {
                     child: TextButton(
                       onPressed: () {
                         Utils.hapticFeedback();
-                        Get.offNamed('/bottom-navigation-bar');
+                        Get.offAllNamed('/bottom-navigation-bar'); 
                       },
                       child: Text(
                         'Exit Preview'.tr,


### PR DESCRIPTION
Fixes: #783  

#### **Description**  
This PR fixes the issue where clicking **"Exit Preview"** results in an **error page** instead of navigating correctly to the home page. The issue was caused by using `Get.offNamed('home')`, which did not properly reset the navigation stack.  

#### **Changes Made**  
- Replaced `Get.offNamed('home')` with `Get.offAllNamed('home')` to ensure the navigation stack is fully reset.  

#### **How to Test**  
1. Open the **preview screen**.  
2. Click on **"Exit Preview"**.  
3. Verify that the app correctly navigates to the **home page** **without showing an error page**.  
4. Ensure that the **bottom navigation bar** is **visible and functioning correctly**.  

#### **Screen Recording**  

**Before:**  

https://github.com/user-attachments/assets/42269a5b-d134-4a01-9a5d-ea8a1c40b636)](https://github.com/user-attachments/assets/42269a5b-d134-4a01-9a5d-ea8a1c40b636

**After:**  

https://github.com/user-attachments/assets/0120579b-beee-49eb-9a92-4a09ac69ca34)](https://github.com/user-attachments/assets/0120579b-beee-49eb-9a92-4a09ac69ca34
