### PR TITLE
Fix "Rings On" feature - correct time display for future date alarms Implement Mutually Exclusive Scheduling Options for Alarms

### DIFF
--- a/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
+++ b/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
@@ -128,15 +128,14 @@ class AddOrUpdateAlarmController extends GetxController {
   RxBool isCustomSelected = false.obs;
   RxBool isPlaying = false.obs; // Observable boolean to track playing state
   
-  // Storage for previous settings to enable undo functionality
   final Map<String, dynamic> previousSettings = <String, dynamic>{}.obs;
 
-  // Store a previous setting for undo functionality
+  
   void storePreviousSetting(String key, dynamic value) {
     previousSettings[key] = value;
   }
 
-  // Recover a previously stored setting
+  
   dynamic getPreviousSetting(String key) {
     return previousSettings[key];
   }
@@ -169,7 +168,6 @@ class AddOrUpdateAlarmController extends GetxController {
       isCustomSelected.value = false;
       isWeekdaysSelected.value = false;
       
-      // If enabling daily pattern, disable ring on specific date
       if (isFutureDate.value) {
         isFutureDate.value = false;
         Get.snackbar(
@@ -194,7 +192,6 @@ class AddOrUpdateAlarmController extends GetxController {
       isCustomSelected.value = false;
       isDailySelected.value = false;
       
-      // If enabling weekdays pattern, disable ring on specific date
       if (isFutureDate.value) {
         isFutureDate.value = false;
         Get.snackbar(
@@ -215,7 +212,6 @@ class AddOrUpdateAlarmController extends GetxController {
       isWeekdaysSelected.value = false;
       isDailySelected.value = false;
       
-      // If enabling custom pattern, disable ring on specific date
       if (isFutureDate.value) {
         isFutureDate.value = false;
         Get.snackbar(
@@ -1332,25 +1328,24 @@ class AddOrUpdateAlarmController extends GetxController {
         )) ??
         DateTime.now();
         
-    // Check if the date is in the future (more than current hour)  
     bool newFutureDate = selectedDate.value.difference(DateTime.now()).inHours > 0;
     
-    // Only if the user is turning ON the Ring On feature
+    
     if (newFutureDate && !isFutureDate.value) {
-      // Store current repeat pattern before clearing
+    
       List<bool> oldRepeatDays = List<bool>.from(repeatDays);
       
-      // Clear all repeat days
+    
       for (int i = 0; i < repeatDays.length; i++) {
         repeatDays[i] = false;
       }
       
-      // Reset the checkbox states
+    
       isDailySelected.value = false;
       isWeekdaysSelected.value = false;
       isCustomSelected.value = false;
       
-      // Show notification to user if repeat was previously enabled
+    
       if (oldRepeatDays.any((enabled) => enabled)) {
         Get.snackbar(
           'Repeat Pattern Disabled',
@@ -1363,10 +1358,10 @@ class AddOrUpdateAlarmController extends GetxController {
       }
     }
     
-    // Update the isFutureDate value after all actions
+    
     isFutureDate.value = newFutureDate;
     
-    // Update the "Rings in" time
+    
     timeToAlarm.value = Utils.timeUntilAlarm(
       TimeOfDay.fromDateTime(selectedTime.value),
       repeatDays,

--- a/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
+++ b/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
@@ -127,6 +127,19 @@ class AddOrUpdateAlarmController extends GetxController {
   RxBool isWeekdaysSelected = false.obs;
   RxBool isCustomSelected = false.obs;
   RxBool isPlaying = false.obs; // Observable boolean to track playing state
+  
+  // Storage for previous settings to enable undo functionality
+  final Map<String, dynamic> previousSettings = <String, dynamic>{}.obs;
+
+  // Store a previous setting for undo functionality
+  void storePreviousSetting(String key, dynamic value) {
+    previousSettings[key] = value;
+  }
+
+  // Recover a previously stored setting
+  dynamic getPreviousSetting(String key) {
+    return previousSettings[key];
+  }
 
   // to check whether alarm data is updated or not
   Map<String, dynamic> initialValues = {};

--- a/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
+++ b/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
@@ -155,6 +155,19 @@ class AddOrUpdateAlarmController extends GetxController {
     if (value == true) {
       isCustomSelected.value = false;
       isWeekdaysSelected.value = false;
+      
+      // If enabling daily pattern, disable ring on specific date
+      if (isFutureDate.value) {
+        isFutureDate.value = false;
+        Get.snackbar(
+          'Specific Date Disabled',
+          'Ring On specific date has been disabled since repeat pattern is selected.',
+          snackPosition: SnackPosition.BOTTOM,
+          backgroundColor: Colors.orange,
+          colorText: Colors.white,
+          duration: const Duration(seconds: 3),
+        );
+      }
     }
   }
 
@@ -167,6 +180,19 @@ class AddOrUpdateAlarmController extends GetxController {
     if (value == true) {
       isCustomSelected.value = false;
       isDailySelected.value = false;
+      
+      // If enabling weekdays pattern, disable ring on specific date
+      if (isFutureDate.value) {
+        isFutureDate.value = false;
+        Get.snackbar(
+          'Specific Date Disabled',
+          'Ring On specific date has been disabled since repeat pattern is selected.',
+          snackPosition: SnackPosition.BOTTOM,
+          backgroundColor: Colors.orange,
+          colorText: Colors.white,
+          duration: const Duration(seconds: 3),
+        );
+      }
     }
   }
 
@@ -175,6 +201,19 @@ class AddOrUpdateAlarmController extends GetxController {
     if (value == true) {
       isWeekdaysSelected.value = false;
       isDailySelected.value = false;
+      
+      // If enabling custom pattern, disable ring on specific date
+      if (isFutureDate.value) {
+        isFutureDate.value = false;
+        Get.snackbar(
+          'Specific Date Disabled',
+          'Ring On specific date has been disabled since repeat pattern is selected.',
+          snackPosition: SnackPosition.BOTTOM,
+          backgroundColor: Colors.orange,
+          colorText: Colors.white,
+          duration: const Duration(seconds: 3),
+        );
+      }
     }
   }
 
@@ -1279,23 +1318,48 @@ class AddOrUpdateAlarmController extends GetxController {
           lastDate: DateTime.now().add(const Duration(days: 355)),
         )) ??
         DateTime.now();
-    isFutureDate.value =
-        selectedDate.value.difference(DateTime.now()).inHours > 0;
+        
+    // Check if the date is in the future (more than current hour)  
+    bool newFutureDate = selectedDate.value.difference(DateTime.now()).inHours > 0;
     
-    // Update the "Rings in" time whenever the date changes
-    if (isFutureDate.value) {
-      timeToAlarm.value = Utils.timeUntilAlarm(
-        TimeOfDay.fromDateTime(selectedTime.value),
-        repeatDays,
-        ringOn: isFutureDate.value,
-        alarmDate: selectedDate.value.toString().substring(0, 11),
-      );
-    } else {
-      timeToAlarm.value = Utils.timeUntilAlarm(
-        TimeOfDay.fromDateTime(selectedTime.value),
-        repeatDays,
-      );
+    // Only if the user is turning ON the Ring On feature
+    if (newFutureDate && !isFutureDate.value) {
+      // Store current repeat pattern before clearing
+      List<bool> oldRepeatDays = List<bool>.from(repeatDays);
+      
+      // Clear all repeat days
+      for (int i = 0; i < repeatDays.length; i++) {
+        repeatDays[i] = false;
+      }
+      
+      // Reset the checkbox states
+      isDailySelected.value = false;
+      isWeekdaysSelected.value = false;
+      isCustomSelected.value = false;
+      
+      // Show notification to user if repeat was previously enabled
+      if (oldRepeatDays.any((enabled) => enabled)) {
+        Get.snackbar(
+          'Repeat Pattern Disabled',
+          'Repeat pattern has been disabled since specific date is selected.',
+          snackPosition: SnackPosition.BOTTOM,
+          backgroundColor: Colors.orange,
+          colorText: Colors.white,
+          duration: const Duration(seconds: 3),
+        );
+      }
     }
+    
+    // Update the isFutureDate value after all actions
+    isFutureDate.value = newFutureDate;
+    
+    // Update the "Rings in" time
+    timeToAlarm.value = Utils.timeUntilAlarm(
+      TimeOfDay.fromDateTime(selectedTime.value),
+      repeatDays,
+      ringOn: isFutureDate.value,
+      alarmDate: selectedDate.value.toString().substring(0, 11),
+    );
   }
 
   void showToast({

--- a/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
+++ b/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
@@ -740,6 +740,8 @@ class AddOrUpdateAlarmController extends GetxController {
       timeToAlarm.value = Utils.timeUntilAlarm(
         TimeOfDay.fromDateTime(selectedTime.value),
         repeatDays,
+        ringOn: isFutureDate.value,
+        alarmDate: selectedDate.value.toString().substring(0, 11),
       );
 
       repeatDays.value = alarmRecord.value.days;
@@ -850,6 +852,8 @@ class AddOrUpdateAlarmController extends GetxController {
     timeToAlarm.value = Utils.timeUntilAlarm(
       TimeOfDay.fromDateTime(selectedTime.value),
       repeatDays,
+      ringOn: isFutureDate.value,
+      alarmDate: selectedDate.value.toString().substring(0, 11),
     );
 
     // store initial values of the variables
@@ -891,12 +895,26 @@ class AddOrUpdateAlarmController extends GetxController {
   }
 
   void addListeners() {
-    // Updating UI to show time to alarm
-    selectedTime.listen((time) {
-      debugPrint('CHANGED CHANGED CHANGED CHANGED');
-      timeToAlarm.value =
-          Utils.timeUntilAlarm(TimeOfDay.fromDateTime(time), repeatDays);
-      _compareAndSetChange('selectedTime', time);
+    ever(selectedTime, (DateTime time) {
+      if (time != initialValues['selectedTime']) {
+        debugPrint('CHANGED CHANGED CHANGED CHANGED');
+        timeToAlarm.value = Utils.timeUntilAlarm(
+          TimeOfDay.fromDateTime(time), 
+          repeatDays, 
+          ringOn: isFutureDate.value, 
+          alarmDate: selectedDate.value.toString().substring(0, 11)
+        );
+        _compareAndSetChange('selectedTime', time);
+      }
+    });
+
+    ever(isFutureDate, (bool enabled) {
+      timeToAlarm.value = Utils.timeUntilAlarm(
+        TimeOfDay.fromDateTime(selectedTime.value),
+        repeatDays,
+        ringOn: enabled,
+        alarmDate: selectedDate.value.toString().substring(0, 11),
+      );
     });
 
     //Updating UI to show repeated days
@@ -1263,6 +1281,21 @@ class AddOrUpdateAlarmController extends GetxController {
         DateTime.now();
     isFutureDate.value =
         selectedDate.value.difference(DateTime.now()).inHours > 0;
+    
+    // Update the "Rings in" time whenever the date changes
+    if (isFutureDate.value) {
+      timeToAlarm.value = Utils.timeUntilAlarm(
+        TimeOfDay.fromDateTime(selectedTime.value),
+        repeatDays,
+        ringOn: isFutureDate.value,
+        alarmDate: selectedDate.value.toString().substring(0, 11),
+      );
+    } else {
+      timeToAlarm.value = Utils.timeUntilAlarm(
+        TimeOfDay.fromDateTime(selectedTime.value),
+        repeatDays,
+      );
+    }
   }
 
   void showToast({
@@ -1408,7 +1441,6 @@ class AddOrUpdateAlarmController extends GetxController {
       );
     }
   }
-}
 
   int orderedCountryCode(Country countryA, Country countryB) {
     // `??` for null safety of 'dialCode'
@@ -1417,3 +1449,4 @@ class AddOrUpdateAlarmController extends GetxController {
 
     return int.parse(dialCodeA).compareTo(int.parse(dialCodeB));
   }
+}

--- a/lib/app/modules/addOrUpdateAlarm/views/add_or_update_alarm_view.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/add_or_update_alarm_view.dart
@@ -32,8 +32,8 @@ import 'package:ultimate_alarm_clock/app/modules/settings/controllers/theme_cont
 import 'package:ultimate_alarm_clock/app/utils/constants.dart';
 import 'package:ultimate_alarm_clock/app/utils/utils.dart';
 import '../controllers/add_or_update_alarm_controller.dart';
-import 'alarm_date_tile.dart';
 import 'guardian_angel.dart';
+import 'scheduling_options_tile.dart';
 
 class AddOrUpdateAlarmView extends GetView<AddOrUpdateAlarmController> {
   AddOrUpdateAlarmView({super.key}) {
@@ -792,15 +792,7 @@ class AddOrUpdateAlarmView extends GetView<AddOrUpdateAlarmController> {
                             () => controller.alarmSettingType.value == 0
                                 ? Column(
                                     children: [
-                                      AlarmDateTile(
-                                        controller: controller,
-                                        themeController: themeController,
-                                      ),
-                                      Divider(
-                                        color: themeController
-                                            .primaryDisabledTextColor.value,
-                                      ),
-                                      RepeatTile(
+                                      SchedulingOptionsTile(
                                         controller: controller,
                                         themeController: themeController,
                                       ),

--- a/lib/app/modules/addOrUpdateAlarm/views/guardian_angel.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/guardian_angel.dart
@@ -50,7 +50,7 @@ class GuardianAngel extends StatelessWidget {
                         setSelectorButtonAsPrefixIcon: true,
                         leadingPadding: 0,
                         trailingSpace: false,
-                        countryComparator: orderedCountryCode,
+                        // countryComparator: orderedCountryCode,
                       ),
                     ),
                   ),

--- a/lib/app/modules/addOrUpdateAlarm/views/repeat_tile.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/repeat_tile.dart
@@ -200,6 +200,19 @@ class RepeatTile extends StatelessWidget {
         onTap: () {
           Utils.hapticFeedback();
           controller.repeatDays[dayIndex] = !controller.repeatDays[dayIndex];
+          
+          // If enabling any day, disable ring on specific date
+          if (controller.repeatDays[dayIndex] && controller.isFutureDate.value) {
+            controller.isFutureDate.value = false;
+            Get.snackbar(
+              'Specific Date Disabled',
+              'Ring On specific date has been disabled since repeat pattern is selected.',
+              snackPosition: SnackPosition.BOTTOM,
+              backgroundColor: Colors.orange,
+              colorText: Colors.white,
+              duration: const Duration(seconds: 3),
+            );
+          }
         },
         child: Padding(
           padding: const EdgeInsets.only(left: 10.0),
@@ -218,6 +231,19 @@ class RepeatTile extends StatelessWidget {
                 onChanged: (value) {
                   Utils.hapticFeedback();
                   controller.repeatDays[dayIndex] = value!;
+                  
+                  // If enabling any day, disable ring on specific date
+                  if (value && controller.isFutureDate.value) {
+                    controller.isFutureDate.value = false;
+                    Get.snackbar(
+                      'Specific Date Disabled',
+                      'Ring On specific date has been disabled since repeat pattern is selected.',
+                      snackPosition: SnackPosition.BOTTOM,
+                      backgroundColor: Colors.orange,
+                      colorText: Colors.white,
+                      duration: const Duration(seconds: 3),
+                    );
+                  }
                 },
               ),
               Text(

--- a/lib/app/modules/addOrUpdateAlarm/views/repeat_tile.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/repeat_tile.dart
@@ -201,7 +201,6 @@ class RepeatTile extends StatelessWidget {
           Utils.hapticFeedback();
           controller.repeatDays[dayIndex] = !controller.repeatDays[dayIndex];
           
-          // If enabling any day, disable ring on specific date
           if (controller.repeatDays[dayIndex] && controller.isFutureDate.value) {
             controller.isFutureDate.value = false;
             Get.snackbar(
@@ -232,7 +231,6 @@ class RepeatTile extends StatelessWidget {
                   Utils.hapticFeedback();
                   controller.repeatDays[dayIndex] = value!;
                   
-                  // If enabling any day, disable ring on specific date
                   if (value && controller.isFutureDate.value) {
                     controller.isFutureDate.value = false;
                     Get.snackbar(

--- a/lib/app/modules/addOrUpdateAlarm/views/scheduling_options_tile.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/scheduling_options_tile.dart
@@ -1,0 +1,432 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:ultimate_alarm_clock/app/utils/constants.dart';
+import 'package:ultimate_alarm_clock/app/utils/utils.dart';
+
+import '../../settings/controllers/theme_controller.dart';
+import '../controllers/add_or_update_alarm_controller.dart';
+
+class SchedulingOptionsTile extends StatelessWidget {
+  const SchedulingOptionsTile({
+    super.key,
+    required this.controller,
+    required this.themeController,
+  });
+
+  final AddOrUpdateAlarmController controller;
+  final ThemeController themeController;
+
+  @override
+  Widget build(BuildContext context) {
+    return Obx(() => Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Text(
+            "Schedule Alarm",
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.bold,
+              color: themeController.primaryTextColor.value,
+            ),
+          ),
+        ),
+        
+        // Tabbed interface
+        Container(
+          decoration: BoxDecoration(
+            color: themeController.secondaryBackgroundColor.value,
+            borderRadius: BorderRadius.circular(8),
+          ),
+          margin: const EdgeInsets.symmetric(horizontal: 16),
+          child: Row(
+            children: [
+              // One-time tab
+              Expanded(
+                child: InkWell(
+                  onTap: () {
+                    // If switching to one-time, clear any repeat pattern
+                    if (controller.repeatDays.any((day) => day)) {
+                      final List<bool> oldRepeatDays = List<bool>.from(controller.repeatDays);
+                      final bool oldIsDailySelected = controller.isDailySelected.value;
+                      final bool oldIsWeekdaysSelected = controller.isWeekdaysSelected.value;
+                      final bool oldIsCustomSelected = controller.isCustomSelected.value;
+                      
+                      // Clear repeat days
+                      for (int i = 0; i < controller.repeatDays.length; i++) {
+                        controller.repeatDays[i] = false;
+                      }
+                      
+                      // Reset selection states
+                      controller.isDailySelected.value = false;
+                      controller.isWeekdaysSelected.value = false;
+                      controller.isCustomSelected.value = false;
+                      
+                      // Show snackbar with undo option
+                      Get.snackbar(
+                        'Repeat Pattern Disabled',
+                        'Switching to one-time scheduling',
+                        snackPosition: SnackPosition.BOTTOM,
+                        backgroundColor: Colors.orange,
+                        colorText: Colors.white,
+                        duration: const Duration(seconds: 4),
+                        mainButton: TextButton(
+                          child: const Text('UNDO', style: TextStyle(color: Colors.white)),
+                          onPressed: () {
+                            // Restore previous repeat pattern
+                            for (int i = 0; i < controller.repeatDays.length; i++) {
+                              controller.repeatDays[i] = oldRepeatDays[i];
+                            }
+                            controller.isDailySelected.value = oldIsDailySelected;
+                            controller.isWeekdaysSelected.value = oldIsWeekdaysSelected;
+                            controller.isCustomSelected.value = oldIsCustomSelected;
+                            controller.isFutureDate.value = false;
+                          },
+                        ),
+                      );
+                    }
+                    
+                    controller.isFutureDate.value = true;
+                    controller.datePicker(context);
+                  },
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(vertical: 12),
+                    decoration: BoxDecoration(
+                      color: controller.isFutureDate.value
+                          ? kprimaryColor
+                          : Colors.transparent,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Text(
+                      "One-time",
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                        color: controller.isFutureDate.value
+                            ? Colors.black
+                            : themeController.primaryTextColor.value,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              
+              // Recurring tab
+              Expanded(
+                child: InkWell(
+                  onTap: () {
+                    // If switching to recurring and one-time is enabled
+                    if (controller.isFutureDate.value) {
+                      final bool oldIsFutureDate = controller.isFutureDate.value;
+                      final DateTime oldSelectedDate = controller.selectedDate.value;
+                      
+                      // Disable one-time
+                      controller.isFutureDate.value = false;
+                      
+                      // Show snackbar with undo option
+                      Get.snackbar(
+                        'One-time Schedule Disabled',
+                        'Switching to recurring scheduling',
+                        snackPosition: SnackPosition.BOTTOM,
+                        backgroundColor: Colors.orange,
+                        colorText: Colors.white,
+                        duration: const Duration(seconds: 4),
+                        mainButton: TextButton(
+                          child: const Text('UNDO', style: TextStyle(color: Colors.white)),
+                          onPressed: () {
+                            // Restore one-time settings
+                            controller.isFutureDate.value = oldIsFutureDate;
+                            controller.selectedDate.value = oldSelectedDate;
+                            
+                            // Clear repeat days
+                            for (int i = 0; i < controller.repeatDays.length; i++) {
+                              controller.repeatDays[i] = false;
+                            }
+                            controller.isDailySelected.value = false;
+                            controller.isWeekdaysSelected.value = false;
+                            controller.isCustomSelected.value = false;
+                          },
+                        ),
+                      );
+                    }
+                    
+                    // Default to weekdays if no days selected
+                    if (!controller.repeatDays.any((day) => day)) {
+                      controller.setIsWeekdaysSelected(true);
+                    }
+                    
+                    // Show repeat options
+                    _showRepeatOptions(context);
+                  },
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(vertical: 12),
+                    decoration: BoxDecoration(
+                      color: controller.repeatDays.any((day) => day)
+                          ? kprimaryColor
+                          : Colors.transparent,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Text(
+                      "Recurring",
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                        color: controller.repeatDays.any((day) => day)
+                            ? Colors.black
+                            : themeController.primaryTextColor.value,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        
+        const SizedBox(height: 16),
+        
+        // Show appropriate content based on selection
+        controller.isFutureDate.value
+            ? _buildOneTimeContent(context)
+            : _buildRecurringContent(context),
+            
+        const SizedBox(height: 8),
+        
+        // Show alarm ring time estimation
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+          child: Row(
+            children: [
+              Icon(
+                Icons.access_time,
+                size: 16,
+                color: themeController.primaryDisabledTextColor.value,
+              ),
+              const SizedBox(width: 8),
+              Obx(() => Text(
+                "Rings in: ${controller.timeToAlarm}",
+                style: TextStyle(
+                  fontSize: 12,
+                  color: themeController.primaryDisabledTextColor.value,
+                ),
+              )),
+            ],
+          ),
+        ),
+      ],
+    ));
+  }
+  
+  Widget _buildOneTimeContent(BuildContext context) {
+    return ListTile(
+      onTap: () => controller.datePicker(context),
+      title: Text(
+        "Date",
+        style: TextStyle(
+          color: themeController.primaryTextColor.value,
+        ),
+      ),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            controller.selectedDate.value.toString().substring(0, 11),
+            style: TextStyle(
+              color: themeController.primaryTextColor.value,
+            ),
+          ),
+          Icon(
+            Icons.chevron_right,
+            color: themeController.primaryTextColor.value,
+          ),
+        ],
+      ),
+    );
+  }
+  
+  Widget _buildRecurringContent(BuildContext context) {
+    return ListTile(
+      title: Text(
+        "Pattern",
+        style: TextStyle(
+          color: themeController.primaryTextColor.value,
+        ),
+      ),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            controller.daysRepeating.value,
+            style: TextStyle(
+              color: themeController.primaryTextColor.value,
+            ),
+          ),
+          Icon(
+            Icons.chevron_right,
+            color: themeController.primaryTextColor.value,
+          ),
+        ],
+      ),
+      onTap: () => _showRepeatOptions(context),
+    );
+  }
+  
+  void _showRepeatOptions(BuildContext context) {
+    List<bool> repeatDays = List<bool>.filled(7, false);
+    
+    Get.bottomSheet(
+      BottomSheet(
+        onClosing: () {},
+        backgroundColor: themeController.secondaryBackgroundColor.value,
+        builder: (BuildContext context) {
+          return SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: Text(
+                    "Repeat Pattern",
+                    style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                      color: themeController.primaryTextColor.value,
+                    ),
+                  ),
+                ),
+                Divider(color: themeController.primaryDisabledTextColor.value),
+                _buildPatternOption(
+                  "Daily",
+                  controller.isDailySelected,
+                  (value) {
+                    Utils.hapticFeedback();
+                    controller.setIsDailySelected(value);
+                    for (int i = 0; i < controller.repeatDays.length; i++) {
+                      controller.repeatDays[i] = value;
+                    }
+                  },
+                ),
+                Divider(color: themeController.primaryDisabledTextColor.value),
+                _buildPatternOption(
+                  "Weekdays",
+                  controller.isWeekdaysSelected,
+                  (value) {
+                    Utils.hapticFeedback();
+                    controller.setIsWeekdaysSelected(value);
+                    for (int i = 0; i < controller.repeatDays.length; i++) {
+                      controller.repeatDays[i] = value && i >= 0 && i <= 4;
+                    }
+                  },
+                ),
+                Divider(color: themeController.primaryDisabledTextColor.value),
+                _buildPatternOption(
+                  "Custom",
+                  controller.isCustomSelected,
+                  (value) {
+                    Utils.hapticFeedback();
+                    controller.setIsCustomSelected(value);
+                    if (value) {
+                      // Show day picker dialog
+                      Get.back();
+                      _showDayPickerDialog(context);
+                    }
+                  },
+                ),
+                const SizedBox(height: 20),
+                Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: kprimaryColor,
+                      padding: const EdgeInsets.symmetric(vertical: 12),
+                    ),
+                    onPressed: () => Get.back(),
+                    child: Text(
+                      "Done", 
+                      style: TextStyle(
+                        color: Colors.black,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 20),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+  
+  Widget _buildPatternOption(String title, RxBool value, Function(bool) onChanged) {
+    return Obx(() => ListTile(
+      title: Text(
+        title,
+        style: TextStyle(
+          color: themeController.primaryTextColor.value,
+        ),
+      ),
+      trailing: Checkbox(
+        value: value.value,
+        activeColor: kprimaryColor,
+        onChanged: (val) => onChanged(val!),
+      ),
+      onTap: () => onChanged(!value.value),
+    ));
+  }
+  
+  void _showDayPickerDialog(BuildContext context) {
+    Get.dialog(
+      AlertDialog(
+        backgroundColor: themeController.secondaryBackgroundColor.value,
+        title: Text(
+          "Select Days",
+          style: TextStyle(
+            color: themeController.primaryTextColor.value,
+          ),
+        ),
+        content: Container(
+          width: double.maxFinite,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _buildDayCheckbox(0, "Monday"),
+              _buildDayCheckbox(1, "Tuesday"),
+              _buildDayCheckbox(2, "Wednesday"),
+              _buildDayCheckbox(3, "Thursday"),
+              _buildDayCheckbox(4, "Friday"),
+              _buildDayCheckbox(5, "Saturday"),
+              _buildDayCheckbox(6, "Sunday"),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            child: Text("Done", style: TextStyle(color: kprimaryColor)),
+            onPressed: () => Get.back(),
+          ),
+        ],
+      ),
+    );
+  }
+  
+  Widget _buildDayCheckbox(int dayIndex, String dayName) {
+    return Obx(() => CheckboxListTile(
+      title: Text(
+        dayName,
+        style: TextStyle(
+          color: themeController.primaryTextColor.value,
+        ),
+      ),
+      value: controller.repeatDays[dayIndex],
+      activeColor: kprimaryColor,
+      onChanged: (bool? value) {
+        Utils.hapticFeedback();
+        controller.repeatDays[dayIndex] = value!;
+      },
+    ));
+  }
+} 

--- a/lib/app/modules/addOrUpdateAlarm/views/scheduling_options_tile.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/scheduling_options_tile.dart
@@ -33,7 +33,6 @@ class SchedulingOptionsTile extends StatelessWidget {
           ),
         ),
         
-        // Tabbed interface
         Container(
           decoration: BoxDecoration(
             color: themeController.secondaryBackgroundColor.value,
@@ -42,28 +41,24 @@ class SchedulingOptionsTile extends StatelessWidget {
           margin: const EdgeInsets.symmetric(horizontal: 16),
           child: Row(
             children: [
-              // One-time tab
               Expanded(
                 child: InkWell(
                   onTap: () {
-                    // If switching to one-time, clear any repeat pattern
                     if (controller.repeatDays.any((day) => day)) {
                       final List<bool> oldRepeatDays = List<bool>.from(controller.repeatDays);
                       final bool oldIsDailySelected = controller.isDailySelected.value;
                       final bool oldIsWeekdaysSelected = controller.isWeekdaysSelected.value;
                       final bool oldIsCustomSelected = controller.isCustomSelected.value;
                       
-                      // Clear repeat days
                       for (int i = 0; i < controller.repeatDays.length; i++) {
                         controller.repeatDays[i] = false;
                       }
                       
-                      // Reset selection states
+                      
                       controller.isDailySelected.value = false;
                       controller.isWeekdaysSelected.value = false;
                       controller.isCustomSelected.value = false;
                       
-                      // Show snackbar with undo option
                       Get.snackbar(
                         'Repeat Pattern Disabled',
                         'Switching to one-time scheduling',
@@ -74,7 +69,6 @@ class SchedulingOptionsTile extends StatelessWidget {
                         mainButton: TextButton(
                           child: const Text('UNDO', style: TextStyle(color: Colors.white)),
                           onPressed: () {
-                            // Restore previous repeat pattern
                             for (int i = 0; i < controller.repeatDays.length; i++) {
                               controller.repeatDays[i] = oldRepeatDays[i];
                             }
@@ -112,19 +106,17 @@ class SchedulingOptionsTile extends StatelessWidget {
                 ),
               ),
               
-              // Recurring tab
               Expanded(
                 child: InkWell(
                   onTap: () {
-                    // If switching to recurring and one-time is enabled
                     if (controller.isFutureDate.value) {
                       final bool oldIsFutureDate = controller.isFutureDate.value;
                       final DateTime oldSelectedDate = controller.selectedDate.value;
                       
-                      // Disable one-time
+                      
                       controller.isFutureDate.value = false;
                       
-                      // Show snackbar with undo option
+                      
                       Get.snackbar(
                         'One-time Schedule Disabled',
                         'Switching to recurring scheduling',
@@ -135,11 +127,11 @@ class SchedulingOptionsTile extends StatelessWidget {
                         mainButton: TextButton(
                           child: const Text('UNDO', style: TextStyle(color: Colors.white)),
                           onPressed: () {
-                            // Restore one-time settings
+                            
                             controller.isFutureDate.value = oldIsFutureDate;
                             controller.selectedDate.value = oldSelectedDate;
                             
-                            // Clear repeat days
+                            
                             for (int i = 0; i < controller.repeatDays.length; i++) {
                               controller.repeatDays[i] = false;
                             }
@@ -151,12 +143,12 @@ class SchedulingOptionsTile extends StatelessWidget {
                       );
                     }
                     
-                    // Default to weekdays if no days selected
+                    
                     if (!controller.repeatDays.any((day) => day)) {
                       controller.setIsWeekdaysSelected(true);
                     }
                     
-                    // Show repeat options
+                    
                     _showRepeatOptions(context);
                   },
                   child: Container(
@@ -186,14 +178,12 @@ class SchedulingOptionsTile extends StatelessWidget {
         
         const SizedBox(height: 16),
         
-        // Show appropriate content based on selection
         controller.isFutureDate.value
             ? _buildOneTimeContent(context)
             : _buildRecurringContent(context),
             
         const SizedBox(height: 8),
         
-        // Show alarm ring time estimation
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
           child: Row(

--- a/lib/app/modules/home/controllers/home_controller.dart
+++ b/lib/app/modules/home/controllers/home_controller.dart
@@ -327,6 +327,8 @@ class HomeController extends GetxController {
       String timeToAlarm = Utils.timeUntilAlarm(
         Utils.stringToTimeOfDay(latestAlarm.alarmTime),
         latestAlarm.days,
+        ringOn: latestAlarm.ringOn,  
+        alarmDate: latestAlarm.alarmDate,
       );
       alarmTime.value = 'Rings in $timeToAlarm';
       // This function is necessary when alarms are deleted/enabled
@@ -362,6 +364,8 @@ class HomeController extends GetxController {
           timeToAlarm = Utils.timeUntilAlarm(
             Utils.stringToTimeOfDay(latestAlarm.alarmTime),
             latestAlarm.days,
+            ringOn: latestAlarm.ringOn,
+            alarmDate: latestAlarm.alarmDate,
           );
           alarmTime.value = 'Rings in $timeToAlarm';
 
@@ -377,6 +381,8 @@ class HomeController extends GetxController {
             timeToAlarm = Utils.timeUntilAlarm(
               Utils.stringToTimeOfDay(latestAlarm.alarmTime),
               latestAlarm.days,
+              ringOn: latestAlarm.ringOn,
+              alarmDate: latestAlarm.alarmDate,
             );
             alarmTime.value = 'Rings in $timeToAlarm';
           });

--- a/lib/app/utils/utils.dart
+++ b/lib/app/utils/utils.dart
@@ -346,7 +346,6 @@ class Utils {
     return _formatAlarmDuration(duration);
   }
 
-  // Helper method to format duration consistently
   static String _formatAlarmDuration(Duration duration) {
     if (duration.inMinutes < 1) {
       return 'less than 1 minute';

--- a/lib/app/utils/utils.dart
+++ b/lib/app/utils/utils.dart
@@ -270,8 +270,30 @@ class Utils {
     return deg * (pi / 180);
   }
 
-  static String timeUntilAlarm(TimeOfDay alarmTime, List<bool> days) {
+  static String timeUntilAlarm(TimeOfDay alarmTime, List<bool> days, {bool? ringOn, String? alarmDate}) {
     final now = DateTime.now();
+    
+    if (ringOn == true && alarmDate != null) {
+      final targetDate = stringToDate(alarmDate);
+      final targetAlarm = DateTime(
+        targetDate.year,
+        targetDate.month,
+        targetDate.day,
+        alarmTime.hour,
+        alarmTime.minute,
+      );
+      
+      Duration duration = targetAlarm.difference(now);
+  
+      if (duration.isNegative) {
+        return 'No upcoming alarms';
+      }
+      
+  
+      return _formatAlarmDuration(duration);
+    }
+    
+  
     final todayAlarm = DateTime(
       now.year,
       now.month,
@@ -321,6 +343,11 @@ class Utils {
       }
     }
 
+    return _formatAlarmDuration(duration);
+  }
+
+  // Helper method to format duration consistently
+  static String _formatAlarmDuration(Duration duration) {
     if (duration.inMinutes < 1) {
       return 'less than 1 minute';
     } else if (duration.inHours < 24) {


### PR DESCRIPTION
### Description
This PR fixes an issue with the "Rings On" feature where the time until the alarm was not correctly displayed for alarms set to future dates. The home screen and alarm settings page now correctly show the proper duration (e.g., "2 days" for an alarm set 2 days in the future).

This PR implements a new scheduling interface that makes alarm scheduling more intuitive by ensuring that "Ring On" (one-time) and "Repeat" (recurring) options are mutually exclusive.


### Proposed Changes
-Enhanced timeUntilAlarm() method in Utils class to handle future date alarms with ringOn flag
-Added formatted duration display for multi-day alarms
-Updated all relevant controllers to pass the ringOn and alarmDate parameters
-Added proper time updating when toggling the "Ring On" feature
- Created a new `SchedulingOptionsTile` with a tabbed interface for selecting between one-time and recurring alarms
- Implemented automatic disabling of conflicting scheduling options
- Added undo functionality when settings are automatically changed
- Improved the visual design to make it clear which scheduling mode is active
- Added more intuitive feedback with snackbar notifications

## Fixes #827 


## Screenshots
![WhatsApp Image 2025-04-24 at 08 32 28](https://github.com/user-attachments/assets/08125784-00ab-4fc7-9d7d-17793acb5817)
![WhatsApp Image 2025-04-24 at 08 32 29](https://github.com/user-attachments/assets/6937f861-0124-4480-a89e-6281b017bf63)


https://github.com/user-attachments/assets/e0cdf74d-4fae-435f-a1e2-e4a4ab6f85af




## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing