### PR TITLE
fix: replace print() with debugPrint() across controllers and services

### DIFF
--- a/lib/app/data/providers/push_notifications.dart
+++ b/lib/app/data/providers/push_notifications.dart
@@ -1,10 +1,11 @@
 import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/foundation.dart';
 
 class PushNotifications {
   static final _firebaseMessaging = FirebaseMessaging.instance;
   static Future init() async {
     await _firebaseMessaging.requestPermission(announcement: true);
     final token = await _firebaseMessaging.getToken();
-    print("token - $token");
+    debugPrint("token - $token");
   }
 }

--- a/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
+++ b/lib/app/modules/addOrUpdateAlarm/controllers/add_or_update_alarm_controller.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_map/flutter_map.dart';
@@ -659,7 +660,7 @@ class AddOrUpdateAlarmController extends GetxController {
       }
     } else {
       // Making sure the alarm wasn't suddenly updated to be an offline alarm
-      print('aid = ${alarmRecord.value.alarmID}');
+      debugPrint('aid = ${alarmRecord.value.alarmID}');
       if (await IsarDb.doesAlarmExist(alarmRecord.value.alarmID) == true) {
         alarmData.isarId = alarmRecord.value.isarId;
         await IsarDb.updateAlarm(alarmData);
@@ -1417,9 +1418,9 @@ class AddOrUpdateAlarmController extends GetxController {
       if (homeController.isProfileUpdate.value) {
         var profileId =
             await IsarDb.profileId(homeController.selectedProfile.value);
-        print(profileId);
+        debugPrint(profileId.toString());
         if (profileId != 'null') profileModel.isarId = profileId;
-        print(profileModel.isarId);
+        debugPrint(profileModel.isarId.toString());
         await IsarDb.updateAlarmProfiles(profileTextEditingController.text);
       }
 

--- a/lib/app/modules/alarmRing/controllers/alarm_ring_controller.dart
+++ b/lib/app/modules/alarmRing/controllers/alarm_ring_controller.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:math';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -396,9 +397,9 @@ class AlarmControlController extends GetxController {
             'milliSeconds': intervaltoAlarm,
             'activityMonitor': latestAlarm.activityMonitor
           });
-          print("Scheduled...");
+          debugPrint("Scheduled...");
         } on PlatformException catch (e) {
-          print("Failed to schedule alarm: ${e.message}");
+          debugPrint("Failed to schedule alarm: ${e.message}");
         }
       }
     }

--- a/lib/app/modules/home/controllers/home_controller.dart
+++ b/lib/app/modules/home/controllers/home_controller.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:googleapis/calendar/v3.dart' as CalendarApi;
 import 'package:intl/intl.dart';
@@ -410,9 +411,9 @@ class HomeController extends GetxController {
           'milliSeconds': intervaltoAlarm,
           'activityMonitor': latestAlarm.activityMonitor,
         });
-        print('Scheduled...');
+        debugPrint('Scheduled...');
       } on PlatformException catch (e) {
-        print('Failed to schedule alarm: ${e.message}');
+        debugPrint('Failed to schedule alarm: ${e.message}');
       }
     }
   }
@@ -444,7 +445,7 @@ class HomeController extends GetxController {
       calendarFetchStatus.value = 'Loaded';
       isCalender.value = false;
     }
-    print(Events.value);
+    debugPrint(Events.value.toString());
   }
 
   Future<void> setAlarmFromEvent(CalendarApi.Event event, String date) async {

--- a/lib/app/modules/splashScreen/controllers/splash_screen_controller.dart
+++ b/lib/app/modules/splashScreen/controllers/splash_screen_controller.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
@@ -106,7 +107,7 @@ class SplashScreenController extends GetxController {
     alarmChannel.setMethodCallHandler((call) async {
       if (call.method == 'appStartup') {
         bool shouldAlarmRing = call.arguments['shouldAlarmRing'];
-        print("shouldring: $shouldAlarmRing");
+        debugPrint("shouldring: $shouldAlarmRing");
         // This indicates the app was started through native code
         if (shouldAlarmRing == true) {
           shouldNavigate = false;
@@ -166,9 +167,9 @@ class SplashScreenController extends GetxController {
                     'milliSeconds': intervaltoAlarm,
                     'activityMonitor': latestAlarm.activityMonitor
                   });
-                  print("Scheduled...");
+                  debugPrint("Scheduled...");
                 } on PlatformException catch (e) {
-                  print("Failed to schedule alarm: ${e.message}");
+                  debugPrint("Failed to schedule alarm: ${e.message}");
                 }
               }
               SystemNavigator.pop();

--- a/lib/app/modules/timer/controllers/timer_controller.dart
+++ b/lib/app/modules/timer/controllers/timer_controller.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
@@ -118,24 +119,24 @@ class TimerController extends FullLifeCycleController with FullLifeCycleMixin {
   void startRinger(int id) async {
     try {
       isRinging.value.add(id);
-      print(isRinging.value);
+      debugPrint(isRinging.value.toString());
       if (isRinging.value.length == 1) {
         await timerChannel.invokeMethod('playDefaultAlarm');
       }
     } on PlatformException catch (e) {
-      print('Failed to schedule alarm: ${e.message}');
+      debugPrint('Failed to schedule alarm: ${e.message}');
     }
   }
 
   void stopRinger(int id) async {
     try {
       isRinging.value.remove(id);
-      print(isRinging.value);
+      debugPrint(isRinging.value.toString());
       if (isRinging.value.length == 0) {
         await timerChannel.invokeMethod('stopDefaultAlarm');
       }
     } on PlatformException catch (e) {
-      print('Failed to schedule alarm: ${e.message}');
+      debugPrint('Failed to schedule alarm: ${e.message}');
     }
   }
 
@@ -174,7 +175,7 @@ class TimerController extends FullLifeCycleController with FullLifeCycleMixin {
       await timerChannel.invokeMethod('runtimerNotif');
       Get.back();
     } on PlatformException catch (e) {
-      print('Failed to schedule alarm: ${e.message}');
+      debugPrint('Failed to schedule alarm: ${e.message}');
       Get.back();
     }
   }
@@ -191,7 +192,7 @@ class TimerController extends FullLifeCycleController with FullLifeCycleMixin {
       await timerChannel.invokeMethod('clearTimerNotif');
       Get.back();
     } on PlatformException catch (e) {
-      print('Failed to schedule alarm: ${e.message}');
+      debugPrint('Failed to schedule alarm: ${e.message}');
       Get.back();
     }
   }

--- a/lib/app/utils/system_ringtone_service.dart
+++ b/lib/app/utils/system_ringtone_service.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:ultimate_alarm_clock/app/data/models/system_ringtone_model.dart';
 
@@ -19,7 +20,7 @@ class SystemRingtoneService {
         return SystemRingtoneModel.fromMap(Map<String, dynamic>.from(item));
       }).toList();
     } catch (e) {
-      print('Error getting system ringtones: $e');
+      debugPrint('Error getting system ringtones: $e');
       return [];
     }
   }
@@ -40,7 +41,7 @@ class SystemRingtoneService {
       
       return allRingtones;
     } catch (e) {
-      print('Error getting all system ringtones: $e');
+      debugPrint('Error getting all system ringtones: $e');
       return [];
     }
   }
@@ -61,7 +62,7 @@ class SystemRingtoneService {
       
       return categorizedRingtones;
     } catch (e) {
-      print('Error getting categorized system ringtones: $e');
+      debugPrint('Error getting categorized system ringtones: $e');
       return {};
     }
   }
@@ -72,13 +73,13 @@ class SystemRingtoneService {
     }
 
     try {
-      print('🔊 SystemRingtoneService: Attempting to play ringtone: $ringtoneUri');
+      debugPrint('🔊 SystemRingtoneService: Attempting to play ringtone: $ringtoneUri');
       await _channel.invokeMethod('playSystemRingtone', {
         'ringtoneUri': ringtoneUri,
       });
-      print('✅ SystemRingtoneService: Successfully called platform method');
+      debugPrint('✅ SystemRingtoneService: Successfully called platform method');
     } catch (e) {
-      print('❌ SystemRingtoneService: Error playing system ringtone: $e');
+      debugPrint('❌ SystemRingtoneService: Error playing system ringtone: $e');
     }
   }
 
@@ -88,11 +89,11 @@ class SystemRingtoneService {
     }
 
     try {
-      print('🛑 SystemRingtoneService: Stopping system ringtone');
+      debugPrint('🛑 SystemRingtoneService: Stopping system ringtone');
       await _channel.invokeMethod('stopSystemRingtone');
-      print('✅ SystemRingtoneService: Successfully stopped ringtone');
+      debugPrint('✅ SystemRingtoneService: Successfully stopped ringtone');
     } catch (e) {
-      print('❌ SystemRingtoneService: Error stopping system ringtone: $e');
+      debugPrint('❌ SystemRingtoneService: Error stopping system ringtone: $e');
     }
   }
 
@@ -102,11 +103,11 @@ class SystemRingtoneService {
     }
 
     try {
-      print('🔍 SystemRingtoneService: Running audio diagnostics...');
+      debugPrint('🔍 SystemRingtoneService: Running audio diagnostics...');
       await _channel.invokeMethod('testAudio');
-      print('✅ SystemRingtoneService: Audio test completed');
+      debugPrint('✅ SystemRingtoneService: Audio test completed');
     } catch (e) {
-      print('❌ SystemRingtoneService: Audio test failed: $e');
+      debugPrint('❌ SystemRingtoneService: Audio test failed: $e');
     }
   }
 } 


### PR DESCRIPTION
## Summary
Closes #912

Replaced all 30 `print()` calls with `debugPrint()` across 7 files 
to follow Flutter best practices for production logging.

## Files Changed
| File | Replacements |
|------|-------------|
| system_ringtone_service.dart | 12 |
| splash_screen_controller.dart | 3 |
| timer_controller.dart | 6 |
| home_controller.dart | 3 |
| alarm_ring_controller.dart | 2 |
| add_or_update_alarm_controller.dart | 3 |
| push_notifications.dart | 1 |
| **Total** | **30** |

## Why This Matters
- `print()` runs in release builds causing unnecessary overhead
- `debugPrint()` is automatically stripped in production builds
- Added missing `flutter/foundation.dart` imports where needed

## Testing Done
- `flutter analyze` confirms no new warnings introduced