### PR TITLE
fix: safely merge headers in GoogleHttpClient to prevent unmodifiable…

### DIFF
--- a/lib/app/utils/GoogleHttpClient.dart
+++ b/lib/app/utils/GoogleHttpClient.dart
@@ -11,6 +11,6 @@ class GoogleHttpClient extends IOClient {
 
   @override
   Future<Response> head(Uri url, {Map<String, String>? headers}) =>
-      super.head(url, headers: headers?..addAll(_headers));
+      super.head(url, headers: {...?headers, ..._headers});
 
 }


### PR DESCRIPTION
### Description
This PR addresses a critical, silent runtime crash in `GoogleHttpClient.dart`. Previously, the `.head()` method override attempted to directly mutate the incoming `headers` map using the cascade operator (`..addAll()`). If a developer or third-party package passed a `const` map into this parameter, it triggered a fatal `UnsupportedError: Cannot modify unmodifiable map`, crashing the app.

### Proposed Changes
- Replaced the mutating cascade operator (`headers?..addAll(_headers)`) with the Dart spread operator (`{...?headers, ..._headers}`).
- This ensures that a brand new, mutable `Map` object is instantiated in memory before merging the internal headers with the user-provided headers. 
- Strict immutability rules are now respected, and the client will safely execute regardless of whether a standard `Map` or a `const Map` is passed.

## Fixes #927 

## Screenshots / Testing
Since this is a background networking fix, there are no UI changes. I wrote a standalone Dart script to isolate the `GoogleHttpClient` and explicitly feed it a `const` map to verify the fix natively. 

**Terminal Output proving the fix:**
```text
--- Testing head() request with a const map ---
✅ SUCCESS: The maps merged safely using the spread operator. No crash!
```

## Checklist
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing