### PR TITLE
Improve snooze duration list ux

### DIFF
--- a/lib/app/modules/addOrUpdateAlarm/views/snooze_duration_tile.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/snooze_duration_tile.dart
@@ -51,9 +51,9 @@ class SnoozeDurationTile extends StatelessWidget {
                           Obx(
                             () => NumberPicker(
                               value: controller.snoozeDuration.value <= 0
-                                  ? 1
+                                  ? 0
                                   : controller.snoozeDuration.value,
-                              minValue: 1,
+                              minValue: 0,
                               maxValue: 60,
                               onChanged: (value) {
                                 Utils.hapticFeedback();
@@ -63,9 +63,11 @@ class SnoozeDurationTile extends StatelessWidget {
                           ),
                           Obx(
                             () => Text(
-                              controller.snoozeDuration.value > 1
+                              controller.snoozeDuration.value > 0
+                              ? controller.snoozeDuration.value > 1
                                   ? 'minutes'.tr
-                                  : 'minute'.tr,
+                                  : 'minute'.tr
+                              : 'Off'.tr,
                             ),
                           ),
                         ],


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this pull request -->
The snooze duration NumberPicker starts from 1 (minute) which cannot be selected from first attempt (as shown in first video). Also, user cannot disable snooze after setting it because the minimum choice is 1. 

### Proposed Changes
<!-- List the proposed changes introduced by this pull request -->
Make the list start from 0 (off state) to to add snooze disabling functionality. Also, this is better ux-wise as compared to 1 as initial state which does not get selected even after pressing Done 


## Videos

Before:

https://github.com/user-attachments/assets/ec529f43-11a3-4e27-a243-5aa3c5dc010e


After:

https://github.com/user-attachments/assets/0365ed34-e467-4480-ae26-61f6dc460220



## Checklist
<!-- Mark the completed tasks with [x] -->
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing