### PR TITLE
fix: the long pressed alarm is selected by default in Multiple Select Mode

### DIFF
--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -613,15 +613,25 @@ class HomeView extends GetView<HomeController> {
                                                           .isAnyAlarmHolded
                                                           .value = true;
 
-                                                      // Assigning the alarm list pairs to list of alarms and list of isSelected all equal to false initially
+                                                      // Assigning the alarm list pairs to list of alarms and list of isSelected
+                                                      // The long-pressed alarm is selected by default
                                                       controller
                                                               .alarmListPairs =
                                                           Pair(
                                                         alarms,
                                                         List.generate(
                                                           alarms.length,
-                                                          (index) => false.obs,
+                                                          (i) => (i == index).obs,
                                                         ),
+                                                      );
+
+                                                      // The long-pressed alarm added to the selected set
+                                                      controller.numberOfAlarmsSelected.value = 1;
+                                                      controller.selectedAlarmSet.clear();
+                                                      controller.selectedAlarmSet.add(
+                                                        alarm.isSharedAlarmEnabled
+                                                            ? Pair(alarm.firestoreId, true)
+                                                            : Pair(alarm.isarId, false),
                                                       );
 
                                                 Utils.hapticFeedback();


### PR DESCRIPTION
### Description
The long-pressed alarm is now selected by default for deletion.

### Proposed Changes
Instead of initialising the whole array of isSelected to false, we only change the current index alarm isSelected to true to make it selected.

## Fixes #873 

This PR fixes the issue completely.

## Screenshots

Here is the screen recording after the issue is fixed:

https://github.com/user-attachments/assets/2bf72186-0f92-4458-81da-1fc34f50f562



## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing