### PR TITLE
Implement a graceful UI fallback when system ringtones are unavailable on iOS

### DIFF
--- a/lib/app/modules/addOrUpdateAlarm/views/ringtone_selection_page.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/ringtone_selection_page.dart
@@ -159,7 +159,29 @@ class RingtoneSelectionPage extends GetView<AddOrUpdateAlarmController> {
     );
   }
 
+  // Widget _buildSystemRingtonesTab() {
+  //   return SystemRingtonePicker(
+  //     isFullScreen: true,
+  //   );
+  // }
   Widget _buildSystemRingtonesTab() {
+    if (GetPlatform.isIOS) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32.0),
+          child: Text(
+            'System ringtones are currently only supported on Android.\n\nPlease upload a custom ringtone to use this feature.',
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              color: themeController.primaryTextColor.value.withOpacity(0.7),
+              fontSize: 16,
+              height: 1.5,
+            ),
+          ),
+        ),
+      );
+    }
+
     return SystemRingtonePicker(
       isFullScreen: true,
     );


### PR DESCRIPTION
Description
Fixes a UX issue where iOS users see a blank screen when opening the System Ringtones tab. Since iOS sandbox restrictions prevent third-party apps from accessing native system notification sounds, the ringtone provider returns an empty list.

This PR adds a graceful UI fallback that displays a clear message explaining the limitation instead of showing an empty screen.

Changes
Added GetPlatform.isIOS check in _buildSystemRingtonesTab() (ringtone_selection_page.dart)

Replaced empty list state with a centered explanatory Text widget

Styled the fallback message using themeController to support both Light and Dark modes

Checklist:
 Tests added or updated

 Documentation updated

 Code follows project style guidelines

 All tests passing