### PR TITLE
Fix TimerRingController async misuse and null-safe vibration cleanup (Fixes #854)

### DIFF
--- a/lib/app/modules/timerRing/controllers/timer_ring_controller.dart
+++ b/lib/app/modules/timerRing/controllers/timer_ring_controller.dart
@@ -12,12 +12,14 @@ class TimerRingController extends GetxController {
   MethodChannel timerChannel = const MethodChannel('timer');
   Timer? vibrationTimer;
   late StreamSubscription<FGBGType> _subscription;
-   getFakeTimerModel()async {
-   TimerModel fakeTimer = await Utils.genFakeTimerModel();
-   return fakeTimer;
+
+  Future<TimerModel> getFakeTimerModel() async {
+    TimerModel fakeTimer = await Utils.genFakeTimerModel();
+    return fakeTimer;
   }
+
   @override
-  void onInit() async {
+  Future<void> onInit() async {
     super.onInit();
 
     // Preventing app from being minimized!
@@ -30,17 +32,19 @@ class TimerRingController extends GetxController {
         Timer.periodic(const Duration(milliseconds: 3500), (Timer timer) {
       Vibration.vibrate(pattern: [500, 3000]);
     });
-    AudioUtils.playTimer(alarmRecord: await getFakeTimerModel().value);
+    final timerRecord = await getFakeTimerModel();
+    AudioUtils.playTimer(alarmRecord: timerRecord);
 
     await timerChannel.invokeMethod('cancelTimer');
   }
 
   @override
-  onClose() async {
+  Future<void> onClose() async {
     Vibration.cancel();
-    vibrationTimer!.cancel();
+    vibrationTimer?.cancel();
+    final timerRecord = await getFakeTimerModel();
     AudioUtils.stopTimer(
-      ringtoneName: await getFakeTimerModel().ringtoneName,
+      ringtoneName: timerRecord.ringtoneName,
     );
     _subscription.cancel();
     super.onClose();


### PR DESCRIPTION
This PR resolves the timer ring crash/build issue reported in #854 by correcting improper async handling in TimerRingController and making vibration timer cleanup null-safe.

Proposed Changes

Updated getFakeTimerModel() to explicitly return Future<TimerModel>.

Corrected async handling in onInit():

Replaced await getFakeTimerModel().value with:

final timerRecord = await getFakeTimerModel();

AudioUtils.playTimer(alarmRecord: timerRecord);

Fixed improper await/property access in onClose():

Replaced await getFakeTimerModel().ringtoneName with an awaited model, followed by timerRecord.ringtoneName.

Prevented potential null-related crashes:

Replaced vibrationTimer!.cancel() with vibrationTimer?.cancel().

Updated lifecycle method signatures to use explicit async return types:

Future<void> onInit()

Future<void> onClose()