### PR TITLE
Fix: Replace list equality check with isEmpty in home_controller

### DIFF
--- a/lib/app/modules/home/controllers/home_controller.dart
+++ b/lib/app/modules/home/controllers/home_controller.dart
@@ -428,7 +428,7 @@ class HomeController extends GetxController {
 
   Future<void> fetchGoogleCalendars() async {
     Calendars.value = (await GoogleCloudProvider.getCalenders()) ?? [];
-    if (Calendars.value == []) {
+    if (Calendars.value.isEmpty) {
       calendarFetchStatus.value = 'Empty';
     } else {
       calendarFetchStatus.value = 'Loaded';
@@ -437,8 +437,9 @@ class HomeController extends GetxController {
 
   Future<void> fetchEvents(String calenderId) async {
     Events.value = await GoogleCloudProvider.getEvents(calenderId) ?? [];
-    if (Events.value == []) {
+    if (Events.value.isEmpty) {
       calendarFetchStatus.value = 'Empty';
+      // print("DEBUG: Events list is empty. Setting status to Empty.");
       Get.snackbar('Events', 'No events available');
     } else {
       calendarFetchStatus.value = 'Loaded';


### PR DESCRIPTION
### Description
This PR resolves a state management bug in `home_controller.dart`. Previously, the `calendarFetchStatus` was never properly set to `'Empty'` because comparing a list to `[]` always evaluates to false in Dart due to reference equality.

### Proposed Changes
- Replaced the `Calendars.value == []` check with `Calendars.value.isEmpty` in the `fetchGoogleCalendars()` method.
- Replaced the `Events.value == []` check with `Events.value.isEmpty` in the `fetchEvents()` method.

## Fixes #862

## Screenshots

<img width="1920" height="1080" alt="Screenshot (784)" src="https://github.com/user-attachments/assets/aaf00d96-5d25-418e-b622-aea9e16ea691" />

<img width="1920" height="1080" alt="Screenshot (785)" src="https://github.com/user-attachments/assets/4909b47d-5e0d-49ee-9392-a92120d09045" />


**Note to reviewers:** I have attached screenshots verifying the app builds and runs successfully with these changes. Because I am testing on a local fork without the production `google-services.json` Firebase keys, the Google Sign-in flow blocks me from capturing the actual empty-state Snackbar UI. However, the logic fix addresses the reference equality issue as described in the ticket.

## Checklist
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing