### PR TITLE
fix: add graceful UI fallback for system ringtones on iOS

### DIFF
--- a/lib/app/modules/addOrUpdateAlarm/views/ringtone_selection_page.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/ringtone_selection_page.dart
@@ -159,7 +159,29 @@ class RingtoneSelectionPage extends GetView<AddOrUpdateAlarmController> {
     );
   }
 
+  // Widget _buildSystemRingtonesTab() {
+  //   return SystemRingtonePicker(
+  //     isFullScreen: true,
+  //   );
+  // }
   Widget _buildSystemRingtonesTab() {
+    if (GetPlatform.isIOS) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32.0),
+          child: Text(
+            'System ringtones are currently only supported on Android.\n\nPlease upload a custom ringtone to use this feature.',
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              color: themeController.primaryTextColor.value.withOpacity(0.7),
+              fontSize: 16,
+              height: 1.5,
+            ),
+          ),
+        ),
+      );
+    }
+
     return SystemRingtonePicker(
       isFullScreen: true,
     );


### PR DESCRIPTION
### Description
This PR resolves a UX bug where iOS users are presented with a completely blank screen when navigating to the "System Ringtones" tab. Because Apple's iOS sandbox restricts third-party apps from accessing native system notification sounds, the ringtone provider correctly returns an empty list. This PR intercepts that state and provides a graceful UI fallback, vastly improving the UX for iPhone users and maintaining the app's polished feel.

### Proposed Changes
- Added a `GetPlatform.isIOS` check inside `_buildSystemRingtonesTab()` in `ringtone_selection_page.dart`.
- Intercepted the empty list render and replaced it with a centered, user-friendly `Text` widget explaining the platform limitation.
- Styled the fallback message using the existing `themeController` to ensure perfect contrast and readability in both Light and Dark modes.

## Fixes #899 

## Checklist
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing