### PR TITLE
Resolves issue#827, where `timeUntilAlarm` wasn't working as Expected

### DIFF
--- a/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
+++ b/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
@@ -740,6 +740,7 @@ class AddOrUpdateAlarmController extends GetxController {
       timeToAlarm.value = Utils.timeUntilAlarm(
         TimeOfDay.fromDateTime(selectedTime.value),
         repeatDays,
+        selectedDate.value,
       );
 
       repeatDays.value = alarmRecord.value.days;
@@ -850,6 +851,7 @@ class AddOrUpdateAlarmController extends GetxController {
     timeToAlarm.value = Utils.timeUntilAlarm(
       TimeOfDay.fromDateTime(selectedTime.value),
       repeatDays,
+      selectedDate.value
     );
 
     // store initial values of the variables
@@ -895,8 +897,15 @@ class AddOrUpdateAlarmController extends GetxController {
     selectedTime.listen((time) {
       debugPrint('CHANGED CHANGED CHANGED CHANGED');
       timeToAlarm.value =
-          Utils.timeUntilAlarm(TimeOfDay.fromDateTime(time), repeatDays);
+          Utils.timeUntilAlarm(TimeOfDay.fromDateTime(time), repeatDays, selectedDate.value);
       _compareAndSetChange('selectedTime', time);
+    });
+    
+    selectedDate.listen((date) {
+      debugPrint('CHANGED CHANGED CHANGED CHANGED');
+      timeToAlarm.value =
+          Utils.timeUntilAlarm(TimeOfDay.fromDateTime(selectedTime.value), repeatDays, date);
+      _compareAndSetChange('selectedTime', date);
     });
 
     //Updating UI to show repeated days
@@ -1272,6 +1281,7 @@ class AddOrUpdateAlarmController extends GetxController {
       String timeToAlarm = Utils.timeUntilAlarm(
         Utils.stringToTimeOfDay(alarmRecord.alarmTime),
         alarmRecord.days,
+        Utils.stringToDate(alarmRecord.alarmDate),
       );
 
       Fluttertoast.showToast(

--- a/lib/app/modules/addOrUpdateAlarm/views/alarm_date_tile.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/alarm_date_tile.dart
@@ -19,7 +19,10 @@ class AlarmDateTile extends StatelessWidget {
     
     return Obx(() => InkWell(
           onTap: () async {
-            controller.datePicker(context);
+            await controller.datePicker(context);
+            if (controller.selectedDate.value != DateTime.now()) {
+              controller.repeatDays.value = [false, false, false, false, false, false, false];
+            }
           },
           child: ListTile(
 

--- a/lib/app/modules/addOrUpdateAlarm/views/repeat_tile.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/repeat_tile.dart
@@ -70,6 +70,10 @@ class RepeatTile extends StatelessWidget {
                             ),
                             onPressed: () {
                               Utils.hapticFeedback();
+                              if (controller.repeatDays != [false, false, false, false, false, false, false]) {
+                                controller.selectedDate.value = DateTime.now();
+                                controller.isFutureDate.value = false;
+                              }
                               Get.back();
                             },
                             child: Text(

--- a/lib/app/modules/home/controllers/home_controller.dart
+++ b/lib/app/modules/home/controllers/home_controller.dart
@@ -327,6 +327,7 @@ class HomeController extends GetxController {
       String timeToAlarm = Utils.timeUntilAlarm(
         Utils.stringToTimeOfDay(latestAlarm.alarmTime),
         latestAlarm.days,
+        Utils.stringToDate(latestAlarm.alarmDate),
       );
       alarmTime.value = 'Rings in $timeToAlarm';
       // This function is necessary when alarms are deleted/enabled
@@ -362,6 +363,7 @@ class HomeController extends GetxController {
           timeToAlarm = Utils.timeUntilAlarm(
             Utils.stringToTimeOfDay(latestAlarm.alarmTime),
             latestAlarm.days,
+            Utils.stringToDate(latestAlarm.alarmDate),
           );
           alarmTime.value = 'Rings in $timeToAlarm';
 
@@ -377,6 +379,7 @@ class HomeController extends GetxController {
             timeToAlarm = Utils.timeUntilAlarm(
               Utils.stringToTimeOfDay(latestAlarm.alarmTime),
               latestAlarm.days,
+              Utils.stringToDate(latestAlarm.alarmDate),
             );
             alarmTime.value = 'Rings in $timeToAlarm';
           });

--- a/lib/app/utils/utils.dart
+++ b/lib/app/utils/utils.dart
@@ -305,8 +305,7 @@ class Utils {
         duration = nextAlarm.difference(now);
       }
     } else if (now.isBefore(todayAlarm) && days[now.weekday - 1]) {
-      // If alarm is set for today and time hasn't passed
-      duration = todayAlarm.difference(now);
+        duration = todayAlarm.difference(now);
     } else {
       // Finding the next day when alarm will ring
       int daysUntilNextAlarm = 7;
@@ -315,16 +314,15 @@ class Utils {
       for (int i = 1; i <= 7; i++) {
         int nextDayIndex = (now.weekday + i - 1) % 7;
         if (days[nextDayIndex]) {
-          if (i < daysUntilNextAlarm) {
-            daysUntilNextAlarm = i;
-            nextAlarm = DateTime(
-              now.year,
-              now.month,
-              now.day + i,
-              alarmTime.hour,
-              alarmTime.minute,
-            );
-          }
+          daysUntilNextAlarm = i;
+          nextAlarm = DateTime(
+            now.year,
+            now.month,
+            now.day + i,
+            alarmTime.hour,
+            alarmTime.minute,
+          );
+          break;
         }
       }
 


### PR DESCRIPTION
### Description
Now, the alarm scheduling logic incorporates the `alarmDate` parameter into the `timeUntilAlarm` function for the calculation of a non-repeating alarm that's scheduled after some days.

Also, you can refer to this small discussion [#gsoc-ultimate-alarm-clock >  @ 💬](https://ccextractor.zulipchat.com/#narrow/channel/478731-gsoc-ultimate-alarm-clock/topic//near/514162179), regarding the `Repeat` and `Rings On` feature, where it was proposed to disable the `Rings On` when Repeat is enabled, or vice versa.

### Proposed Changes
<!-- List the proposed changes introduced by this pull request -->
- Added `alarmDate` Parameter: The `timeUntilAlarm` function now accepts an additional alarmDate parameter to handle date-based alarm scheduling.

- Controller Updates: Now, if `Rings On` is enabled or `selectedDate != DateTime.now()`, then make the `Repeat` as **Never** or `repeatDays = [false, false, false, false, false, false, false]`. Or, vice versa.

## Fixes #827  

## Screenshots
In the video below, the calculation for `Rings in __` is now accurate for alarms set on a specific date. And, selecting both a specific date alarm and a repeat alarm is not possible, since enabling one will disable the other.

https://github.com/user-attachments/assets/23e0f172-ca80-4ac9-b3be-a928bd96f491

<!-- If applicable, add screenshots or images demonstrating the changes made -->

## Checklist
<!-- Mark the completed tasks with [x] -->
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing