### PR TITLE
feat: WiFi BSSID based alarm cancellation (Addition to Smart Controls)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -14,6 +14,8 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="android.permission.READ_INTERNAL_STORAGE" />
@@ -68,6 +70,12 @@
             android:name=".SpotifyPlayerService"
             android:enabled="true"
             android:exported="true"></service>
+
+        <service
+            android:name=".ultimate_alarm_clock.Utilities.WifiManagerService"
+            android:enabled="true"
+            android:exported="true"></service>
+
         <service android:name="com.pravera.flutter_foreground_task.service.ForegroundService" />
 
         <receiver

--- a/android/app/src/main/kotlin/com/ccextractor/ultimate_alarm_clock/ultimate_alarm_clock/GetLatestAlarm.kt
+++ b/android/app/src/main/kotlin/com/ccextractor/ultimate_alarm_clock/ultimate_alarm_clock/GetLatestAlarm.kt
@@ -149,7 +149,9 @@ fun getLatestAlarm(db: SQLiteDatabase, wantNextAlarm: Boolean, profile: String,c
                 "location" to setAlarm.location,
                 "isWeather" to setAlarm.isWeatherEnabled,
                 "weatherTypes" to setAlarm.weatherTypes,
-                "alarmID" to setAlarm.alarmId
+                "alarmID" to setAlarm.alarmId,
+                "isWifiEnabled" to setAlarm.isWifiEnabled,
+                "wifiBSSID" to setAlarm.wifiBSSID
             )
             Log.d("s", "sdsd ${a}")
             return a
@@ -298,7 +300,9 @@ data class AlarmModel(
     val location: String,
     val alarmDate: String,
     val alarmId: String,
-    val ringOn: Int
+    val ringOn: Int,
+    val isWifiEnabled: Int,
+    val wifiBSSID: String
 ) {
     companion object {
         @SuppressLint("Range")
@@ -316,6 +320,8 @@ data class AlarmModel(
             val alarmDate = cursor.getString(cursor.getColumnIndex("alarmDate"))
             val alarmId = cursor.getString(cursor.getColumnIndex("alarmID"))
             val ringOn = cursor.getInt(cursor.getColumnIndex("ringOn"))
+            val isWifiEnabled = cursor.getInt(cursor.getColumnIndex("isWifiEnabled"))
+            val wifiBSSID = cursor.getString(cursor.getColumnIndex("wifiBSSID"))
             return AlarmModel(
                 id,
                 minutesSinceMidnight,
@@ -329,7 +335,9 @@ data class AlarmModel(
                 location,
                 alarmDate,
                 alarmId,
-                ringOn
+                ringOn,
+                isWifiEnabled,
+                wifiBSSID
             )
         }
     }

--- a/android/app/src/main/kotlin/com/ccextractor/ultimate_alarm_clock/ultimate_alarm_clock/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/ccextractor/ultimate_alarm_clock/ultimate_alarm_clock/MainActivity.kt
@@ -17,6 +17,7 @@ import android.provider.Settings
 import android.util.Log
 import android.view.WindowManager
 import androidx.annotation.NonNull
+import com.ccextractor.ultimate_alarm_clock.ultimate_alarm_clock.Utilities.WifiManagerService
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
@@ -112,7 +113,9 @@ class MainActivity : FlutterActivity() {
                         ringTime["isLocation"]!! as Int,
                         ringTime["location"]!! as String,
                         ringTime["isWeather"]!! as Int,
-                        ringTime["weatherTypes"]!! as String
+                        ringTime["weatherTypes"]!! as String,
+                        ringTime["isWifiEnabled"]!! as Int,
+                        ringTime["wifiBSSID"]!! as String
                     )
                 } else {
                     println("FLUTTER CALLED CANCEL ALARMS")
@@ -166,7 +169,9 @@ class MainActivity : FlutterActivity() {
         locationMonitor: Int,
         setLocation: String,
         isWeather: Int,
-        weatherTypes: String
+        weatherTypes: String,
+        isWifiEnabled: Int,
+        wifiBSSID: String
     ) {
 
         val alarmManager = getSystemService(Context.ALARM_SERVICE) as AlarmManager
@@ -204,7 +209,26 @@ class MainActivity : FlutterActivity() {
             editor.putLong("flutter.is_screen_on", 0L)
             editor.apply()
         }
-        if (locationMonitor == 1) {
+        if (isWifiEnabled == 1) {
+            val sharedPreferences =
+                getSharedPreferences("FlutterSharedPreferences", Context.MODE_PRIVATE)
+            val editor = sharedPreferences.edit()
+            editor.putString("flutter.wifi_BSSID", wifiBSSID)
+            Log.d("Wifi BSSID", wifiBSSID)
+            editor.apply()
+            val wifiAlarmIntent = Intent(this, WifiManagerService::class.java)
+            val pendingWifiAlarmIntent = PendingIntent.getService(
+                this,
+                10,
+                wifiAlarmIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+            )
+            val alarmClockInfo = AlarmManager.AlarmClockInfo(triggerTime, pendingIntent)
+            alarmManager.setAlarmClock(
+                alarmClockInfo,
+                pendingWifiAlarmIntent
+            )
+        } else if (locationMonitor == 1) {
             val sharedPreferences =
                 getSharedPreferences("FlutterSharedPreferences", Context.MODE_PRIVATE)
             val editor = sharedPreferences.edit()

--- a/android/app/src/main/kotlin/com/ccextractor/ultimate_alarm_clock/ultimate_alarm_clock/Utilities/WifiManagerService.kt
+++ b/android/app/src/main/kotlin/com/ccextractor/ultimate_alarm_clock/ultimate_alarm_clock/Utilities/WifiManagerService.kt
@@ -1,0 +1,95 @@
+package com.ccextractor.ultimate_alarm_clock.ultimate_alarm_clock.Utilities
+
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.SharedPreferences
+import android.net.ConnectivityManager
+import android.net.wifi.WifiInfo
+import android.net.wifi.WifiManager
+import android.os.Build
+import android.os.IBinder
+import com.ccextractor.ultimate_alarm_clock.LogDatabaseHelper
+import com.ccextractor.ultimate_alarm_clock.MainActivity
+import kotlinx.coroutines.runBlocking
+
+class WifiManagerService: Service() {
+
+    override fun onCreate(): Unit = runBlocking {
+        super.onCreate()
+
+        val currBSSID = getCurrentBSSID(this@WifiManagerService)
+        val logdbHelper = LogDatabaseHelper(this@WifiManagerService)
+        if(currBSSID != null){
+            println("WIFI BSSID: $currBSSID")
+
+            val sharedPreferences = getSharedPreferences("FlutterSharedPreferences", Context.MODE_PRIVATE)
+            val wifiBSSID: String = sharedPreferences.getString("flutter.wifi_BSSID", "")!!
+
+            if(wifiBSSID != currBSSID){
+                println("Phone connected to some different wifi network.")
+                val flutterIntent =
+                    Intent(this@WifiManagerService, MainActivity::class.java).apply {
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                        putExtra("initialRoute", "/")
+                        putExtra("alarmRing", "true")
+                        putExtra("isAlarm", "true")
+
+                    }
+                println("ANDROID STARTING APP")
+                this@WifiManagerService.startActivity(flutterIntent)
+                logdbHelper.insertLog(
+                    "Alarm is ringing. Phone is connected to different wifi network than what was specified.",
+                    status = LogDatabaseHelper.Status.SUCCESS,
+                    type = LogDatabaseHelper.LogType.NORMAL,
+                    hasRung = 1
+                )
+
+                stopSelf()
+            }
+            else{
+                logdbHelper.insertLog(
+                    "Alarm doesn't ring. Phone is connected to the same wifi network as what was specified.",
+                    status = LogDatabaseHelper.Status.WARNING,
+                    type = LogDatabaseHelper.LogType.NORMAL,
+                    hasRung = 1
+                )
+                stopSelf()
+            }
+        }
+        else {
+            println("NO WIFI CONNECTED!")
+            val flutterIntent =
+                Intent(this@WifiManagerService, MainActivity::class.java).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                    putExtra("initialRoute", "/")
+                    putExtra("alarmRing", "true")
+                    putExtra("isAlarm", "true")
+
+                }
+            println("ANDROID STARTING APP")
+            this@WifiManagerService.startActivity(flutterIntent)
+            logdbHelper.insertLog(
+                "Alarm is ringing. Phone is not connected to any wifi.",
+                status = LogDatabaseHelper.Status.SUCCESS,
+                type = LogDatabaseHelper.LogType.NORMAL,
+                hasRung = 1
+            )
+
+            stopSelf()
+        }
+
+        stopSelf()
+    }
+
+    fun getCurrentBSSID(context: Context): String? {
+        val wifiManager = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+
+        val info = wifiManager.connectionInfo
+        return info?.bssid
+    }
+
+    override fun onBind(p0: Intent?): IBinder? {
+        return null
+    }
+}

--- a/lib/app/data/models/alarm_model.dart
+++ b/lib/app/data/models/alarm_model.dart
@@ -59,6 +59,9 @@ class AlarmModel {
   late int guardianTimer;
   late String guardian;
   late bool isCall;
+  late bool isWifiEnabled;
+  late String wifiName;
+  late String wifiBSSID;
   @ignore
   Map? offsetDetails;
 
@@ -109,7 +112,11 @@ class AlarmModel {
       required this.isGuardian,
       required this.guardianTimer,
       required this.guardian,
-      required this.isCall});
+      required this.isCall,
+      required this.isWifiEnabled,
+      required this.wifiName,
+      required this.wifiBSSID,
+      });
 
   AlarmModel.fromDocumentSnapshot({
     required firestore.DocumentSnapshot documentSnapshot,
@@ -231,6 +238,9 @@ class AlarmModel {
       guardian: map['guardian'],
       isCall: map['isCall'] == 1,
       ringOn: map['ringOn'] == 1,
+      isWifiEnabled: map['isWifiEnabled'] == 1,
+      wifiName: map['wifiName'],
+      wifiBSSID: map['wifiBSSID'],
     );
   }
 
@@ -283,6 +293,9 @@ class AlarmModel {
       'guardianTimer': guardianTimer,
       'guardian': guardian,
       'isCall': isCall ? 1 : 0,
+      'isWifiEnabled': isWifiEnabled ? 1 : 0,
+      'wifiName': wifiName,
+      'wifiBSSID': wifiBSSID,
     };
   }
 
@@ -338,6 +351,9 @@ class AlarmModel {
     guardian = alarmData['guardian'];
     isCall = alarmData['isCall'];
     ringOn = alarmData['ringOn'];
+    isWifiEnabled = alarmData['isWifiEnabled'];
+    wifiName = alarmData['wifiName'];
+    wifiBSSID = alarmData['wifiBSSID'];
   }
 
   AlarmModel.fromJson(String alarmData, UserModel? user) {
@@ -395,7 +411,10 @@ class AlarmModel {
       'guardianTimer': alarmRecord.guardianTimer,
       'guardian': alarmRecord.guardian,
       'isCall': alarmRecord.isCall,
-      'ringOn': alarmRecord.ringOn
+      'ringOn': alarmRecord.ringOn,
+      'isWifiEnabled': alarmRecord.isWifiEnabled,
+      'wifiName': alarmRecord.wifiName,
+      'wifiBSSID': alarmRecord.wifiBSSID
     };
 
     if (alarmRecord.isSharedAlarmEnabled) {

--- a/lib/app/data/models/alarm_model.g.dart
+++ b/lib/app/data/models/alarm_model.g.dart
@@ -7,7 +7,8 @@ part of 'alarm_model.dart';
 // **************************************************************************
 
 // coverage:ignore-file
-// ignore_for_file: duplicate_ignore, non_constant_identifier_names, constant_identifier_names, invalid_use_of_protected_member, unnecessary_cast, prefer_const_constructors, lines_longer_than_80_chars, require_trailing_commas, inference_failure_on_function_invocation, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_checks, join_return_with_assignment, prefer_final_locals, avoid_js_rounded_ints, avoid_positional_boolean_parameters, always_specify_types
+// ignore_for_file: duplicate_ignore, non_constant_identifier_names, constant_identifier_n
+//ames, invalid_use_of_protected_member, unnecessary_cast, prefer_const_constructors, lines_longer_than_80_chars, require_trailing_commas, inference_failure_on_function_invocation, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_checks, join_return_with_assignment, prefer_final_locals, avoid_js_rounded_ints, avoid_positional_boolean_parameters, always_specify_types
 
 extension GetAlarmModelCollection on Isar {
   IsarCollection<AlarmModel> get alarmModels => this.collection();
@@ -137,120 +138,135 @@ const AlarmModelSchema = CollectionSchema(
       name: r'isWeatherEnabled',
       type: IsarType.bool,
     ),
-    r'label': PropertySchema(
+    r'isWifiEnabled': PropertySchema(
       id: 24,
+      name: r'isWifiEnabled',
+      type: IsarType.bool,
+    ),
+    r'label': PropertySchema(
+      id: 25,
       name: r'label',
       type: IsarType.string,
     ),
     r'lastEditedUserId': PropertySchema(
-      id: 25,
+      id: 26,
       name: r'lastEditedUserId',
       type: IsarType.string,
     ),
     r'location': PropertySchema(
-      id: 26,
+      id: 27,
       name: r'location',
       type: IsarType.string,
     ),
     r'mainAlarmTime': PropertySchema(
-      id: 27,
+      id: 28,
       name: r'mainAlarmTime',
       type: IsarType.string,
     ),
     r'mathsDifficulty': PropertySchema(
-      id: 28,
+      id: 29,
       name: r'mathsDifficulty',
       type: IsarType.long,
     ),
     r'minutesSinceMidnight': PropertySchema(
-      id: 29,
+      id: 30,
       name: r'minutesSinceMidnight',
       type: IsarType.long,
     ),
     r'mutexLock': PropertySchema(
-      id: 30,
+      id: 31,
       name: r'mutexLock',
       type: IsarType.bool,
     ),
     r'note': PropertySchema(
-      id: 31,
+      id: 32,
       name: r'note',
       type: IsarType.string,
     ),
     r'numMathsQuestions': PropertySchema(
-      id: 32,
+      id: 33,
       name: r'numMathsQuestions',
       type: IsarType.long,
     ),
     r'numberOfSteps': PropertySchema(
-      id: 33,
+      id: 34,
       name: r'numberOfSteps',
       type: IsarType.long,
     ),
     r'ownerId': PropertySchema(
-      id: 34,
+      id: 35,
       name: r'ownerId',
       type: IsarType.string,
     ),
     r'ownerName': PropertySchema(
-      id: 35,
+      id: 36,
       name: r'ownerName',
       type: IsarType.string,
     ),
     r'profile': PropertySchema(
-      id: 36,
+      id: 37,
       name: r'profile',
       type: IsarType.string,
     ),
     r'qrValue': PropertySchema(
-      id: 37,
+      id: 38,
       name: r'qrValue',
       type: IsarType.string,
     ),
     r'ringOn': PropertySchema(
-      id: 38,
+      id: 39,
       name: r'ringOn',
       type: IsarType.bool,
     ),
     r'ringtoneName': PropertySchema(
-      id: 39,
+      id: 40,
       name: r'ringtoneName',
       type: IsarType.string,
     ),
     r'shakeTimes': PropertySchema(
-      id: 40,
+      id: 41,
       name: r'shakeTimes',
       type: IsarType.long,
     ),
     r'sharedUserIds': PropertySchema(
-      id: 41,
+      id: 42,
       name: r'sharedUserIds',
       type: IsarType.stringList,
     ),
     r'showMotivationalQuote': PropertySchema(
-      id: 42,
+      id: 43,
       name: r'showMotivationalQuote',
       type: IsarType.bool,
     ),
     r'snoozeDuration': PropertySchema(
-      id: 43,
+      id: 44,
       name: r'snoozeDuration',
       type: IsarType.long,
     ),
     r'volMax': PropertySchema(
-      id: 44,
+      id: 45,
       name: r'volMax',
       type: IsarType.double,
     ),
     r'volMin': PropertySchema(
-      id: 45,
+      id: 46,
       name: r'volMin',
       type: IsarType.double,
     ),
     r'weatherTypes': PropertySchema(
-      id: 46,
+      id: 47,
       name: r'weatherTypes',
       type: IsarType.longList,
+    ),
+    r'wifiBSSID': PropertySchema(
+      id: 48,
+      name: r'wifiBSSID',
+      type: IsarType.string,
+    ),
+    r'wifiName': PropertySchema(
+      id: 49,
+      name: r'wifiName',
+      type: IsarType.string,
     )
   },
   estimateSize: _alarmModelEstimateSize,
@@ -312,6 +328,8 @@ int _alarmModelEstimateSize(
     }
   }
   bytesCount += 3 + object.weatherTypes.length * 8;
+  bytesCount += 3 + object.wifiBSSID.length * 3;
+  bytesCount += 3 + object.wifiName.length * 3;
   return bytesCount;
 }
 
@@ -345,29 +363,32 @@ void _alarmModelSerialize(
   writer.writeBool(offsets[21], object.isShakeEnabled);
   writer.writeBool(offsets[22], object.isSharedAlarmEnabled);
   writer.writeBool(offsets[23], object.isWeatherEnabled);
-  writer.writeString(offsets[24], object.label);
-  writer.writeString(offsets[25], object.lastEditedUserId);
-  writer.writeString(offsets[26], object.location);
-  writer.writeString(offsets[27], object.mainAlarmTime);
-  writer.writeLong(offsets[28], object.mathsDifficulty);
-  writer.writeLong(offsets[29], object.minutesSinceMidnight);
-  writer.writeBool(offsets[30], object.mutexLock);
-  writer.writeString(offsets[31], object.note);
-  writer.writeLong(offsets[32], object.numMathsQuestions);
-  writer.writeLong(offsets[33], object.numberOfSteps);
-  writer.writeString(offsets[34], object.ownerId);
-  writer.writeString(offsets[35], object.ownerName);
-  writer.writeString(offsets[36], object.profile);
-  writer.writeString(offsets[37], object.qrValue);
-  writer.writeBool(offsets[38], object.ringOn);
-  writer.writeString(offsets[39], object.ringtoneName);
-  writer.writeLong(offsets[40], object.shakeTimes);
-  writer.writeStringList(offsets[41], object.sharedUserIds);
-  writer.writeBool(offsets[42], object.showMotivationalQuote);
-  writer.writeLong(offsets[43], object.snoozeDuration);
-  writer.writeDouble(offsets[44], object.volMax);
-  writer.writeDouble(offsets[45], object.volMin);
-  writer.writeLongList(offsets[46], object.weatherTypes);
+  writer.writeBool(offsets[24], object.isWifiEnabled);
+  writer.writeString(offsets[25], object.label);
+  writer.writeString(offsets[26], object.lastEditedUserId);
+  writer.writeString(offsets[27], object.location);
+  writer.writeString(offsets[28], object.mainAlarmTime);
+  writer.writeLong(offsets[29], object.mathsDifficulty);
+  writer.writeLong(offsets[30], object.minutesSinceMidnight);
+  writer.writeBool(offsets[31], object.mutexLock);
+  writer.writeString(offsets[32], object.note);
+  writer.writeLong(offsets[33], object.numMathsQuestions);
+  writer.writeLong(offsets[34], object.numberOfSteps);
+  writer.writeString(offsets[35], object.ownerId);
+  writer.writeString(offsets[36], object.ownerName);
+  writer.writeString(offsets[37], object.profile);
+  writer.writeString(offsets[38], object.qrValue);
+  writer.writeBool(offsets[39], object.ringOn);
+  writer.writeString(offsets[40], object.ringtoneName);
+  writer.writeLong(offsets[41], object.shakeTimes);
+  writer.writeStringList(offsets[42], object.sharedUserIds);
+  writer.writeBool(offsets[43], object.showMotivationalQuote);
+  writer.writeLong(offsets[44], object.snoozeDuration);
+  writer.writeDouble(offsets[45], object.volMax);
+  writer.writeDouble(offsets[46], object.volMin);
+  writer.writeLongList(offsets[47], object.weatherTypes);
+  writer.writeString(offsets[48], object.wifiBSSID);
+  writer.writeString(offsets[49], object.wifiName);
 }
 
 AlarmModel _alarmModelDeserialize(
@@ -400,29 +421,32 @@ AlarmModel _alarmModelDeserialize(
     isShakeEnabled: reader.readBool(offsets[21]),
     isSharedAlarmEnabled: reader.readBool(offsets[22]),
     isWeatherEnabled: reader.readBool(offsets[23]),
-    label: reader.readString(offsets[24]),
-    lastEditedUserId: reader.readString(offsets[25]),
-    location: reader.readString(offsets[26]),
-    mainAlarmTime: reader.readStringOrNull(offsets[27]),
-    mathsDifficulty: reader.readLong(offsets[28]),
-    minutesSinceMidnight: reader.readLong(offsets[29]),
-    mutexLock: reader.readBool(offsets[30]),
-    note: reader.readString(offsets[31]),
-    numMathsQuestions: reader.readLong(offsets[32]),
-    numberOfSteps: reader.readLong(offsets[33]),
-    ownerId: reader.readString(offsets[34]),
-    ownerName: reader.readString(offsets[35]),
-    profile: reader.readString(offsets[36]),
-    qrValue: reader.readString(offsets[37]),
-    ringOn: reader.readBool(offsets[38]),
-    ringtoneName: reader.readString(offsets[39]),
-    shakeTimes: reader.readLong(offsets[40]),
-    sharedUserIds: reader.readStringList(offsets[41]),
-    showMotivationalQuote: reader.readBool(offsets[42]),
-    snoozeDuration: reader.readLong(offsets[43]),
-    volMax: reader.readDouble(offsets[44]),
-    volMin: reader.readDouble(offsets[45]),
-    weatherTypes: reader.readLongList(offsets[46]) ?? [],
+    isWifiEnabled: reader.readBool(offsets[24]),
+    label: reader.readString(offsets[25]),
+    lastEditedUserId: reader.readString(offsets[26]),
+    location: reader.readString(offsets[27]),
+    mainAlarmTime: reader.readStringOrNull(offsets[28]),
+    mathsDifficulty: reader.readLong(offsets[29]),
+    minutesSinceMidnight: reader.readLong(offsets[30]),
+    mutexLock: reader.readBool(offsets[31]),
+    note: reader.readString(offsets[32]),
+    numMathsQuestions: reader.readLong(offsets[33]),
+    numberOfSteps: reader.readLong(offsets[34]),
+    ownerId: reader.readString(offsets[35]),
+    ownerName: reader.readString(offsets[36]),
+    profile: reader.readString(offsets[37]),
+    qrValue: reader.readString(offsets[38]),
+    ringOn: reader.readBool(offsets[39]),
+    ringtoneName: reader.readString(offsets[40]),
+    shakeTimes: reader.readLong(offsets[41]),
+    sharedUserIds: reader.readStringList(offsets[42]),
+    showMotivationalQuote: reader.readBool(offsets[43]),
+    snoozeDuration: reader.readLong(offsets[44]),
+    volMax: reader.readDouble(offsets[45]),
+    volMin: reader.readDouble(offsets[46]),
+    weatherTypes: reader.readLongList(offsets[47]) ?? [],
+    wifiBSSID: reader.readString(offsets[48]),
+    wifiName: reader.readString(offsets[49]),
   );
   object.firestoreId = reader.readStringOrNull(offsets[7]);
   object.isarId = id;
@@ -485,27 +509,27 @@ P _alarmModelDeserializeProp<P>(
     case 23:
       return (reader.readBool(offset)) as P;
     case 24:
-      return (reader.readString(offset)) as P;
+      return (reader.readBool(offset)) as P;
     case 25:
       return (reader.readString(offset)) as P;
     case 26:
       return (reader.readString(offset)) as P;
     case 27:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readString(offset)) as P;
     case 28:
-      return (reader.readLong(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 29:
       return (reader.readLong(offset)) as P;
     case 30:
-      return (reader.readBool(offset)) as P;
-    case 31:
-      return (reader.readString(offset)) as P;
-    case 32:
       return (reader.readLong(offset)) as P;
+    case 31:
+      return (reader.readBool(offset)) as P;
+    case 32:
+      return (reader.readString(offset)) as P;
     case 33:
       return (reader.readLong(offset)) as P;
     case 34:
-      return (reader.readString(offset)) as P;
+      return (reader.readLong(offset)) as P;
     case 35:
       return (reader.readString(offset)) as P;
     case 36:
@@ -513,23 +537,29 @@ P _alarmModelDeserializeProp<P>(
     case 37:
       return (reader.readString(offset)) as P;
     case 38:
-      return (reader.readBool(offset)) as P;
-    case 39:
       return (reader.readString(offset)) as P;
-    case 40:
-      return (reader.readLong(offset)) as P;
-    case 41:
-      return (reader.readStringList(offset)) as P;
-    case 42:
+    case 39:
       return (reader.readBool(offset)) as P;
-    case 43:
+    case 40:
+      return (reader.readString(offset)) as P;
+    case 41:
       return (reader.readLong(offset)) as P;
+    case 42:
+      return (reader.readStringList(offset)) as P;
+    case 43:
+      return (reader.readBool(offset)) as P;
     case 44:
-      return (reader.readDouble(offset)) as P;
+      return (reader.readLong(offset)) as P;
     case 45:
       return (reader.readDouble(offset)) as P;
     case 46:
+      return (reader.readDouble(offset)) as P;
+    case 47:
       return (reader.readLongList(offset) ?? []) as P;
+    case 48:
+      return (reader.readString(offset)) as P;
+    case 49:
+      return (reader.readString(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
   }
@@ -1817,6 +1847,16 @@ extension AlarmModelQueryFilter
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(FilterCondition.equalTo(
         property: r'isWeatherEnabled',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<AlarmModel, AlarmModel, QAfterFilterCondition>
+      isWifiEnabledEqualTo(bool value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'isWifiEnabled',
         value: value,
       ));
     });
@@ -4102,6 +4142,274 @@ extension AlarmModelQueryFilter
       );
     });
   }
+
+  QueryBuilder<AlarmModel, AlarmModel, QAfterFilterCondition> wifiBSSIDEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'wifiBSSID',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AlarmModel, AlarmModel, QAfterFilterCondition>
+      wifiBSSIDGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'wifiBSSID',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AlarmModel, AlarmModel, QAfterFilterCondition> wifiBSSIDLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'wifiBSSID',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AlarmModel, AlarmModel, QAfterFilterCondition> wifiBSSIDBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'wifiBSSID',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AlarmModel, AlarmModel, QAfterFilterCondition>
+      wifiBSSIDStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'wifiBSSID',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AlarmModel, AlarmModel, QAfterFilterCondition> wifiBSSIDEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'wifiBSSID',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AlarmModel, AlarmModel, QAfterFilterCondition> wifiBSSIDContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'wifiBSSID',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AlarmModel, AlarmModel, QAfterFilterCondition> wifiBSSIDMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'wifiBSSID',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AlarmModel, AlarmModel, QAfterFilterCondition>
+      wifiBSSIDIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'wifiBSSID',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<AlarmModel, AlarmModel, QAfterFilterCondition>
+      wifiBSSIDIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'wifiBSSID',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<AlarmModel, AlarmModel, QAfterFilterCondition> wifiNameEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'wifiName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AlarmModel, AlarmModel, QAfterFilterCondition>
+      wifiNameGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'wifiName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AlarmModel, AlarmModel, QAfterFilterCondition> wifiNameLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'wifiName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AlarmModel, AlarmModel, QAfterFilterCondition> wifiNameBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'wifiName',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AlarmModel, AlarmModel, QAfterFilterCondition>
+      wifiNameStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'wifiName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AlarmModel, AlarmModel, QAfterFilterCondition> wifiNameEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'wifiName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AlarmModel, AlarmModel, QAfterFilterCondition> wifiNameContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'wifiName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AlarmModel, AlarmModel, QAfterFilterCondition> wifiNameMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'wifiName',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AlarmModel, AlarmModel, QAfterFilterCondition>
+      wifiNameIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'wifiName',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<AlarmModel, AlarmModel, QAfterFilterCondition>
+      wifiNameIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'wifiName',
+        value: '',
+      ));
+    });
+  }
 }
 
 extension AlarmModelQueryObject
@@ -4402,6 +4710,18 @@ extension AlarmModelQuerySortBy
     });
   }
 
+  QueryBuilder<AlarmModel, AlarmModel, QAfterSortBy> sortByIsWifiEnabled() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isWifiEnabled', Sort.asc);
+    });
+  }
+
+  QueryBuilder<AlarmModel, AlarmModel, QAfterSortBy> sortByIsWifiEnabledDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isWifiEnabled', Sort.desc);
+    });
+  }
+
   QueryBuilder<AlarmModel, AlarmModel, QAfterSortBy> sortByLabel() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'label', Sort.asc);
@@ -4659,6 +4979,30 @@ extension AlarmModelQuerySortBy
   QueryBuilder<AlarmModel, AlarmModel, QAfterSortBy> sortByVolMinDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'volMin', Sort.desc);
+    });
+  }
+
+  QueryBuilder<AlarmModel, AlarmModel, QAfterSortBy> sortByWifiBSSID() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'wifiBSSID', Sort.asc);
+    });
+  }
+
+  QueryBuilder<AlarmModel, AlarmModel, QAfterSortBy> sortByWifiBSSIDDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'wifiBSSID', Sort.desc);
+    });
+  }
+
+  QueryBuilder<AlarmModel, AlarmModel, QAfterSortBy> sortByWifiName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'wifiName', Sort.asc);
+    });
+  }
+
+  QueryBuilder<AlarmModel, AlarmModel, QAfterSortBy> sortByWifiNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'wifiName', Sort.desc);
     });
   }
 }
@@ -4955,6 +5299,18 @@ extension AlarmModelQuerySortThenBy
     });
   }
 
+  QueryBuilder<AlarmModel, AlarmModel, QAfterSortBy> thenByIsWifiEnabled() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isWifiEnabled', Sort.asc);
+    });
+  }
+
+  QueryBuilder<AlarmModel, AlarmModel, QAfterSortBy> thenByIsWifiEnabledDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isWifiEnabled', Sort.desc);
+    });
+  }
+
   QueryBuilder<AlarmModel, AlarmModel, QAfterSortBy> thenByIsarId() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'isarId', Sort.asc);
@@ -5226,6 +5582,30 @@ extension AlarmModelQuerySortThenBy
       return query.addSortBy(r'volMin', Sort.desc);
     });
   }
+
+  QueryBuilder<AlarmModel, AlarmModel, QAfterSortBy> thenByWifiBSSID() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'wifiBSSID', Sort.asc);
+    });
+  }
+
+  QueryBuilder<AlarmModel, AlarmModel, QAfterSortBy> thenByWifiBSSIDDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'wifiBSSID', Sort.desc);
+    });
+  }
+
+  QueryBuilder<AlarmModel, AlarmModel, QAfterSortBy> thenByWifiName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'wifiName', Sort.asc);
+    });
+  }
+
+  QueryBuilder<AlarmModel, AlarmModel, QAfterSortBy> thenByWifiNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'wifiName', Sort.desc);
+    });
+  }
 }
 
 extension AlarmModelQueryWhereDistinct
@@ -5384,6 +5764,12 @@ extension AlarmModelQueryWhereDistinct
     });
   }
 
+  QueryBuilder<AlarmModel, AlarmModel, QDistinct> distinctByIsWifiEnabled() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'isWifiEnabled');
+    });
+  }
+
   QueryBuilder<AlarmModel, AlarmModel, QDistinct> distinctByLabel(
       {bool caseSensitive = true}) {
     return QueryBuilder.apply(this, (query) {
@@ -5534,6 +5920,20 @@ extension AlarmModelQueryWhereDistinct
   QueryBuilder<AlarmModel, AlarmModel, QDistinct> distinctByWeatherTypes() {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'weatherTypes');
+    });
+  }
+
+  QueryBuilder<AlarmModel, AlarmModel, QDistinct> distinctByWifiBSSID(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'wifiBSSID', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<AlarmModel, AlarmModel, QDistinct> distinctByWifiName(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'wifiName', caseSensitive: caseSensitive);
     });
   }
 }
@@ -5693,6 +6093,12 @@ extension AlarmModelQueryProperty
     });
   }
 
+  QueryBuilder<AlarmModel, bool, QQueryOperations> isWifiEnabledProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'isWifiEnabled');
+    });
+  }
+
   QueryBuilder<AlarmModel, String, QQueryOperations> labelProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'label');
@@ -5832,6 +6238,18 @@ extension AlarmModelQueryProperty
   QueryBuilder<AlarmModel, List<int>, QQueryOperations> weatherTypesProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'weatherTypes');
+    });
+  }
+
+  QueryBuilder<AlarmModel, String, QQueryOperations> wifiBSSIDProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'wifiBSSID');
+    });
+  }
+
+  QueryBuilder<AlarmModel, String, QQueryOperations> wifiNameProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'wifiName');
     });
   }
 }

--- a/lib/app/data/models/profile_model.dart
+++ b/lib/app/data/models/profile_model.dart
@@ -54,6 +54,9 @@ class ProfileModel {
   late int guardianTimer;
   late String guardian;
   late bool isCall;
+  late bool isWifiEnabled;
+  late String wifiName;
+  late String wifiBSSID;
   @ignore
   Map? offsetDetails;
 
@@ -101,7 +104,11 @@ class ProfileModel {
       required this.isGuardian,
       required this.guardianTimer,
       required this.guardian,
-      required this.isCall});
+      required this.isCall,
+      required this.isWifiEnabled,
+      required this.wifiName,
+      required this.wifiBSSID,
+      });
 
   ProfileModel.fromDocumentSnapshot({
     required firestore.DocumentSnapshot documentSnapshot,
@@ -167,6 +174,9 @@ class ProfileModel {
     guardianTimer = documentSnapshot['guardianTimer'];
     guardian = documentSnapshot['guardian'];
     isCall = documentSnapshot['isCall'];
+    isWifiEnabled = documentSnapshot['isWifiEnabled'];
+    wifiName = documentSnapshot['wifiName'];
+    wifiBSSID = documentSnapshot['wifiBSSID'];
   }
 
   ProfileModel.fromMap(Map<String, dynamic> profileData) {
@@ -219,6 +229,9 @@ class ProfileModel {
     guardian = profileData['guardian'];
     isCall = profileData['isCall'];
     ringOn = profileData['ringOn'];
+    isWifiEnabled = profileData['isWifiEnabled'];
+    wifiName = profileData['wifiName'];
+    wifiBSSID = profileData['wifiBSSID'];
   }
 
   ProfileModel.fromJson(String profileData, UserModel? user) {
@@ -274,7 +287,10 @@ class ProfileModel {
       'guardianTimer': profileRecord.guardianTimer,
       'guardian': profileRecord.guardian,
       'isCall': profileRecord.isCall,
-      'ringOn': profileRecord.ringOn
+      'ringOn': profileRecord.ringOn,
+      'isWifiEnabled': profileRecord.isWifiEnabled,
+      'wifiName': profileRecord.wifiName,
+      'wifiBSSID': profileRecord.wifiBSSID,
     };
 
     if (profileRecord.isSharedAlarmEnabled) {

--- a/lib/app/data/models/profile_model.g.dart
+++ b/lib/app/data/models/profile_model.g.dart
@@ -127,115 +127,130 @@ const ProfileModelSchema = CollectionSchema(
       name: r'isWeatherEnabled',
       type: IsarType.bool,
     ),
-    r'label': PropertySchema(
+    r'isWifiEnabled': PropertySchema(
       id: 22,
+      name: r'isWifiEnabled',
+      type: IsarType.bool,
+    ),
+    r'label': PropertySchema(
+      id: 23,
       name: r'label',
       type: IsarType.string,
     ),
     r'lastEditedUserId': PropertySchema(
-      id: 23,
+      id: 24,
       name: r'lastEditedUserId',
       type: IsarType.string,
     ),
     r'location': PropertySchema(
-      id: 24,
+      id: 25,
       name: r'location',
       type: IsarType.string,
     ),
     r'mathsDifficulty': PropertySchema(
-      id: 25,
+      id: 26,
       name: r'mathsDifficulty',
       type: IsarType.long,
     ),
     r'minutesSinceMidnight': PropertySchema(
-      id: 26,
+      id: 27,
       name: r'minutesSinceMidnight',
       type: IsarType.long,
     ),
     r'mutexLock': PropertySchema(
-      id: 27,
+      id: 28,
       name: r'mutexLock',
       type: IsarType.bool,
     ),
     r'note': PropertySchema(
-      id: 28,
+      id: 29,
       name: r'note',
       type: IsarType.string,
     ),
     r'numMathsQuestions': PropertySchema(
-      id: 29,
+      id: 30,
       name: r'numMathsQuestions',
       type: IsarType.long,
     ),
     r'numberOfSteps': PropertySchema(
-      id: 30,
+      id: 31,
       name: r'numberOfSteps',
       type: IsarType.long,
     ),
     r'ownerId': PropertySchema(
-      id: 31,
+      id: 32,
       name: r'ownerId',
       type: IsarType.string,
     ),
     r'ownerName': PropertySchema(
-      id: 32,
+      id: 33,
       name: r'ownerName',
       type: IsarType.string,
     ),
     r'profileName': PropertySchema(
-      id: 33,
+      id: 34,
       name: r'profileName',
       type: IsarType.string,
     ),
     r'qrValue': PropertySchema(
-      id: 34,
+      id: 35,
       name: r'qrValue',
       type: IsarType.string,
     ),
     r'ringOn': PropertySchema(
-      id: 35,
+      id: 36,
       name: r'ringOn',
       type: IsarType.bool,
     ),
     r'ringtoneName': PropertySchema(
-      id: 36,
+      id: 37,
       name: r'ringtoneName',
       type: IsarType.string,
     ),
     r'shakeTimes': PropertySchema(
-      id: 37,
+      id: 38,
       name: r'shakeTimes',
       type: IsarType.long,
     ),
     r'sharedUserIds': PropertySchema(
-      id: 38,
+      id: 39,
       name: r'sharedUserIds',
       type: IsarType.stringList,
     ),
     r'showMotivationalQuote': PropertySchema(
-      id: 39,
+      id: 40,
       name: r'showMotivationalQuote',
       type: IsarType.bool,
     ),
     r'snoozeDuration': PropertySchema(
-      id: 40,
+      id: 41,
       name: r'snoozeDuration',
       type: IsarType.long,
     ),
     r'volMax': PropertySchema(
-      id: 41,
+      id: 42,
       name: r'volMax',
       type: IsarType.double,
     ),
     r'volMin': PropertySchema(
-      id: 42,
+      id: 43,
       name: r'volMin',
       type: IsarType.double,
     ),
     r'weatherTypes': PropertySchema(
-      id: 43,
+      id: 44,
       name: r'weatherTypes',
       type: IsarType.longList,
+    ),
+    r'wifiBSSID': PropertySchema(
+      id: 45,
+      name: r'wifiBSSID',
+      type: IsarType.string,
+    ),
+    r'wifiName': PropertySchema(
+      id: 46,
+      name: r'wifiName',
+      type: IsarType.string,
     )
   },
   estimateSize: _profileModelEstimateSize,
@@ -289,6 +304,8 @@ int _profileModelEstimateSize(
     }
   }
   bytesCount += 3 + object.weatherTypes.length * 8;
+  bytesCount += 3 + object.wifiBSSID.length * 3;
+  bytesCount += 3 + object.wifiName.length * 3;
   return bytesCount;
 }
 
@@ -320,28 +337,31 @@ void _profileModelSerialize(
   writer.writeBool(offsets[19], object.isShakeEnabled);
   writer.writeBool(offsets[20], object.isSharedAlarmEnabled);
   writer.writeBool(offsets[21], object.isWeatherEnabled);
-  writer.writeString(offsets[22], object.label);
-  writer.writeString(offsets[23], object.lastEditedUserId);
-  writer.writeString(offsets[24], object.location);
-  writer.writeLong(offsets[25], object.mathsDifficulty);
-  writer.writeLong(offsets[26], object.minutesSinceMidnight);
-  writer.writeBool(offsets[27], object.mutexLock);
-  writer.writeString(offsets[28], object.note);
-  writer.writeLong(offsets[29], object.numMathsQuestions);
-  writer.writeLong(offsets[30], object.numberOfSteps);
-  writer.writeString(offsets[31], object.ownerId);
-  writer.writeString(offsets[32], object.ownerName);
-  writer.writeString(offsets[33], object.profileName);
-  writer.writeString(offsets[34], object.qrValue);
-  writer.writeBool(offsets[35], object.ringOn);
-  writer.writeString(offsets[36], object.ringtoneName);
-  writer.writeLong(offsets[37], object.shakeTimes);
-  writer.writeStringList(offsets[38], object.sharedUserIds);
-  writer.writeBool(offsets[39], object.showMotivationalQuote);
-  writer.writeLong(offsets[40], object.snoozeDuration);
-  writer.writeDouble(offsets[41], object.volMax);
-  writer.writeDouble(offsets[42], object.volMin);
-  writer.writeLongList(offsets[43], object.weatherTypes);
+  writer.writeBool(offsets[22], object.isWifiEnabled);
+  writer.writeString(offsets[23], object.label);
+  writer.writeString(offsets[24], object.lastEditedUserId);
+  writer.writeString(offsets[25], object.location);
+  writer.writeLong(offsets[26], object.mathsDifficulty);
+  writer.writeLong(offsets[27], object.minutesSinceMidnight);
+  writer.writeBool(offsets[28], object.mutexLock);
+  writer.writeString(offsets[29], object.note);
+  writer.writeLong(offsets[30], object.numMathsQuestions);
+  writer.writeLong(offsets[31], object.numberOfSteps);
+  writer.writeString(offsets[32], object.ownerId);
+  writer.writeString(offsets[33], object.ownerName);
+  writer.writeString(offsets[34], object.profileName);
+  writer.writeString(offsets[35], object.qrValue);
+  writer.writeBool(offsets[36], object.ringOn);
+  writer.writeString(offsets[37], object.ringtoneName);
+  writer.writeLong(offsets[38], object.shakeTimes);
+  writer.writeStringList(offsets[39], object.sharedUserIds);
+  writer.writeBool(offsets[40], object.showMotivationalQuote);
+  writer.writeLong(offsets[41], object.snoozeDuration);
+  writer.writeDouble(offsets[42], object.volMax);
+  writer.writeDouble(offsets[43], object.volMin);
+  writer.writeLongList(offsets[44], object.weatherTypes);
+  writer.writeString(offsets[45], object.wifiBSSID);
+  writer.writeString(offsets[46], object.wifiName);
 }
 
 ProfileModel _profileModelDeserialize(
@@ -372,28 +392,31 @@ ProfileModel _profileModelDeserialize(
     isShakeEnabled: reader.readBool(offsets[19]),
     isSharedAlarmEnabled: reader.readBool(offsets[20]),
     isWeatherEnabled: reader.readBool(offsets[21]),
-    label: reader.readString(offsets[22]),
-    lastEditedUserId: reader.readString(offsets[23]),
-    location: reader.readString(offsets[24]),
-    mathsDifficulty: reader.readLong(offsets[25]),
-    minutesSinceMidnight: reader.readLong(offsets[26]),
-    mutexLock: reader.readBool(offsets[27]),
-    note: reader.readString(offsets[28]),
-    numMathsQuestions: reader.readLong(offsets[29]),
-    numberOfSteps: reader.readLong(offsets[30]),
-    ownerId: reader.readString(offsets[31]),
-    ownerName: reader.readString(offsets[32]),
-    profileName: reader.readString(offsets[33]),
-    qrValue: reader.readString(offsets[34]),
-    ringOn: reader.readBool(offsets[35]),
-    ringtoneName: reader.readString(offsets[36]),
-    shakeTimes: reader.readLong(offsets[37]),
-    sharedUserIds: reader.readStringList(offsets[38]),
-    showMotivationalQuote: reader.readBool(offsets[39]),
-    snoozeDuration: reader.readLong(offsets[40]),
-    volMax: reader.readDouble(offsets[41]),
-    volMin: reader.readDouble(offsets[42]),
-    weatherTypes: reader.readLongList(offsets[43]) ?? [],
+    isWifiEnabled: reader.readBool(offsets[22]),
+    label: reader.readString(offsets[23]),
+    lastEditedUserId: reader.readString(offsets[24]),
+    location: reader.readString(offsets[25]),
+    mathsDifficulty: reader.readLong(offsets[26]),
+    minutesSinceMidnight: reader.readLong(offsets[27]),
+    mutexLock: reader.readBool(offsets[28]),
+    note: reader.readString(offsets[29]),
+    numMathsQuestions: reader.readLong(offsets[30]),
+    numberOfSteps: reader.readLong(offsets[31]),
+    ownerId: reader.readString(offsets[32]),
+    ownerName: reader.readString(offsets[33]),
+    profileName: reader.readString(offsets[34]),
+    qrValue: reader.readString(offsets[35]),
+    ringOn: reader.readBool(offsets[36]),
+    ringtoneName: reader.readString(offsets[37]),
+    shakeTimes: reader.readLong(offsets[38]),
+    sharedUserIds: reader.readStringList(offsets[39]),
+    showMotivationalQuote: reader.readBool(offsets[40]),
+    snoozeDuration: reader.readLong(offsets[41]),
+    volMax: reader.readDouble(offsets[42]),
+    volMin: reader.readDouble(offsets[43]),
+    weatherTypes: reader.readLongList(offsets[44]) ?? [],
+    wifiBSSID: reader.readString(offsets[45]),
+    wifiName: reader.readString(offsets[46]),
   );
   object.firestoreId = reader.readStringOrNull(offsets[5]);
   object.isarId = id;
@@ -452,25 +475,25 @@ P _profileModelDeserializeProp<P>(
     case 21:
       return (reader.readBool(offset)) as P;
     case 22:
-      return (reader.readString(offset)) as P;
+      return (reader.readBool(offset)) as P;
     case 23:
       return (reader.readString(offset)) as P;
     case 24:
       return (reader.readString(offset)) as P;
     case 25:
-      return (reader.readLong(offset)) as P;
+      return (reader.readString(offset)) as P;
     case 26:
       return (reader.readLong(offset)) as P;
     case 27:
-      return (reader.readBool(offset)) as P;
-    case 28:
-      return (reader.readString(offset)) as P;
-    case 29:
       return (reader.readLong(offset)) as P;
+    case 28:
+      return (reader.readBool(offset)) as P;
+    case 29:
+      return (reader.readString(offset)) as P;
     case 30:
       return (reader.readLong(offset)) as P;
     case 31:
-      return (reader.readString(offset)) as P;
+      return (reader.readLong(offset)) as P;
     case 32:
       return (reader.readString(offset)) as P;
     case 33:
@@ -478,23 +501,29 @@ P _profileModelDeserializeProp<P>(
     case 34:
       return (reader.readString(offset)) as P;
     case 35:
-      return (reader.readBool(offset)) as P;
-    case 36:
       return (reader.readString(offset)) as P;
-    case 37:
-      return (reader.readLong(offset)) as P;
-    case 38:
-      return (reader.readStringList(offset)) as P;
-    case 39:
+    case 36:
       return (reader.readBool(offset)) as P;
-    case 40:
+    case 37:
+      return (reader.readString(offset)) as P;
+    case 38:
       return (reader.readLong(offset)) as P;
+    case 39:
+      return (reader.readStringList(offset)) as P;
+    case 40:
+      return (reader.readBool(offset)) as P;
     case 41:
-      return (reader.readDouble(offset)) as P;
+      return (reader.readLong(offset)) as P;
     case 42:
       return (reader.readDouble(offset)) as P;
     case 43:
+      return (reader.readDouble(offset)) as P;
+    case 44:
       return (reader.readLongList(offset) ?? []) as P;
+    case 45:
+      return (reader.readString(offset)) as P;
+    case 46:
+      return (reader.readString(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
   }
@@ -1526,6 +1555,16 @@ extension ProfileModelQueryFilter
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(FilterCondition.equalTo(
         property: r'isWeatherEnabled',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<ProfileModel, ProfileModel, QAfterFilterCondition>
+      isWifiEnabledEqualTo(bool value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'isWifiEnabled',
         value: value,
       ));
     });
@@ -3687,6 +3726,278 @@ extension ProfileModelQueryFilter
       );
     });
   }
+
+  QueryBuilder<ProfileModel, ProfileModel, QAfterFilterCondition>
+      wifiBSSIDEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'wifiBSSID',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ProfileModel, ProfileModel, QAfterFilterCondition>
+      wifiBSSIDGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'wifiBSSID',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ProfileModel, ProfileModel, QAfterFilterCondition>
+      wifiBSSIDLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'wifiBSSID',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ProfileModel, ProfileModel, QAfterFilterCondition>
+      wifiBSSIDBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'wifiBSSID',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ProfileModel, ProfileModel, QAfterFilterCondition>
+      wifiBSSIDStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'wifiBSSID',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ProfileModel, ProfileModel, QAfterFilterCondition>
+      wifiBSSIDEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'wifiBSSID',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ProfileModel, ProfileModel, QAfterFilterCondition>
+      wifiBSSIDContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'wifiBSSID',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ProfileModel, ProfileModel, QAfterFilterCondition>
+      wifiBSSIDMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'wifiBSSID',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ProfileModel, ProfileModel, QAfterFilterCondition>
+      wifiBSSIDIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'wifiBSSID',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<ProfileModel, ProfileModel, QAfterFilterCondition>
+      wifiBSSIDIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'wifiBSSID',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<ProfileModel, ProfileModel, QAfterFilterCondition>
+      wifiNameEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'wifiName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ProfileModel, ProfileModel, QAfterFilterCondition>
+      wifiNameGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'wifiName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ProfileModel, ProfileModel, QAfterFilterCondition>
+      wifiNameLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'wifiName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ProfileModel, ProfileModel, QAfterFilterCondition>
+      wifiNameBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'wifiName',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ProfileModel, ProfileModel, QAfterFilterCondition>
+      wifiNameStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'wifiName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ProfileModel, ProfileModel, QAfterFilterCondition>
+      wifiNameEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'wifiName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ProfileModel, ProfileModel, QAfterFilterCondition>
+      wifiNameContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'wifiName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ProfileModel, ProfileModel, QAfterFilterCondition>
+      wifiNameMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'wifiName',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ProfileModel, ProfileModel, QAfterFilterCondition>
+      wifiNameIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'wifiName',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<ProfileModel, ProfileModel, QAfterFilterCondition>
+      wifiNameIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'wifiName',
+        value: '',
+      ));
+    });
+  }
 }
 
 extension ProfileModelQueryObject
@@ -3975,6 +4286,19 @@ extension ProfileModelQuerySortBy
     });
   }
 
+  QueryBuilder<ProfileModel, ProfileModel, QAfterSortBy> sortByIsWifiEnabled() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isWifiEnabled', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ProfileModel, ProfileModel, QAfterSortBy>
+      sortByIsWifiEnabledDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isWifiEnabled', Sort.desc);
+    });
+  }
+
   QueryBuilder<ProfileModel, ProfileModel, QAfterSortBy> sortByLabel() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'label', Sort.asc);
@@ -4228,6 +4552,30 @@ extension ProfileModelQuerySortBy
   QueryBuilder<ProfileModel, ProfileModel, QAfterSortBy> sortByVolMinDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'volMin', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ProfileModel, ProfileModel, QAfterSortBy> sortByWifiBSSID() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'wifiBSSID', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ProfileModel, ProfileModel, QAfterSortBy> sortByWifiBSSIDDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'wifiBSSID', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ProfileModel, ProfileModel, QAfterSortBy> sortByWifiName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'wifiName', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ProfileModel, ProfileModel, QAfterSortBy> sortByWifiNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'wifiName', Sort.desc);
     });
   }
 }
@@ -4512,6 +4860,19 @@ extension ProfileModelQuerySortThenBy
     });
   }
 
+  QueryBuilder<ProfileModel, ProfileModel, QAfterSortBy> thenByIsWifiEnabled() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isWifiEnabled', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ProfileModel, ProfileModel, QAfterSortBy>
+      thenByIsWifiEnabledDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isWifiEnabled', Sort.desc);
+    });
+  }
+
   QueryBuilder<ProfileModel, ProfileModel, QAfterSortBy> thenByIsarId() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'isarId', Sort.asc);
@@ -4779,6 +5140,30 @@ extension ProfileModelQuerySortThenBy
       return query.addSortBy(r'volMin', Sort.desc);
     });
   }
+
+  QueryBuilder<ProfileModel, ProfileModel, QAfterSortBy> thenByWifiBSSID() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'wifiBSSID', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ProfileModel, ProfileModel, QAfterSortBy> thenByWifiBSSIDDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'wifiBSSID', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ProfileModel, ProfileModel, QAfterSortBy> thenByWifiName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'wifiName', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ProfileModel, ProfileModel, QAfterSortBy> thenByWifiNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'wifiName', Sort.desc);
+    });
+  }
 }
 
 extension ProfileModelQueryWhereDistinct
@@ -4930,6 +5315,13 @@ extension ProfileModelQueryWhereDistinct
     });
   }
 
+  QueryBuilder<ProfileModel, ProfileModel, QDistinct>
+      distinctByIsWifiEnabled() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'isWifiEnabled');
+    });
+  }
+
   QueryBuilder<ProfileModel, ProfileModel, QDistinct> distinctByLabel(
       {bool caseSensitive = true}) {
     return QueryBuilder.apply(this, (query) {
@@ -5076,6 +5468,20 @@ extension ProfileModelQueryWhereDistinct
   QueryBuilder<ProfileModel, ProfileModel, QDistinct> distinctByWeatherTypes() {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'weatherTypes');
+    });
+  }
+
+  QueryBuilder<ProfileModel, ProfileModel, QDistinct> distinctByWifiBSSID(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'wifiBSSID', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<ProfileModel, ProfileModel, QDistinct> distinctByWifiName(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'wifiName', caseSensitive: caseSensitive);
     });
   }
 }
@@ -5226,6 +5632,12 @@ extension ProfileModelQueryProperty
     });
   }
 
+  QueryBuilder<ProfileModel, bool, QQueryOperations> isWifiEnabledProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'isWifiEnabled');
+    });
+  }
+
   QueryBuilder<ProfileModel, String, QQueryOperations> labelProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'label');
@@ -5361,6 +5773,18 @@ extension ProfileModelQueryProperty
       weatherTypesProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'weatherTypes');
+    });
+  }
+
+  QueryBuilder<ProfileModel, String, QQueryOperations> wifiBSSIDProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'wifiBSSID');
+    });
+  }
+
+  QueryBuilder<ProfileModel, String, QQueryOperations> wifiNameProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'wifiName');
     });
   }
 }

--- a/lib/app/data/providers/firestore_provider.dart
+++ b/lib/app/data/providers/firestore_provider.dart
@@ -82,8 +82,10 @@ class FirestoreDb {
         guardianTimer INTEGER,
         guardian TEXT,
         isCall INTEGER,
-        ringOn INTEGER
-
+        ringOn INTEGER,
+        isWifiEnabled INTEGER NOT NULL DEFAULT 0,
+        wifiName TEXT,
+        wifiBSSID TEXT
       )
     ''');
     await db.execute('''

--- a/lib/app/data/providers/isar_provider.dart
+++ b/lib/app/data/providers/isar_provider.dart
@@ -156,8 +156,10 @@ class IsarDb {
         guardianTimer INTEGER,
         guardian TEXT,
         isCall INTEGER,
-        ringOn INTEGER
-        
+        ringOn INTEGER,
+        isWifiEnabled INTEGER NOT NULL DEFAULT 0,
+        wifiName TEXT,
+        wifiBSSID TEXT
       )
     ''');
     await db.execute('''

--- a/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
+++ b/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
@@ -40,6 +40,9 @@ class AddOrUpdateAlarmController extends GetxController {
   final isActivityMonitorenabled = 0.obs;
   final activityInterval = 0.obs;
   final isLocationEnabled = false.obs;
+  final isWifiEnabled = false.obs;
+  final wifiName = ''.obs;
+  final wifiBSSID = ''.obs;
   final isSharedAlarmEnabled = false.obs;
   late final isWeatherEnabled = false.obs;
   final weatherApiKeyExists = false.obs;
@@ -768,6 +771,10 @@ class AddOrUpdateAlarmController extends GetxController {
       isWeatherEnabled.value = alarmRecord.value.isWeatherEnabled;
       weatherTypes.value = Utils.getFormattedWeatherTypes(selectedWeather);
 
+      isWifiEnabled.value = alarmRecord.value.isWifiEnabled;
+      wifiName.value = alarmRecord.value.wifiName;
+      wifiBSSID.value = alarmRecord.value.wifiBSSID;
+
       isMathsEnabled.value = alarmRecord.value.isMathsEnabled;
       numMathsQuestions.value = alarmRecord.value.numMathsQuestions;
       mathsDifficulty.value =
@@ -1075,6 +1082,9 @@ class AddOrUpdateAlarmController extends GetxController {
       guardian: guardian.value,
       isCall: isCall.value,
       ringOn: isFutureDate.value,
+      isWifiEnabled: isWifiEnabled.value,
+      wifiName: wifiName.value,
+      wifiBSSID: wifiBSSID.value,
     );
   }
 
@@ -1370,6 +1380,9 @@ class AddOrUpdateAlarmController extends GetxController {
       guardian: guardian.value,
       isCall: isCall.value,
       ringOn: isFutureDate.value,
+      isWifiEnabled: isWifiEnabled.value,
+      wifiName: wifiName.value,
+      wifiBSSID: wifiBSSID.value,
       );
 
       if (homeController.isProfileUpdate.value) {

--- a/lib/app/modules/addOrUpdateAlarm/views/add_or_update_alarm_view.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/add_or_update_alarm_view.dart
@@ -27,6 +27,7 @@ import 'package:ultimate_alarm_clock/app/modules/addOrUpdateAlarm/views/shared_a
 import 'package:ultimate_alarm_clock/app/modules/addOrUpdateAlarm/views/shared_users_tile.dart';
 import 'package:ultimate_alarm_clock/app/modules/addOrUpdateAlarm/views/snooze_duration_tile.dart';
 import 'package:ultimate_alarm_clock/app/modules/addOrUpdateAlarm/views/weather_tile.dart';
+import 'package:ultimate_alarm_clock/app/modules/addOrUpdateAlarm/views/wifi_based_tile.dart';
 import 'package:ultimate_alarm_clock/app/modules/settings/controllers/settings_controller.dart';
 import 'package:ultimate_alarm_clock/app/modules/settings/controllers/theme_controller.dart';
 import 'package:ultimate_alarm_clock/app/utils/constants.dart';
@@ -918,6 +919,16 @@ class AddOrUpdateAlarmView extends GetView<AddOrUpdateAlarmController> {
                                         color: themeController
                                             .primaryDisabledTextColor.value,
                                       ),
+                                      WifiBasedTile(
+                                        controller: controller,
+                                        height: height,
+                                        width: width,
+                                        themeController: themeController,
+                                      ),
+                                      Divider(
+                                        color: themeController
+                                            .primaryDisabledTextColor.value,
+                                      ),
                                       GuardianAngel(
                                         controller: controller,
                                         themeController: themeController,
@@ -1160,6 +1171,9 @@ class AddOrUpdateAlarmView extends GetView<AddOrUpdateAlarmController> {
                                     .contactTextEditingController.text,
                                 isCall: controller.isCall.value,
                                 ringOn: controller.isFutureDate.value,
+                                isWifiEnabled: controller.isWifiEnabled.value,
+                                wifiName: controller.wifiName.value,
+                                wifiBSSID: controller.wifiBSSID.value,
                               );
 
                               // Adding offset details to the database if

--- a/lib/app/modules/addOrUpdateAlarm/views/wifi_based_tile.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/wifi_based_tile.dart
@@ -1,0 +1,227 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:get_storage/get_storage.dart';
+import 'package:network_info_plus/network_info_plus.dart';
+import 'package:ultimate_alarm_clock/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart';
+import 'package:ultimate_alarm_clock/app/modules/settings/controllers/theme_controller.dart';
+import 'package:ultimate_alarm_clock/app/utils/constants.dart';
+import 'package:ultimate_alarm_clock/app/utils/utils.dart';
+
+class WifiBasedTile extends StatelessWidget {
+  const WifiBasedTile({
+    super.key,
+    required this.controller,
+    required this.height,
+    required this.width,
+    required this.themeController,
+  });
+
+  final AddOrUpdateAlarmController controller;
+  final ThemeController themeController;
+  final double height;
+  final double width;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      child: ListTile(
+        onTap: () async {
+          Utils.hapticFeedback();
+          if (await controller.checkAndRequestPermission()) {
+            final info = NetworkInfo();
+            final wifiName = await info.getWifiName();
+            final wifiBSSID = await info.getWifiBSSID();
+
+            Get.defaultDialog(
+                titlePadding: const EdgeInsets.symmetric(vertical: 20),
+                contentPadding: const EdgeInsets.symmetric(horizontal: 20),
+                backgroundColor: themeController.secondaryBackgroundColor.value,
+                title: 'Use this wifi network for alarm cancellation.',
+                titleStyle: Theme.of(context).textTheme.displaySmall,
+                content: WifiOption(
+                    name: wifiName,
+                    bssid: wifiBSSID,
+                    controller: controller,
+                    themeController: themeController,),
+                
+                
+                );
+                
+          } else {}
+        },
+        title: Row(
+          children: [
+            FittedBox(
+              alignment: Alignment.centerLeft,
+              fit: BoxFit.scaleDown,
+              child: Text(
+                'Wifi SSID Based'.tr,
+                style: TextStyle(
+                  color: themeController.primaryTextColor.value,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ),
+            IconButton(
+              icon: Icon(
+                Icons.info_sharp,
+                size: 21,
+                color: themeController.primaryTextColor.value.withOpacity(0.3),
+              ),
+              onPressed: () {
+                Utils.hapticFeedback();
+                Utils.showModal(
+                  context: context,
+                  title: 'Wifi SSID based cancellation',
+                  description:
+                      'This feature will automatically cancel the alarm if you are connected to the specified wifi network',
+                  iconData: Icons.wifi,
+                  isLightMode:
+                      themeController.currentTheme.value == ThemeMode.light,
+                );
+              },
+            ),
+          ],
+        ),
+        trailing: InkWell(
+          child: Wrap(
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              Obx(
+                () => Container(
+                  width: MediaQuery.of(context).size.width *
+                      0.3, // Adjust width dynamically
+                  alignment: Alignment.centerRight,
+                  child: Text(
+                    controller.isWifiEnabled.value
+                        ? controller.wifiName.value
+                        : 'Off',
+                    textAlign: TextAlign.right,
+                    style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                          color: (controller.isWeatherEnabled.value == false)
+                              ? kprimaryDisabledTextColor
+                              : themeController.primaryTextColor.value,
+                        ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ),
+              const Icon(
+                Icons.chevron_right,
+                color: kprimaryDisabledTextColor,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class WifiOption extends StatelessWidget {
+  const WifiOption({
+    super.key,
+    required this.name,
+    required this.bssid,
+    required this.controller,
+    required this.themeController,
+  });
+
+  final AddOrUpdateAlarmController controller;
+  final ThemeController themeController;
+  final String? name;
+  final String? bssid;
+
+  @override
+  Widget build(BuildContext context) {
+    if (bssid != null) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [Text('Name: ', style: TextStyle(
+              color: themeController.primaryDisabledTextColor.value,
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+            ),),
+            const SizedBox(width: 5,),
+            Text(name!.substring(1, name!.length-1)),],
+          ),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [Text('BSSID: ', style: TextStyle(
+              color: themeController.primaryDisabledTextColor.value,
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+            ),),
+            const SizedBox(width: 5,),
+            Text(bssid!)],
+          ),
+          SizedBox(height: 20,),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: [
+              TextButton(
+                  style: ButtonStyle(
+                    backgroundColor: WidgetStatePropertyAll(themeController.primaryColor.value),
+                    foregroundColor: WidgetStatePropertyAll(themeController.secondaryTextColor.value)
+                  ),
+                  onPressed: () {
+                    controller.isWifiEnabled.value = false;
+                    controller.wifiName.value = '';
+                    controller.wifiBSSID.value = '';
+                    Get.back();
+                  },
+                  child: const Text('Cancel', style: TextStyle(fontWeight: FontWeight.w600),)),
+              TextButton(
+                  style: ButtonStyle(
+                    backgroundColor: WidgetStatePropertyAll(themeController.primaryColor.value),
+                    foregroundColor: WidgetStatePropertyAll(themeController.secondaryTextColor.value)
+                  ),
+                  onPressed: () {
+                    controller.isWifiEnabled.value = true;
+                    controller.wifiName.value = name!.substring(1, name!.length-1);
+                    controller.wifiBSSID.value = bssid!;
+                    Get.back();
+                  },
+                  child: const Text('Confirm', style: TextStyle(fontWeight: FontWeight.w600),)),
+            ],
+          )
+        ],
+      );
+    }
+    else {
+      return Column(
+        children: [
+          const Text('No Wifi Connected!'),
+          Text(
+            'Connect to a wifi network to use this feature.',
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              color: themeController.primaryDisabledTextColor.value,
+              fontSize: 14
+            ),
+          ),
+          const SizedBox(height: 20,),
+          TextButton(
+            style: ButtonStyle(
+              backgroundColor: WidgetStatePropertyAll(themeController.primaryColor.value),
+              foregroundColor: WidgetStatePropertyAll(themeController.secondaryTextColor.value)
+            ),
+            onPressed: () {
+              controller.isWifiEnabled.value = false;
+              controller.wifiName.value = '';
+              controller.wifiBSSID.value = '';
+              Get.back();
+            },
+            child: const Text('Turn this feature Off', style: TextStyle(fontWeight: FontWeight.w600),)),
+        ],
+      );
+    }
+  }
+}

--- a/lib/app/modules/home/controllers/home_controller.dart
+++ b/lib/app/modules/home/controllers/home_controller.dart
@@ -768,6 +768,10 @@ class HomeController extends GetxController {
         guardianTimer: profileModel.value.guardianTimer,
         guardian: profileModel.value.guardian,
         isCall: profileModel.value.isCall,
-        ringOn: false);
+        ringOn: false,
+        isWifiEnabled: profileModel.value.isWifiEnabled,
+        wifiName: profileModel.value.wifiName,
+        wifiBSSID: profileModel.value.wifiBSSID,
+        );
   }
 }

--- a/lib/app/utils/utils.dart
+++ b/lib/app/utils/utils.dart
@@ -76,6 +76,9 @@ class Utils {
     guardian: '',
     isCall: false,
     ringOn: false,
+    isWifiEnabled: false,
+    wifiName: '',
+    wifiBSSID: '',
   );
 
   static String formatDateTimeToHHMMSS(DateTime dateTime) {
@@ -495,6 +498,9 @@ class Utils {
       guardian: '',
       isCall: false,
       ringOn: false,
+      isWifiEnabled: false,
+      wifiName: '',
+      wifiBSSID: '',
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,7 @@ dependencies:
   intl_phone_number_input: ^0.7.4
   firebase_messaging: ^14.7.19
   shared_preferences: ^2.2.3
+  network_info_plus: ^6.1.3
 
 dev_dependencies:
   flutter_lints: ^4.0.0


### PR DESCRIPTION
### Description
This PR adds a new condition, `WiFi Based alarm cancellation`, to the Smart Controls.

By using this feature, the user will be able to auto-cancel the alarm when their device is connected to the specified Wi-Fi network.

There may occur three different conditions when alarm is about to ring (when this feature is turned ON):
- Device connected to the same Wi-Fi Network.
- Device connected to a different Wi-Fi Network.
- Device not connected to any Wi-Fi Network.

![Screenshot 2025-04-17 at 6 54 50 PM](https://github.com/user-attachments/assets/43bcfc1c-d52c-43d5-af89-7a844a15365d)


### Proposed Changes
- #### To the `Alarm Model` & `Profile Model`
```
isWifiEnabled INTEGER NOT NULL DEFAULT 0,
wifiName TEXT,
wifiBSSID TEXT
```
- A new file `wifi_based_tile.dart`
- A new Service `WifiManagerService.kt`

## Fixes #802 

## Screenshots
![Screenshot 2025-04-17 at 7 09 52 PM](https://github.com/user-attachments/assets/c7148031-9bf8-4d9b-9a51-89fe8f4da38d)

![Screenshot 2025-04-17 at 7 11 32 PM](https://github.com/user-attachments/assets/e38cc832-afa9-490b-9c4a-6c1398653037)


## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing