### PR TITLE
fix: error in alarm creation resolved

### DIFF
--- a/lib/app/modules/addOrUpdateAlarm/views/add_or_update_alarm_view.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/add_or_update_alarm_view.dart
@@ -37,12 +37,14 @@ import 'guardian_angel.dart';
 
 class AddOrUpdateAlarmView extends GetView<AddOrUpdateAlarmController> {
   AddOrUpdateAlarmView({super.key}) {
-    inputTimeController.initTimeTextField();
+   Get.delete<InputTimeController>();
+    _inputTimeController = Get.put(InputTimeController(), tag: 'alarm_input_${DateTime.now().millisecondsSinceEpoch}');
+    _inputTimeController.initTimeTextField();
   }
 
   final ThemeController themeController = Get.find<ThemeController>();
-  final InputTimeController inputTimeController =
-      Get.put(InputTimeController());
+  late final InputTimeController _inputTimeController;
+  InputTimeController get inputTimeController => _inputTimeController;
   final SettingsController settingsController = Get.find<SettingsController>();
 
   @override


### PR DESCRIPTION
### Description
When the user used to delete an alarm then the onClose() was called to Dispose all the controllers, and therefore when creating a new alarm, there was no controller available and hence the Error.

### Proposed Changes
- deleting the existing controller eveytime
- a new InputTimeController each time AddOrUpdateAlarmView is created ensures fresh TextEditingController

## Fixes #831 

## Screenshots

https://github.com/user-attachments/assets/d56098cb-bf62-44f7-9792-add67bf7a40e

https://github.com/user-attachments/assets/2b53e8aa-d88e-4b07-b742-1e5f22a28ce8



## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing