### PR TITLE
fix:Dismiss shows error 

### DIFF
--- a/lib/app/modules/alarmRing/views/alarm_ring_view.dart
+++ b/lib/app/modules/alarmRing/views/alarm_ring_view.dart
@@ -213,7 +213,7 @@ class AlarmControlView extends GetView<AlarmControlController> {
                               arguments: controller.currentlyRingingAlarm.value,
                             );
                           } else {
-                            Get.offNamed(
+                            Get.offAllNamed(
                               '/bottom-navigation-bar',
                               arguments: controller.currentlyRingingAlarm.value,
                             );


### PR DESCRIPTION
### Description
This PR solves the dismiss screen, the app is supposed to navigate back to the home page. However, clicking the "Exit Preview" button currently results in an error page instead.
it is fixed now


### Proposed Changes
alarm_ring_view.dart
used offAllNamed()


## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing