### PR TITLE
fix: prevent memory leak by cancelling all timers in onClose

### DIFF
--- a/lib/app/modules/home/controllers/home_controller.dart
+++ b/lib/app/modules/home/controllers/home_controller.dart
@@ -420,10 +420,12 @@ class HomeController extends GetxController {
   @override
   void onClose() {
     super.onClose();
-
-    if (delayToSchedule != null) {
-      delayToSchedule!.cancel();
-    }
+    // Cancel the periodic UI update timer
+    _timer.cancel(); 
+    // Cancel the delay timer if it was currently waiting
+    _delayTimer?.cancel();
+    // Cancel the scheduling delay timer
+    delayToSchedule?.cancel();
   }
 
   Future<void> fetchGoogleCalendars() async {


### PR DESCRIPTION
### Description
This PR addresses a memory leak in the `HomeController` where background timers were not being properly disposed of when the controller was closed.

### Proposed Changes
* Modified the `onClose()` method in `lib/app/modules/home/controllers/home_controller.dart`.
* Added explicit `.cancel()` calls for the periodic `_timer` and the nullable `_delayTimer`.
* This ensures that background processes are halted when the user navigates away from the Home screen, saving battery and preventing potential null-pointer exceptions during UI updates.

## Fixes #884 

## Screenshots
N/A - This is a background performance fix. No visible UI changes, but it improves memory management and battery efficiency.

## Checklist
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing