### PR TITLE
fix: resolve exponential timer drain in wake-up challenges by adding …

### DIFF
--- a/lib/app/modules/alarmChallenge/controllers/alarm_challenge_controller.dart
+++ b/lib/app/modules/alarmChallenge/controllers/alarm_challenge_controller.dart
@@ -15,6 +15,7 @@ class AlarmChallengeController extends GetxController {
   AlarmModel alarmRecord = Get.arguments;
 
   final RxDouble progress = 1.0.obs;
+  int _timerSessionId = 0;
 
   final RxInt shakedCount = 0.obs;
   final isShakeOngoing = Status.initialized.obs;
@@ -204,7 +205,15 @@ class AlarmChallengeController extends GetxController {
     const totalIterations = 1500000;
     const decrement = 0.000001;
 
+    // Capture the current session ID for this specific async loop
+    final int currentSessionId = _timerSessionId;
+
     for (var i = totalIterations; i > 0; i--) {
+      // If the global session ID has changed, kill this orphaned loop immediately
+      if (currentSessionId != _timerSessionId) {
+        break;
+      }
+
       if (!isTimerEnabled) {
         debugPrint('THIS IS THE BUG');
         break;
@@ -220,9 +229,35 @@ class AlarmChallengeController extends GetxController {
   }
 
   restartTimer() {
+    _timerSessionId++; // Increment ID to kill any existing async loops
     progress.value = 1.0; // Reset the progress to its initial value
     _startTimer(); // Start a new timer
   }
+
+  // void _startTimer() async {
+  //   const duration = Duration(seconds: 15);
+  //   const totalIterations = 1500000;
+  //   const decrement = 0.000001;
+
+  //   for (var i = totalIterations; i > 0; i--) {
+  //     if (!isTimerEnabled) {
+  //       debugPrint('THIS IS THE BUG');
+  //       break;
+  //     }
+  //     if (progress.value <= 0.0) {
+  //       shouldProcessStepCount = false;
+  //       Get.until((route) => route.settings.name == '/alarm-ring');
+  //       break;
+  //     }
+  //     await Future.delayed(duration ~/ i);
+  //     progress.value -= decrement;
+  //   }
+  // }
+
+  // restartTimer() {
+  //   progress.value = 1.0; // Reset the progress to its initial value
+  //   _startTimer(); // Start a new timer
+  // }
 
   isChallengesComplete() {
     if (!Utils.isChallengeEnabled(alarmRecord)) {


### PR DESCRIPTION
### Description
This PR addresses a critical concurrency bug in `alarm_challenge_controller.dart` where multiple asynchronous `_startTimer()` loops could run simultaneously. Previously, calling `restartTimer()` spawned a new `for` loop without terminating the old one, leading to an exponential drain on the progress bar and causing users to unfairly fail wake-up challenges.

### Proposed Changes
- Introduced a `_timerSessionId` state variable to track the active timer lifecycle.
- Updated `restartTimer()` to increment the session ID upon invocation.
- Added a cancellation check `(if (currentSessionId != _timerSessionId) break;)` inside the `_startTimer()` async loop. This acts as a cancellation token, instantly killing orphaned loops and ensuring only a single asynchronous loop modifies `progress.value` at any given time.

## Fixes #901 

## Screenshots
*(Not applicable - backend logic and concurrency fix)*

## Checklist
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing