### PR TITLE
Centralize alarm PendingIntent identities

### DIFF
--- a/android/app/src/main/kotlin/com/ccextractor/ultimate_alarm_clock/ultimate_alarm_clock/AlarmPendingIntents.kt
+++ b/android/app/src/main/kotlin/com/ccextractor/ultimate_alarm_clock/ultimate_alarm_clock/AlarmPendingIntents.kt
@@ -1,0 +1,48 @@
+package com.ccextractor.ultimate_alarm_clock
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+
+internal enum class AlarmPendingIntentKind(
+    val requestCode: Int,
+    val isBroadcast: Boolean,
+) {
+    MAIN_ALARM(0, true),
+    LEGACY_BOOT_ALARM(1, true),
+    ACTIVITY_CHECK(4, false),
+    LOCATION_CHECK(5, false),
+    WEATHER_CHECK(6, false),
+}
+
+internal object AlarmPendingIntents {
+    private const val FLAGS = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+
+    fun broadcast(
+        context: Context,
+        kind: AlarmPendingIntentKind,
+        intent: Intent,
+    ): PendingIntent {
+        require(kind.isBroadcast) { "$kind must use a broadcast PendingIntent" }
+        return PendingIntent.getBroadcast(
+            context,
+            kind.requestCode,
+            intent,
+            FLAGS
+        )
+    }
+
+    fun service(
+        context: Context,
+        kind: AlarmPendingIntentKind,
+        intent: Intent,
+    ): PendingIntent {
+        require(!kind.isBroadcast) { "$kind must use a service PendingIntent" }
+        return PendingIntent.getService(
+            context,
+            kind.requestCode,
+            intent,
+            FLAGS
+        )
+    }
+}

--- a/android/app/src/main/kotlin/com/ccextractor/ultimate_alarm_clock/ultimate_alarm_clock/BootReceiver.kt
+++ b/android/app/src/main/kotlin/com/ccextractor/ultimate_alarm_clock/ultimate_alarm_clock/BootReceiver.kt
@@ -2,7 +2,6 @@ package com.ccextractor.ultimate_alarm_clock
 
 import android.annotation.SuppressLint
 import android.app.AlarmManager
-import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -68,18 +67,16 @@ class BootReceiver : BroadcastReceiver() {
     fun scheduleAlarm(milliSeconds: Long, context: Context, activityMonitor: Any) {
         val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
         val intent = Intent(context, AlarmReceiver::class.java)
-        val pendingIntent = PendingIntent.getBroadcast(
+        val pendingIntent = AlarmPendingIntents.broadcast(
             context,
-            1,
-            intent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+            AlarmPendingIntentKind.LEGACY_BOOT_ALARM,
+            intent
         )
         val activityCheckIntent = Intent(context, ScreenMonitorService::class.java)
-        val pendingActivityCheckIntent = PendingIntent.getService(
+        val pendingActivityCheckIntent = AlarmPendingIntents.service(
             context,
-            4,
-            activityCheckIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+            AlarmPendingIntentKind.ACTIVITY_CHECK,
+            activityCheckIntent
         )
         // Schedule the alarm
         val tenMinutesInMilliseconds = 600000L

--- a/android/app/src/main/kotlin/com/ccextractor/ultimate_alarm_clock/ultimate_alarm_clock/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/ccextractor/ultimate_alarm_clock/ultimate_alarm_clock/MainActivity.kt
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint
 import android.app.ActivityManager
 import android.app.AlarmManager
 import android.app.NotificationManager
-import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
@@ -211,18 +210,16 @@ class MainActivity : FlutterActivity() {
 
         val alarmManager = getSystemService(Context.ALARM_SERVICE) as AlarmManager
         val intent = Intent(this, AlarmReceiver::class.java)
-        val pendingIntent = PendingIntent.getBroadcast(
+        val pendingIntent = AlarmPendingIntents.broadcast(
             this,
-            0,
-            intent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+            AlarmPendingIntentKind.MAIN_ALARM,
+            intent
         )
         val activityCheckIntent = Intent(this, ScreenMonitorService::class.java)
-        val pendingActivityCheckIntent = PendingIntent.getService(
+        val pendingActivityCheckIntent = AlarmPendingIntents.service(
             this,
-            4,
-            activityCheckIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+            AlarmPendingIntentKind.ACTIVITY_CHECK,
+            activityCheckIntent
         )
         // Schedule the alarm
         val tenMinutesInMilliseconds = 600000L
@@ -254,11 +251,10 @@ class MainActivity : FlutterActivity() {
             editor.putInt("flutter.is_location_on", 1)
             editor.apply()
             val locationAlarmIntent = Intent(this, LocationFetcherService::class.java)
-            val pendingLocationAlarmIntent = PendingIntent.getService(
+            val pendingLocationAlarmIntent = AlarmPendingIntents.service(
                 this,
-                5,
-                locationAlarmIntent,
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+                AlarmPendingIntentKind.LOCATION_CHECK,
+                locationAlarmIntent
             )
             val alarmClockInfo = AlarmManager.AlarmClockInfo(triggerTime - 10000, pendingIntent)
             alarmManager.setAlarmClock(
@@ -273,11 +269,10 @@ class MainActivity : FlutterActivity() {
             Log.d("we", getWeatherConditions(weatherTypes))
             editor.apply()
             val weatherAlarmIntent = Intent(this, WeatherFetcherService::class.java)
-            val pendingWeatherAlarmIntent = PendingIntent.getService(
+            val pendingWeatherAlarmIntent = AlarmPendingIntents.service(
                 this,
-                6,
-                weatherAlarmIntent,
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+                AlarmPendingIntentKind.WEATHER_CHECK,
+                weatherAlarmIntent
             )
             val alarmClockInfo = AlarmManager.AlarmClockInfo(triggerTime - 10000, pendingIntent)
             alarmManager.setAlarmClock(
@@ -295,26 +290,47 @@ class MainActivity : FlutterActivity() {
     private fun cancelAllScheduledAlarms() {
         val alarmManager = getSystemService(Context.ALARM_SERVICE) as AlarmManager
         val intent = Intent(this, AlarmReceiver::class.java)
-        val pendingIntent = PendingIntent.getBroadcast(
+        val pendingIntent = AlarmPendingIntents.broadcast(
             this,
-            0,
-            intent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+            AlarmPendingIntentKind.MAIN_ALARM,
+            intent
+        )
+        val legacyBootPendingIntent = AlarmPendingIntents.broadcast(
+            this,
+            AlarmPendingIntentKind.LEGACY_BOOT_ALARM,
+            intent
         )
 
         val activityCheckIntent = Intent(this, ScreenMonitorService::class.java)
-        val pendingActivityCheckIntent = PendingIntent.getService(
+        val pendingActivityCheckIntent = AlarmPendingIntents.service(
             this,
-            4,
-            activityCheckIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+            AlarmPendingIntentKind.ACTIVITY_CHECK,
+            activityCheckIntent
+        )
+        val locationIntent = Intent(this, LocationFetcherService::class.java)
+        val pendingLocationIntent = AlarmPendingIntents.service(
+            this,
+            AlarmPendingIntentKind.LOCATION_CHECK,
+            locationIntent
+        )
+        val weatherIntent = Intent(this, WeatherFetcherService::class.java)
+        val pendingWeatherIntent = AlarmPendingIntents.service(
+            this,
+            AlarmPendingIntentKind.WEATHER_CHECK,
+            weatherIntent
         )
 
         // Cancel any existing alarms by providing the same pending intent
         alarmManager.cancel(pendingIntent)
         pendingIntent.cancel()
+        alarmManager.cancel(legacyBootPendingIntent)
+        legacyBootPendingIntent.cancel()
         alarmManager.cancel(pendingActivityCheckIntent)
         pendingActivityCheckIntent.cancel()
+        alarmManager.cancel(pendingLocationIntent)
+        pendingLocationIntent.cancel()
+        alarmManager.cancel(pendingWeatherIntent)
+        pendingWeatherIntent.cancel()
 
     }
 

--- a/android/app/src/test/kotlin/com/ccextractor/ultimate_alarm_clock/ultimate_alarm_clock/AlarmPendingIntentContractTest.kt
+++ b/android/app/src/test/kotlin/com/ccextractor/ultimate_alarm_clock/ultimate_alarm_clock/AlarmPendingIntentContractTest.kt
@@ -1,0 +1,25 @@
+package com.ccextractor.ultimate_alarm_clock
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AlarmPendingIntentContractTest {
+    @Test
+    fun `main and legacy boot alarms keep different request codes`() {
+        assertNotEquals(
+            AlarmPendingIntentKind.MAIN_ALARM.requestCode,
+            AlarmPendingIntentKind.LEGACY_BOOT_ALARM.requestCode
+        )
+        assertTrue(AlarmPendingIntentKind.MAIN_ALARM.isBroadcast)
+        assertTrue(AlarmPendingIntentKind.LEGACY_BOOT_ALARM.isBroadcast)
+    }
+
+    @Test
+    fun `service request codes stay stable`() {
+        assertEquals(4, AlarmPendingIntentKind.ACTIVITY_CHECK.requestCode)
+        assertEquals(5, AlarmPendingIntentKind.LOCATION_CHECK.requestCode)
+        assertEquals(6, AlarmPendingIntentKind.WEATHER_CHECK.requestCode)
+    }
+}


### PR DESCRIPTION
## Summary
- centralize alarm PendingIntent request codes and creation in one helper
- reuse that helper from MainActivity and BootReceiver so scheduling and cancellation target the same identities
- cancel the legacy boot-restored alarm identity alongside the current alarm identity
- add a native regression test for the stable PendingIntent request-code contract

## Testing
- branch diff against main reduced to the intended 4 files
- native unit test remains blocked on current main in this environment because the repo still uses the removed imperative Flutter Gradle plugin loader

Closes #887