### PR TITLE
Add visible remove action for World Clock entries

### DIFF
--- a/lib/app/modules/worldClock/views/world_clock_view.dart
+++ b/lib/app/modules/worldClock/views/world_clock_view.dart
@@ -99,6 +99,13 @@ class WorldClockView extends GetView<WorldClockController> {
                   controller: controller,
                   themeController: themeController,
                   is24Hour: is24Hour,
+                  onRemove: () async {
+                    final shouldRemove =
+                        await _confirmRemove(context, clock.cityName);
+                    if (shouldRemove) {
+                      controller.removeClock(userIndex);
+                    }
+                  },
                 ),
               ),
             );
@@ -316,12 +323,14 @@ class _ClockCard extends StatelessWidget {
   final WorldClockController controller;
   final ThemeController themeController;
   final bool is24Hour;
+  final VoidCallback onRemove;
 
   const _ClockCard({
     required this.clock,
     required this.controller,
     required this.themeController,
     required this.is24Hour,
+    required this.onRemove,
   });
 
   @override
@@ -346,15 +355,32 @@ class _ClockCard extends StatelessWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    clock.cityName,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      fontSize: 18,
-                      fontWeight: FontWeight.bold,
-                      color: themeController.primaryTextColor.value,
-                    ),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          clock.cityName,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            fontSize: 18,
+                            fontWeight: FontWeight.bold,
+                            color: themeController.primaryTextColor.value,
+                          ),
+                        ),
+                      ),
+                      IconButton(
+                        onPressed: onRemove,
+                        icon: Icon(
+                          Icons.delete_outline,
+                          color: themeController.primaryDisabledTextColor.value,
+                          size: 20,
+                        ),
+                        tooltip: 'Remove Clock'.tr,
+                        visualDensity: VisualDensity.compact,
+                        splashRadius: 18,
+                      ),
+                    ],
                   ),
                   const SizedBox(height: 5),
                   Text(


### PR DESCRIPTION
## Summary
- add an explicit delete icon button to each user-added World Clock card
- keep existing remove confirmation dialog before deletion
- keep swipe-to-delete behavior as an additional remove path

## Why
Users could add cities but had no obvious visible control to remove them.

## Testing
- flutter analyze lib/app/modules/worldClock/views/world_clock_view.dart (only info-level lints)


Closes #937



## Screenshots
<img width="757" height="1600" alt="WhatsApp Image 2026-04-19 at 9 14 16 AM" src="https://github.com/user-attachments/assets/5867a928-f26e-4a4c-99e4-b7f91994312b" />


<img width="757" height="1600" alt="WhatsApp Image 2026-04-19 at 9 14 16 AM (1)" src="https://github.com/user-attachments/assets/aa9b825b-d3f9-4681-942b-3d91c4949152" />


<img width="757" height="1600" alt="WhatsApp Image 2026-04-19 at 9 14 17 AM" src="https://github.com/user-attachments/assets/488b8e2f-e526-4880-a32a-aac7207b9f71" />
