### PR TITLE
fix: guarantee isPreviewing state reset using finally block in audio_…

### DIFF
--- a/lib/app/utils/audio_utils.dart
+++ b/lib/app/utils/audio_utils.dart
@@ -237,10 +237,12 @@ class AudioUtils {
         await alarmChannel.invokeMethod('stopDefaultAlarm');
         await SystemRingtoneService.stopSystemRingtone();
         await audioSession!.setActive(false);
-        isPreviewing = false;
       }
     } catch (e) {
       debugPrint(e.toString());
+    } finally {
+      // Guaranteed to execute even if the native channels throw an error!
+      isPreviewing = false; 
     }
   }
 


### PR DESCRIPTION
### Description
This PR addresses a silent state management leak in `audio_utils.dart`. Previously, the `stopPreviewCustomSound()` method only reset the `isPreviewing` flag if all asynchronous native audio teardown calls succeeded. If any native channel threw an exception, the reset was bypassed, permanently locking the app into an invalid state.

### Proposed Changes
- Relocated `isPreviewing = false;` from the bottom of the `try` block into a `finally` block.
- This guarantees the state is properly cleaned up regardless of native channel successes or failures.

## Fixes #929 

## Screenshots
*(Note: This is an internal state logic fix, so there are no UI changes. Code has been manually reviewed to ensure proper `try/catch/finally` control flow).*

## Checklist
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing