### PR TITLE
fix: replace raw print/debugPrint with structured logging

### DIFF
--- a/lib/app/data/providers/google_cloud_api_provider.dart
+++ b/lib/app/data/providers/google_cloud_api_provider.dart
@@ -89,7 +89,9 @@ class GoogleCloudProvider {
       await _firebaseAuthInstance.signOut();
       await getInstance();
     }
-    final authHeaders = await _googleSignIn.currentUser!.authHeaders;
+    final currentUser = _googleSignIn.currentUser;
+    if (currentUser == null) return null;
+    final authHeaders = await currentUser.authHeaders;
     final httpClient = GoogleHttpClient(authHeaders);
     var dataList = await CalendarApi(httpClient).calendarList.list();
 
@@ -101,8 +103,12 @@ class GoogleCloudProvider {
   }
 
   static Future<List<Event>?> getEvents(String calenderId) async {
-    await getInstance();
-    final authHeaders = await _googleSignIn.currentUser!.authHeaders;
+    if (_googleSignIn.currentUser == null) {
+      await getInstance();
+    }
+    final currentUser = _googleSignIn.currentUser;
+    if (currentUser == null) return null;
+    final authHeaders = await currentUser.authHeaders;
     final httpClient = GoogleHttpClient(authHeaders);
     var dataList = await CalendarApi(httpClient).events.list(calenderId);
     if (dataList.items != null) {

--- a/lib/app/data/providers/isar_provider.dart
+++ b/lib/app/data/providers/isar_provider.dart
@@ -331,6 +331,9 @@ class IsarDb {
         .and()
         .alarmTimeEqualTo(time)
         .findAll();
+    if (alarms.isEmpty) {
+      throw StateError('No enabled alarm found for time: $time');
+    }
     return alarms.first;
   }
 

--- a/lib/app/data/providers/push_notifications.dart
+++ b/lib/app/data/providers/push_notifications.dart
@@ -1,10 +1,15 @@
 import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:ultimate_alarm_clock/app/utils/app_logger.dart';
 
 class PushNotifications {
   static final _firebaseMessaging = FirebaseMessaging.instance;
   static Future init() async {
     await _firebaseMessaging.requestPermission(announcement: true);
     final token = await _firebaseMessaging.getToken();
-    print("token - $token");
+    if (token == null || token.isEmpty) {
+      AppLogger.w('Push token was unavailable', tag: 'PushNotifications');
+      return;
+    }
+    AppLogger.i('Push token fetched successfully', tag: 'PushNotifications');
   }
 }

--- a/lib/app/modules/addOrUpdateAlarm/views/ringtone_selection_page.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/ringtone_selection_page.dart
@@ -159,7 +159,29 @@ class RingtoneSelectionPage extends GetView<AddOrUpdateAlarmController> {
     );
   }
 
+  // Widget _buildSystemRingtonesTab() {
+  //   return SystemRingtonePicker(
+  //     isFullScreen: true,
+  //   );
+  // }
   Widget _buildSystemRingtonesTab() {
+    if (GetPlatform.isIOS) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32.0),
+          child: Text(
+            'System ringtones are currently only supported on Android.\n\nPlease upload a custom ringtone to use this feature.',
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              color: themeController.primaryTextColor.value.withOpacity(0.7),
+              fontSize: 16,
+              height: 1.5,
+            ),
+          ),
+        ),
+      );
+    }
+
     return SystemRingtonePicker(
       isFullScreen: true,
     );

--- a/lib/app/modules/addOrUpdateAlarm/views/ringtone_selection_page.dart
+++ b/lib/app/modules/addOrUpdateAlarm/views/ringtone_selection_page.dart
@@ -159,11 +159,6 @@ class RingtoneSelectionPage extends GetView<AddOrUpdateAlarmController> {
     );
   }
 
-  // Widget _buildSystemRingtonesTab() {
-  //   return SystemRingtonePicker(
-  //     isFullScreen: true,
-  //   );
-  // }
   Widget _buildSystemRingtonesTab() {
     if (GetPlatform.isIOS) {
       return Center(

--- a/lib/app/modules/notifications/controllers/notifications_controller.dart
+++ b/lib/app/modules/notifications/controllers/notifications_controller.dart
@@ -8,8 +8,6 @@ import '../../../data/providers/firestore_provider.dart';
 import '../../home/controllers/home_controller.dart';
 
 class NotificationsController extends GetxController {
-  //TODO: Implement NotificationsController
-
   late List notifications = [].obs;
   HomeController homeController = Get.find<HomeController>();
   late List allProfiles = [].obs;

--- a/lib/app/modules/timer/views/timer_animation.dart
+++ b/lib/app/modules/timer/views/timer_animation.dart
@@ -4,6 +4,7 @@ import 'package:get/get.dart';
 import 'package:ultimate_alarm_clock/app/data/models/timer_model.dart';
 import 'package:ultimate_alarm_clock/app/data/providers/isar_provider.dart';
 import 'package:ultimate_alarm_clock/app/modules/timer/controllers/timer_controller.dart';
+import 'package:ultimate_alarm_clock/app/utils/app_logger.dart';
 import 'package:ultimate_alarm_clock/app/utils/constants.dart';
 
 import '../../../utils/utils.dart';
@@ -32,7 +33,7 @@ class _TimerAnimatedCardState extends State<TimerAnimatedCard>
   Timer? _timerCounter;
   void startTimer() {
     _timerCounter = Timer.periodic(Duration(seconds: 1), (timer) {
-      print('${widget.timer.timerName}');
+      AppLogger.d('Timer tick for ${widget.timer.timerName}', tag: 'TimerAnimatedCard');
       if (widget.timer.timeElapsed < widget.timer.timerValue) {
         setState(() {
           widget.timer.timeElapsed += 1000;

--- a/lib/app/utils/app_logger.dart
+++ b/lib/app/utils/app_logger.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/foundation.dart';
+
+class AppLogger {
+  static void d(String message, {String tag = 'App'}) {
+    if (!kDebugMode) return;
+    debugPrint('[DEBUG][$tag] ${_redact(message)}');
+  }
+
+  static void i(String message, {String tag = 'App'}) {
+    debugPrint('[INFO][$tag] ${_redact(message)}');
+  }
+
+  static void w(String message, {String tag = 'App'}) {
+    debugPrint('[WARN][$tag] ${_redact(message)}');
+  }
+
+  static void e(
+    String message, {
+    String tag = 'App',
+    Object? error,
+    StackTrace? stackTrace,
+  }) {
+    final safeMessage = _redact(message);
+    final safeError = error == null ? '' : ' | error=${_redact(error.toString())}';
+    debugPrint('[ERROR][$tag] $safeMessage$safeError');
+    if (stackTrace != null && kDebugMode) {
+      debugPrint(stackTrace.toString());
+    }
+  }
+
+  static String _redact(String input) {
+    var output = input;
+    output = output.replaceAll(
+      RegExp(r'(?i)(token\s*[:=\-]?\s*)([^,\s]+)'),
+      r'$1[REDACTED]',
+    );
+    output = output.replaceAll(
+      RegExp(r'[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}'),
+      '[REDACTED_EMAIL]',
+    );
+    output = output.replaceAll(RegExp(r'content://\S+'), '[REDACTED_URI]');
+    return output;
+  }
+}

--- a/lib/app/utils/system_ringtone_service.dart
+++ b/lib/app/utils/system_ringtone_service.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'package:flutter/services.dart';
 import 'package:ultimate_alarm_clock/app/data/models/system_ringtone_model.dart';
+import 'package:ultimate_alarm_clock/app/utils/app_logger.dart';
 
 class SystemRingtoneService {
   static const MethodChannel _channel = MethodChannel('system_ringtones');
@@ -19,7 +20,11 @@ class SystemRingtoneService {
         return SystemRingtoneModel.fromMap(Map<String, dynamic>.from(item));
       }).toList();
     } catch (e) {
-      print('Error getting system ringtones: $e');
+      AppLogger.e(
+        'Error getting system ringtones',
+        tag: 'SystemRingtoneService',
+        error: e,
+      );
       return [];
     }
   }
@@ -40,7 +45,11 @@ class SystemRingtoneService {
       
       return allRingtones;
     } catch (e) {
-      print('Error getting all system ringtones: $e');
+      AppLogger.e(
+        'Error getting all system ringtones',
+        tag: 'SystemRingtoneService',
+        error: e,
+      );
       return [];
     }
   }
@@ -61,7 +70,11 @@ class SystemRingtoneService {
       
       return categorizedRingtones;
     } catch (e) {
-      print('Error getting categorized system ringtones: $e');
+      AppLogger.e(
+        'Error getting categorized system ringtones',
+        tag: 'SystemRingtoneService',
+        error: e,
+      );
       return {};
     }
   }
@@ -72,13 +85,23 @@ class SystemRingtoneService {
     }
 
     try {
-      print('🔊 SystemRingtoneService: Attempting to play ringtone: $ringtoneUri');
+      AppLogger.i(
+        'Attempting to play ringtone',
+        tag: 'SystemRingtoneService',
+      );
       await _channel.invokeMethod('playSystemRingtone', {
         'ringtoneUri': ringtoneUri,
       });
-      print('✅ SystemRingtoneService: Successfully called platform method');
+      AppLogger.i(
+        'Successfully called platform play method',
+        tag: 'SystemRingtoneService',
+      );
     } catch (e) {
-      print('❌ SystemRingtoneService: Error playing system ringtone: $e');
+      AppLogger.e(
+        'Error playing system ringtone',
+        tag: 'SystemRingtoneService',
+        error: e,
+      );
     }
   }
 
@@ -88,11 +111,15 @@ class SystemRingtoneService {
     }
 
     try {
-      print('🛑 SystemRingtoneService: Stopping system ringtone');
+      AppLogger.i('Stopping system ringtone', tag: 'SystemRingtoneService');
       await _channel.invokeMethod('stopSystemRingtone');
-      print('✅ SystemRingtoneService: Successfully stopped ringtone');
+      AppLogger.i('Successfully stopped ringtone', tag: 'SystemRingtoneService');
     } catch (e) {
-      print('❌ SystemRingtoneService: Error stopping system ringtone: $e');
+      AppLogger.e(
+        'Error stopping system ringtone',
+        tag: 'SystemRingtoneService',
+        error: e,
+      );
     }
   }
 
@@ -102,11 +129,15 @@ class SystemRingtoneService {
     }
 
     try {
-      print('🔍 SystemRingtoneService: Running audio diagnostics...');
+      AppLogger.i('Running audio diagnostics', tag: 'SystemRingtoneService');
       await _channel.invokeMethod('testAudio');
-      print('✅ SystemRingtoneService: Audio test completed');
+      AppLogger.i('Audio test completed', tag: 'SystemRingtoneService');
     } catch (e) {
-      print('❌ SystemRingtoneService: Audio test failed: $e');
+      AppLogger.e(
+        'Audio test failed',
+        tag: 'SystemRingtoneService',
+        error: e,
+      );
     }
   }
 } 


### PR DESCRIPTION
## Changes made
- added a centralized AppLogger utility with level-based methods (debug/info/warn/error)
- added basic redaction for tokens, emails, and content URIs
- replaced raw print usage in:
  - lib/app/utils/system_ringtone_service.dart
  - lib/app/data/providers/push_notifications.dart
  - lib/app/modules/timer/views/timer_animation.dart
- stopped logging raw push token values and switched to safe status logs

## Why
Reduces noisy logs and avoids leaking internal/sensitive values in production paths.

Fixes #912