### PR TITLE
the orderedCountryCode function is placed outside of the controller a…

### DIFF
--- a/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
+++ b/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
@@ -1545,7 +1545,6 @@ class AddOrUpdateAlarmController extends GetxController {
                 : selectedTime.value.hour.toString()));
     inputMinutesController.text = selectedTime.value.minute.toString().padLeft(2, '0');
   }
-}
 
   int orderedCountryCode(Country countryA, Country countryB) {
     // `??` for null safety of 'dialCode'
@@ -1554,6 +1553,7 @@ class AddOrUpdateAlarmController extends GetxController {
 
     return int.parse(dialCodeA).compareTo(int.parse(dialCodeB));
   }
+}
 
 class LimitRange extends TextInputFormatter {
   LimitRange(this.minRange, this.maxRange) : assert(minRange < maxRange);

--- a/lib/app/modules/addOrUpdateAlarm/views/guardian_angel.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/guardian_angel.dart
@@ -45,12 +45,12 @@ class GuardianAngel extends StatelessWidget {
                       onInputChanged: (value) {},
                       onInputValidated: (value) {},
                       spaceBetweenSelectorAndTextField: 0,
-                      selectorConfig: const SelectorConfig(
+                      selectorConfig: SelectorConfig(
                         showFlags: true,
                         setSelectorButtonAsPrefixIcon: true,
                         leadingPadding: 0,
                         trailingSpace: false,
-                        countryComparator: orderedCountryCode,
+                        countryComparator: controller.orderedCountryCode,
                       ),
                     ),
                   ),


### PR DESCRIPTION
…nd in the guardian angel file i added countryComparator: controller.orderedCountryCode

### Description
<!-- Provide a brief description of the changes in this pull request -->

Removed the top-level orderedCountryCode function since it was duplicating what's already in the controller
Removed the unnecessary import for Country model
Changed selectorConfig from const to non-const since we're now accessing a method from the controller instance
Updated the countryComparator to use controller.orderedCountryCode instead of just orderedCountryCode