### PR TITLE
fix: corrected date suffix logic for 11th, 12th, and 13th

### DIFF
--- a/lib/app/utils/utils.dart
+++ b/lib/app/utils/utils.dart
@@ -212,18 +212,20 @@ class Utils {
     if (day >= 11 && day <= 13) {
       daySuffix = 'th';
     }
-    switch (day % 10) {
-      case 1:
-        daySuffix = 'st';
-        break;
-      case 2:
-        daySuffix = 'nd';
-        break;
-      case 3:
-        daySuffix = 'rd';
-        break;
-      default:
-        daySuffix = 'th';
+    else{
+      switch (day % 10) {
+        case 1:
+          daySuffix = 'st';
+          break;
+        case 2:
+          daySuffix = 'nd';
+          break;
+        case 3:
+          daySuffix = 'rd';
+          break;
+        default:
+          daySuffix = 'th';
+      }
     }
 
     return '$formattedDate$daySuffix';


### PR DESCRIPTION
### Description
This PR fixes a date formatting bug where the 11th, 12th, and 13th days of the month were incorrectly displayed with the wrong suffixes (e.g., "11st", "12nd", "13rd").

### Proposed Changes
* Updated the `getFormattedDate()` function in `lib/app/utils/utils.dart`.
* Added an `else` block to the existing `if (day >= 11 && day <= 13)` condition. This prevents the subsequent `switch (day % 10)` statement from executing and incorrectly overwriting the valid `'th'` suffix.

## Fixes #875

## Screenshots

**Before (Bug: "12nd"):**

<img width="1920" height="1080" alt="Screenshot (889)" src="https://github.com/user-attachments/assets/140e0c0a-61a7-4f37-9170-4c1c613c544c" />

**After (Fixed: "12th"):**

<img width="1920" height="1080" alt="Screenshot (890)" src="https://github.com/user-attachments/assets/55490b26-0055-4a69-a43b-e53ff3f34c96" />

## Checklist
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing