### PR TITLE
Time Selection Issue #731 Resolved

### DIFF
--- a/lib/app/modules/addOrUpdateAlarm/controllers/input_time_controller.dart
+++ b/lib/app/modules/addOrUpdateAlarm/controllers/input_time_controller.dart
@@ -40,6 +40,21 @@ class InputTimeController extends GetxController {
     super.onInit();
   }
 
+  void initTimeTextField() {
+    AddOrUpdateAlarmController addOrUpdateAlarmController = Get.find<AddOrUpdateAlarmController>();
+    selectedDateTime.value = addOrUpdateAlarmController.selectedTime.value;
+
+    isAM.value = addOrUpdateAlarmController.selectedTime.value.hour < 12;
+    inputHrsController.text = settingsController.is24HrsEnabled.value
+        ? selectedDateTime.value.hour.toString()
+        : (selectedDateTime.value.hour == 0
+            ? '12'
+            : (selectedDateTime.value.hour > 12
+                ? (selectedDateTime.value.hour - 12).toString()
+                : selectedDateTime.value.hour.toString()));
+    inputMinutesController.text = selectedDateTime.value.minute.toString().padLeft(2, '0');
+  }
+
 
   final isAM = true.obs;
 
@@ -51,6 +66,10 @@ class InputTimeController extends GetxController {
 
   void changeDatePicker() {
     isTimePicker.value = !isTimePicker.value;
+
+    if (isTimePicker.value) {
+      initTimeTextField();
+    }
   }
 
 
@@ -108,18 +127,6 @@ class InputTimeController extends GetxController {
     AddOrUpdateAlarmController addOrUpdateAlarmController = Get.find<AddOrUpdateAlarmController>();
     selectedDateTime.value = addOrUpdateAlarmController.selectedTime.value;
 
-
-    isAM.value = addOrUpdateAlarmController.selectedTime.value.hour < 12;
-    inputHrsController.text = settingsController.is24HrsEnabled.value
-        ? selectedDateTime.value.hour.toString()
-        : (selectedDateTime.value.hour == 0
-            ? '12'
-            : (selectedDateTime.value.hour > 12
-                ? (selectedDateTime.value.hour - 12).toString()
-                : selectedDateTime.value.hour.toString()));
-    inputMinutesController.text = selectedDateTime.value.minute.toString();
-
-
     toggleIfAtBoundary();
 
     try {
@@ -135,7 +142,7 @@ class InputTimeController extends GetxController {
       int minute = int.parse(inputMinutesController.text);
       final time = TimeOfDay(hour: hour, minute: minute);
       DateTime today = DateTime.now();
-      DateTime tomorrow = today.add(Duration(days: 1));
+      DateTime tomorrow = today.add(const Duration(days: 1));
 
       bool isNextDay = (time.hour == today.hour && time.minute < today.minute) || (time.hour < today.hour);
       bool isNextMonth = isNextDay && (today.day > tomorrow.day);
@@ -210,6 +217,9 @@ class LimitRange extends TextInputFormatter {
   @override
   TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
     try {
+      if (newValue.text.isEmpty) {
+        return newValue;
+      }
       int value = int.parse(newValue.text);
       if (value < minRange) return TextEditingValue(text: minRange.toString());
       else if (value > maxRange) return TextEditingValue(text: maxRange.toString());

--- a/lib/app/modules/addOrUpdateAlarm/views/add_or_update_alarm_view.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/add_or_update_alarm_view.dart
@@ -36,7 +36,9 @@ import 'alarm_date_tile.dart';
 import 'guardian_angel.dart';
 
 class AddOrUpdateAlarmView extends GetView<AddOrUpdateAlarmController> {
-  AddOrUpdateAlarmView({Key? key}) : super(key: key);
+  AddOrUpdateAlarmView({super.key}) {
+    inputTimeController.initTimeTextField();
+  }
 
   final ThemeController themeController = Get.find<ThemeController>();
   final InputTimeController inputTimeController =
@@ -620,16 +622,13 @@ class AddOrUpdateAlarmView extends GetView<AddOrUpdateAlarmController> {
                                                           inputFormatters: [
                                                             FilteringTextInputFormatter
                                                                 .allow(RegExp(
-                                                                    '[1,2,3,4,5,6,7,8,9,0]')),
+                                                                    '[0-9]')),
                                                             LengthLimitingTextInputFormatter(
                                                                 2),
                                                             LimitRange(
-                                                                0,
-                                                                settingsController
-                                                                        .is24HrsEnabled
-                                                                        .value
-                                                                    ? 23
-                                                                    : 12),
+                                                              settingsController.is24HrsEnabled.value ? 0 : 1,
+                                                              settingsController.is24HrsEnabled.value ? 23 : 12,
+                                                            ),
                                                           ],
                                                         ),
                                                       ),


### PR DESCRIPTION
### Description
The issue was the `TextField`s in add/update alarm page weren't working correctly. 
The main problem was that the updation of values of both `TextEditingController`s was not happening as in `LimitRange` Text Formatter if an empty value is detected, it was returning the old value itself.

**One more thing upon opening the add/update alarm page with the TextFields alarm editing option, the initial values weren't of current timings but rather some other one.

### Proposed Changes
- Resolved by changing the LimitRange formatted by returning the newValue when the current text is empty.
- Moved the updating TextEditingController values to the function that would be called whenever the user switches from NumberPicker to TextFields, in the `changeDatePicker` function and the constructor of `AddOrUpdateAlarmView` where the ** part is resolved.

## Fixes #731

## Screenshots
### Before
https://github.com/user-attachments/assets/763dd272-7460-42cf-a457-1c6c01afaa49
### After

https://github.com/user-attachments/assets/9918cbca-daa3-4b14-8747-b3db63eb5313

## Checklist
<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing