### PR TITLE
Fix: Remove duplicate and unused imports in end_drawer.dart

### DIFF
--- a/lib/app/utils/end_drawer.dart
+++ b/lib/app/utils/end_drawer.dart
@@ -5,8 +5,6 @@ import 'package:ultimate_alarm_clock/app/routes/app_pages.dart';
 import 'package:ultimate_alarm_clock/app/utils/constants.dart';
 import 'package:ultimate_alarm_clock/app/utils/utils.dart';
 import 'package:ultimate_alarm_clock/app/modules/debug/views/debug_view.dart';
-import 'package:ultimate_alarm_clock/app/modules/debug/views/debug_view.dart';
-import 'package:ultimate_alarm_clock/app/modules/debug/controllers/debug_controller.dart';
 
 Widget buildEndDrawer(BuildContext context) {
   ThemeController themeController = Get.find<ThemeController>();


### PR DESCRIPTION
## Summary
Fixes #914

## Changes
- Removed duplicate import of debug_view.dart (lines 7-8)
- Removed unused import of DebugController (line 9)

## Why
- Duplicate imports trigger Dart analyzer warnings
- Unused imports trigger analyzer warnings
- These warnings can fail CI pipelines that treat warnings as errors

## Testing
The changes only remove unused/duplicate imports. No functional changes. Ready for merge once CI passes.