### PR TITLE
fix: deletion UI consistency fixed

### DIFF
--- a/lib/app/modules/home/controllers/home_controller.dart
+++ b/lib/app/modules/home/controllers/home_controller.dart
@@ -67,7 +67,6 @@ class HomeController extends GetxController {
 
   RxBool isSortedAlarmListEnabled = true.obs;
   RxBool inMultipleSelectMode = false.obs;
-  RxBool isAnyAlarmHolded = false.obs;
   RxBool isAllAlarmsSelected = false.obs;
   RxInt numberOfAlarmsSelected = 0.obs;
   Pair<List<AlarmModel>, List<RxBool>> alarmListPairs = Pair([], []);
@@ -681,7 +680,6 @@ class HomeController extends GetxController {
 
                       // Closing the multiple select mode
                       inMultipleSelectMode.value = false;
-                      isAnyAlarmHolded.value = false;
                       isAllAlarmsSelected.value = false;
 
                       numberOfAlarmsSelected.value = 0;

--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -271,8 +271,6 @@ class HomeView extends GetView<HomeController> {
                                               // On pressing the close button, we're closing the multiple select mode, and clearing the select alarm set
                                               controller.inMultipleSelectMode
                                                   .value = false;
-                                              controller.isAnyAlarmHolded
-                                                  .value = false;
                                               controller.isAllAlarmsSelected
                                                   .value = false;
                                               controller.numberOfAlarmsSelected
@@ -420,7 +418,6 @@ class HomeView extends GetView<HomeController> {
 
                                                                     // Closing the multiple select mode
                                                                     controller.inMultipleSelectMode.value = false;
-                                                                    controller.isAnyAlarmHolded.value = false;
                                                                     controller.isAllAlarmsSelected.value = false;
                                                                     controller.numberOfAlarmsSelected.value = 0;
                                                                     controller.selectedAlarmSet.clear();
@@ -609,9 +606,6 @@ class HomeView extends GetView<HomeController> {
                                                       controller
                                                           .inMultipleSelectMode
                                                           .value = true;
-                                                      controller
-                                                          .isAnyAlarmHolded
-                                                          .value = true;
 
                                                       // Assigning the alarm list pairs to list of alarms and list of isSelected all equal to false initially
                                                       controller
@@ -626,17 +620,7 @@ class HomeView extends GetView<HomeController> {
 
                                                 Utils.hapticFeedback();
                                               },
-                                              onLongPressEnd: (details) {
-                                                controller
-                                                    .isAnyAlarmHolded
-                                                    .value = false;
-                                              },
-                                              child: AnimatedContainer(
-                                                duration: const Duration(
-                                                  milliseconds: 600,
-                                                ),
-                                                curve: Curves.easeInOut,
-                                                child: Center(
+                                              child:  Center(
                                                   child: Padding(
                                                     padding:
                                                     const EdgeInsets
@@ -1057,7 +1041,6 @@ class HomeView extends GetView<HomeController> {
                                                 ),
                                               ),
                                             ),
-                                          ),
                                         )
                                       : SizedBox();
                                       },

--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -636,13 +636,6 @@ class HomeView extends GetView<HomeController> {
                                                   milliseconds: 600,
                                                 ),
                                                 curve: Curves.easeInOut,
-                                                margin: EdgeInsets.all(
-                                                  controller
-                                                      .isAnyAlarmHolded
-                                                          .value
-                                                      ? 10
-                                                      : 0,
-                                                ),
                                                 child: Center(
                                                   child: Padding(
                                                     padding:


### PR DESCRIPTION
### Description
Whenever an alarm is longpressed, the app goes into deletion mode. This deletion mode however shows the alarm separation getting wider with significant frame drops at times making it laggy and inconsistent. This PR fixes that.

### Proposed Changes
- Instead of Animated Container, use a simple widget which does not have to change margins.

## Fixes #871 

This issue is fixed and addressed by this PR. However, please let me know if you want some animation inside the alarm card itself, which will make it both consistent and less sudden for going into Deletion mode from Normal mode.

## Screenshots

A Screen Recording for after the fix:

https://github.com/user-attachments/assets/340aa850-4659-445c-b5d3-1e73903e8f72



## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing