### PR TITLE
Make foreground service startup API-safe for minSdk 24

### DIFF
--- a/android/app/src/main/kotlin/com/ccextractor/ultimate_alarm_clock/ultimate_alarm_clock/Utilities/LocationFetcherService.kt
+++ b/android/app/src/main/kotlin/com/ccextractor/ultimate_alarm_clock/ultimate_alarm_clock/Utilities/LocationFetcherService.kt
@@ -10,6 +10,7 @@ import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.content.SharedPreferences
 import android.hardware.display.DisplayManager
+import android.os.Build
 import android.os.IBinder
 import android.os.SystemClock.sleep
 import android.util.Log
@@ -40,7 +41,7 @@ class LocationFetcherService : Service() {
         displayManager = getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
 
         createNotificationChannel()
-        startForeground(notificationId, getNotification(), ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION)
+        startForegroundCompat()
         var fetchLocationDeffered = async {
             fetchLocation()
         }
@@ -148,6 +149,15 @@ class LocationFetcherService : Service() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         return START_STICKY
+    }
+
+    private fun startForegroundCompat() {
+        val notification = getNotification()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(notificationId, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION)
+        } else {
+            startForeground(notificationId, notification)
+        }
     }
 
     private fun getNotification(): Notification {

--- a/android/app/src/main/kotlin/com/ccextractor/ultimate_alarm_clock/ultimate_alarm_clock/Utilities/WeatherFetcherService.kt
+++ b/android/app/src/main/kotlin/com/ccextractor/ultimate_alarm_clock/ultimate_alarm_clock/Utilities/WeatherFetcherService.kt
@@ -9,6 +9,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
 import android.hardware.display.DisplayManager
+import android.os.Build
 import android.os.IBinder
 import android.util.Log
 import androidx.core.app.NotificationCompat
@@ -179,8 +180,17 @@ class WeatherFetcherService() : Service() {
 
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        startForeground(notificationId, getNotification(), ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION)
+        startForegroundCompat()
         return START_STICKY
+    }
+
+    private fun startForegroundCompat() {
+        val notification = getNotification()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(notificationId, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION)
+        } else {
+            startForeground(notificationId, notification)
+        }
     }
 
     private fun getNotification(): Notification {


### PR DESCRIPTION
## Title

Fix foreground service startup compatibility across API levels

---

## Description

This PR ensures safe and compatible usage of `startForeground` across different Android API levels.

### Changes

* Added API-gated foreground startup helper in `LocationFetcherService`
* Added API-gated foreground startup helper in `WeatherFetcherService`
* Used 3-argument `startForeground` only on API 29+
* Used 2-argument `startForeground` for older API levels (minSdk 24 compatible)

---

## Issue

Refs #934

---

## Why

The 3-argument `startForeground` overload (with service type) is API-level dependent. This change preserves correct behavior on newer Android versions while ensuring compatibility with lower supported versions.

---

## Testing

* Verified no errors in modified Kotlin files
* Changes limited to foreground service startup paths

---

## Notes

* No breaking changes
* No impact on existing functionality
