### PR TITLE
Add delete profile functionality

### DIFF
--- a/lib/app/data/providers/isar_provider.dart
+++ b/lib/app/data/providers/isar_provider.dart
@@ -271,6 +271,31 @@ class IsarDb {
     return profileModel;
   }
 
+  static void deleteProfile(String profileName) async {
+    final isarProvider = IsarDb();
+    final db = await isarProvider.db;
+    
+    final profile = await db.profileModels.filter().
+      profileNameEqualTo(profileName).findFirst();
+      
+    if (profile == null) return;
+
+    final deletedAlarms = await db.alarmModels.filter().
+      profileEqualTo(profileName).findAll();
+    
+    try {
+      await db.writeTxn(() async {
+        for (final alarm in deletedAlarms) {
+          await db.alarmModels.delete(alarm.isarId);
+        }
+        await db.profileModels.delete(profile.isarId);
+      });
+    } catch (e) {
+      debugPrint('Error deleting profile: $e');
+      rethrow;
+    }
+  }
+
   static Stream<List<ProfileModel>> getProfiles() async* {
     try {
       final isarProvider = IsarDb();

--- a/lib/app/modules/home/controllers/home_controller.dart
+++ b/lib/app/modules/home/controllers/home_controller.dart
@@ -242,6 +242,124 @@ class HomeController extends GetxController {
     profileModel.value = p!;
   }
 
+  void deleteProfile(ProfileModel profile, BuildContext context) async {
+    if (profile.profileName == 'Default') {
+      Get.snackbar(
+        'Error',
+        'Cannot delete the default profile',
+        snackPosition: SnackPosition.BOTTOM,
+        backgroundColor: Colors.red,
+        colorText: Colors.white,
+      );
+      return;
+    }
+
+    if (profile.isSharedAlarmEnabled) {
+      Get.snackbar(
+        'Error',
+        'This profile contains shared alarms.',
+        snackPosition: SnackPosition.BOTTOM,
+        backgroundColor: Colors.red,
+        colorText: Colors.white,
+      );
+      return;
+    }
+
+    Get.defaultDialog(
+      titlePadding: const EdgeInsets.symmetric(
+        vertical: 20,
+      ),
+      backgroundColor: themeController.secondaryBackgroundColor.value,
+      title: 'Delete Profile',
+      titleStyle: Theme.of(context).textTheme.displaySmall,
+      content: Column(
+        children: [
+          Text(
+            'This action will permanently delete '
+            'this profile and all its alarms.',
+            style: Theme.of(context).textTheme.bodyMedium,
+            textAlign: TextAlign.center,
+          ),
+          Padding(
+            padding: const EdgeInsets.only(
+              top: 20,
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                TextButton(
+                  onPressed: () => Get.back(),
+                  style: ButtonStyle(
+                    backgroundColor: MaterialStateProperty.all(
+                      kprimaryTextColor.withOpacity(0.5),
+                    ),
+                  ),
+                  child: Text(
+                    'Cancel',
+                    style: Theme.of(context).textTheme.displaySmall!,
+                  ),
+                ),
+                TextButton(
+                  onPressed: () async {
+                    ProfileModel deletedProfile = profile;
+                    try{
+                      IsarDb.deleteProfile(profile.profileName);
+                    } catch (e) {
+                      Get.snackbar(
+                        'Error',
+                        'Failed to delete profile',
+                        snackPosition: SnackPosition.BOTTOM,
+                        backgroundColor: Colors.red,
+                        colorText: Colors.white,
+                      );
+                      return;
+                    }
+                    
+                    if (profile.profileName == selectedProfile.value) {
+                      writeProfileName('Default');
+                    }
+                    Get.back();
+                    Get.snackbar(
+                      'Success',
+                      'Profile deleted successfully',
+                      snackPosition: SnackPosition.BOTTOM,
+                      colorText: Colors.white,
+                      margin: const EdgeInsets.symmetric(
+                        horizontal: 10,
+                        vertical: 15,
+                      ),
+                      mainButton: TextButton(
+                        onPressed: () async {
+                          await IsarDb.addProfile(deletedProfile);
+                          writeProfileName(deletedProfile.profileName);
+                          // might want to add the alarms back to the profile
+                          // however, patch alarm addition is not implemented yet
+                        },
+                        child: Text(
+                          'Undo',
+                          style: TextStyle(color: Colors.white),
+                        ),
+                      ),
+                    );
+                  },
+                  style: ButtonStyle(
+                    backgroundColor: MaterialStateProperty.all(kprimaryColor),
+                  ),
+                  child: Text(
+                    'Delete',
+                    style: Theme.of(context).textTheme.displaySmall!.copyWith(
+                      color: kprimaryBackgroundColor,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   @override
   void onInit() async {
     super.onInit();

--- a/lib/app/modules/home/views/profile_config.dart
+++ b/lib/app/modules/home/views/profile_config.dart
@@ -69,7 +69,7 @@ class _ProfileSelectState extends State<ProfileSelect> {
                       scrollDirection: Axis.horizontal,
                       child: Row(
                         children: profiles!
-                                  .map((e) => profileCapsule(e))
+                                  .map((e) => profileCapsule(e, context))
                                   .toList(),
                       ),
                     );
@@ -82,7 +82,7 @@ class _ProfileSelectState extends State<ProfileSelect> {
     ));
   }
 
-  Widget profileCapsule(ProfileModel profile) {
+  Widget profileCapsule(ProfileModel profile, BuildContext context) {
     return Padding(
       key: profile.profileName == controller.selectedProfile.value
           ? scrollKey
@@ -93,6 +93,9 @@ class _ProfileSelectState extends State<ProfileSelect> {
         onTap: () {
           controller.writeProfileName(profile.profileName);
           controller.expandProfile.value = !controller.expandProfile.value;
+        },
+        onLongPress: () {
+          controller.deleteProfile(profile, context);
         },
         child: Obx(() => Container(
               padding: EdgeInsets.symmetric(


### PR DESCRIPTION
### Description
Allowed the user to delete a profile and all of it's alarms. It must not have any shared alarms for now. The profile delete only can be undone but will be retrieved without any alarms (left for further development) 

### Proposed Changes
- Added delete dialog
- Added Undo for profile

## Fixes #796 

## Screenshots

![deleteDialog](https://github.com/user-attachments/assets/241e93f0-b976-48de-b7e2-3febc981e815)
![undo](https://github.com/user-attachments/assets/053313f3-e9ac-4b5c-9265-40557edfebd8)


## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing