### PR TITLE
fix : Exiting Preview Shows Error Page

### DIFF
--- a/lib/app/modules/alarmRing/views/alarm_ring_view.dart
+++ b/lib/app/modules/alarmRing/views/alarm_ring_view.dart
@@ -251,7 +251,7 @@ class AlarmControlView extends GetView<AlarmControlController> {
                     child: TextButton(
                       onPressed: () {
                         Utils.hapticFeedback();
-                        Get.offNamed('/bottom-navigation-bar');
+                        Get.offAllNamed('/bottom-navigation-bar');
                       },
                       child: Text(
                         'Exit Preview'.tr,

--- a/lib/app/modules/bottomNavigationBar/views/bottom_navigation_bar_view.dart
+++ b/lib/app/modules/bottomNavigationBar/views/bottom_navigation_bar_view.dart
@@ -6,13 +6,10 @@ import 'package:ultimate_alarm_clock/app/utils/constants.dart';
 import 'package:ultimate_alarm_clock/app/utils/utils.dart';
 
 class BottomNavigationBarView extends GetView<BottomNavigationBarController> {
-  late final PageController pageController;
+  PageController pageController = PageController();
   final ThemeController themeController = Get.find<ThemeController>();
 
-  BottomNavigationBarView({super.key}) {
-    pageController = PageController();
-  }
-
+  BottomNavigationBarView({super.key});
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -21,9 +18,8 @@ class BottomNavigationBarView extends GetView<BottomNavigationBarController> {
           future: controller.loadSavedState(),
           builder: (context, snapshot) {
             if (controller.hasloaded.value != false) {
-              if (pageController.hasClients && pageController.page != controller.activeTabIndex.value) {
-                pageController.jumpToPage(controller.activeTabIndex.value);
-              }
+              pageController =
+                  PageController(initialPage: controller.activeTabIndex.value);
               return PageView(
                 controller: pageController,
                 children: controller.pages,

--- a/lib/app/modules/bottomNavigationBar/views/bottom_navigation_bar_view.dart
+++ b/lib/app/modules/bottomNavigationBar/views/bottom_navigation_bar_view.dart
@@ -6,10 +6,13 @@ import 'package:ultimate_alarm_clock/app/utils/constants.dart';
 import 'package:ultimate_alarm_clock/app/utils/utils.dart';
 
 class BottomNavigationBarView extends GetView<BottomNavigationBarController> {
-  PageController pageController = PageController();
+  late final PageController pageController;
   final ThemeController themeController = Get.find<ThemeController>();
 
-  BottomNavigationBarView({super.key});
+  BottomNavigationBarView({super.key}) {
+    pageController = PageController();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -18,8 +21,9 @@ class BottomNavigationBarView extends GetView<BottomNavigationBarController> {
           future: controller.loadSavedState(),
           builder: (context, snapshot) {
             if (controller.hasloaded.value != false) {
-              pageController =
-                  PageController(initialPage: controller.activeTabIndex.value);
+              if (pageController.hasClients && pageController.page != controller.activeTabIndex.value) {
+                pageController.jumpToPage(controller.activeTabIndex.value);
+              }
               return PageView(
                 controller: pageController,
                 children: controller.pages,


### PR DESCRIPTION
### Description
This PR solves the  preview screen, the app is supposed to navigate back to the home page. However, clicking the "Exit Preview" button currently results in an error page instead.
it is fixed now 

### Proposed Changes
alarm_ring_view.dart
used offAllNamed()

## Fixes #783 

## Screenshots

https://github.com/user-attachments/assets/e6d1ccb2-b066-4730-b1e5-d54d986cf98f

## Checklist


- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing