### PR TITLE
Fix alarm not being saved due to premature navigation in permission c…

### DIFF
--- a/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
+++ b/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
@@ -195,10 +195,11 @@ class AddOrUpdateAlarmController extends GetxController {
     }
   }
 
-  checkOverlayPermissionAndNavigate() async {
-    if (!(await Permission.systemAlertWindow.isGranted) &&
+  Future<bool> checkOverlayPermission() async {
+    if (!(await Permission.systemAlertWindow.isGranted) ||
         !(await Permission.ignoreBatteryOptimizations.isGranted)) {
-      Get.defaultDialog(
+      bool result = false;
+      await Get.defaultDialog(
         backgroundColor: themeController.secondaryBackgroundColor.value,
         title: 'Permission Required',
         titleStyle: TextStyle(
@@ -208,8 +209,8 @@ class AddOrUpdateAlarmController extends GetxController {
             const EdgeInsets.symmetric(vertical: 20, horizontal: 20),
         titlePadding: const EdgeInsets.only(top: 30, right: 40),
         content: const Text(
-          'This app requires permission to draw overlays,send notifications'
-          ' and Ignore batter optimization.',
+          'This app requires permission to draw overlays, send notifications'
+          ' and ignore battery optimization for the alarm to work reliably.',
         ),
         actions: [
           TextButton(
@@ -218,6 +219,7 @@ class AddOrUpdateAlarmController extends GetxController {
             ),
             child: const Text('Cancel', style: TextStyle(color: Colors.black)),
             onPressed: () {
+              result = false;
               Get.back();
             },
           ),
@@ -233,47 +235,30 @@ class AddOrUpdateAlarmController extends GetxController {
               style: TextStyle(color: Colors.black),
             ),
             onPressed: () async {
-              Get.back();
-
               if (Platform.isAndroid) {
                 // Request overlay permission
                 if (!(await Permission.systemAlertWindow.isGranted)) {
-                  final status = await Permission.systemAlertWindow.request();
-                  if (!status.isGranted) {
-                    debugPrint('SYSTEM_ALERT_WINDOW permission denied!');
-                    return;
-                  }
+                  await Permission.systemAlertWindow.request();
                 }
 
                 if (!(await Permission.ignoreBatteryOptimizations.isGranted)) {
-                  bool requested = await Permission.ignoreBatteryOptimizations
-                      .request()
-                      .isGranted;
-                  if (!requested) {
-                    debugPrint(
-                      'IGNORE_BATTERY_OPTIMIZATION permission denied!',
-                    );
-                    return;
-                  }
+                  await Permission.ignoreBatteryOptimizations.request();
+                }
+
+                // Request notification permission
+                if (!await Permission.notification.isGranted) {
+                  await Permission.notification.request();
                 }
               }
-
-              // Request notification permission
-              if (!await Permission.notification.isGranted) {
-                final status = await Permission.notification.request();
-                if (status != PermissionStatus.granted) {
-                  debugPrint('Notification permission denied!');
-                  return;
-                }
-              }
-
+              result = true;
               Get.back();
             },
           ),
         ],
       );
+      return result;
     } else {
-      Get.back();
+      return true;
     }
   }
 

--- a/lib/app/modules/addOrUpdateAlarm/views/add_or_update_alarm_view.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/add_or_update_alarm_view.dart
@@ -1044,11 +1044,10 @@ class AddOrUpdateAlarmView extends GetView<AddOrUpdateAlarmController> {
                         ),
                         onPressed: () async {
                           Utils.hapticFeedback();
-                          await controller.checkOverlayPermissionAndNavigate();
+                          bool hasPermission =
+                              await controller.checkOverlayPermission();
 
-                          if ((await Permission.systemAlertWindow.isGranted) &&
-                              (await Permission
-                                  .ignoreBatteryOptimizations.isGranted)) {
+                          if (hasPermission) {
                             if (!controller.homeController.isProfile.value) {
                               if (controller.userModel.value != null) {
                                 controller.offsetDetails[
@@ -1178,18 +1177,19 @@ class AddOrUpdateAlarmView extends GetView<AddOrUpdateAlarmController> {
                                   await controller
                                       .updateAlarm(updatedAlarmModel);
                                 }
+                                Get.back();
                               } catch (e) {
                                 debugPrint(e.toString());
                               }
                             } else {
-                              controller.createProfile();
+                              await controller.createProfile();
+                              Get.back();
                             }
                           }
                         },
                       ),
                     ),
-                  ),
-          ],
+            )],
         ),
       ),
     );


### PR DESCRIPTION
### Description

This PR fixes an issue where alarms were not being saved when pressing the **Save** button.

The root cause was that `checkOverlayPermissionAndNavigate()` triggered `Get.back()` before the alarm creation logic (`createAlarm` / `updateAlarm`) executed. This caused the screen to close prematurely and the alarm was never persisted.

### Changes
- Refactored permission logic to `Future<bool> checkOverlayPermission()`
- Removed premature navigation inside the permission function
- Updated the Save button logic to proceed only if permission is granted
- Ensured `Get.back()` is called **after** alarm creation/update

### Result
- Alarms are now correctly saved
- Newly created alarms appear immediately in the list
- Alarm persistence works across app restarts

## Testing
Tested on a physical Android device:
1. Created a new alarm
2. Verified the alarm appears in the alarm list
3. Verified the alarm record appears in the ISAR database
4. Restarted the app and confirmed the alarm persists

## Fixes #896


## Screenshots

![WhatsApp Image 2026-03-14 at 2 04 45 AM](https://github.com/user-attachments/assets/5f03b750-cae4-42c5-bc1e-e84a3227cb75)


<img width="1879" height="870" alt="image" src="https://github.com/user-attachments/assets/c98bbc08-128d-4952-9b92-65eb29348233" />

The screenshot shows alarms appearing correctly in both the UI and the ISAR database.

## Checklist

- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [ ] All tests are passing