### PR TITLE
fix: add error handling and UI feedback for Firestore share calls

### DIFF
--- a/lib/app/utils/share_dialog.dart
+++ b/lib/app/utils/share_dialog.dart
@@ -50,15 +50,24 @@ class ShareDialog extends StatelessWidget {
                         ),
                         onPressed: () async {
                           if (controller.selectedEmails.isNotEmpty) {
-                            if (homeController.isProfile.value) {
-                              await FirestoreDb.shareProfile(
-                                controller.selectedEmails,
-                              );
-                            } else {
-                              await FirestoreDb.shareAlarm(
-                                controller.selectedEmails,
-                                controller.alarmRecord.value,
-                              );
+                            try {
+                              if (homeController.isProfile.value) {
+                                await FirestoreDb.shareProfile(
+                                  controller.selectedEmails,
+                                );
+                              } else {
+                                await FirestoreDb.shareAlarm(
+                                  controller.selectedEmails,
+                                  controller.alarmRecord.value,
+                                );
+                              }
+                              // Give the user feedback that it actually worked!
+                              Get.snackbar('Success', 'Successfully shared!');
+                            } catch (e) {
+                              // Prevent the silent crash if they are offline
+                              Get.snackbar('Error',
+                                  'Failed to share. Please check your connection.');
+                              debugPrint('Share Error: $e');
                             }
                           } else {
                             Get.snackbar('Error', 'Select an User');


### PR DESCRIPTION
### Description
This PR addresses a silent UX failure in the `share_dialog.dart` component. Previously, the Firestore network calls for sharing alarms and profiles lacked proper error handling. If a user attempted to share an alarm while offline, or if the Firebase request timed out, the app silently swallowed the `FirebaseException` and provided no feedback, leading to a confusing user experience.

### Proposed Changes
- Wrapped the `FirestoreDb.shareProfile` and `FirestoreDb.shareAlarm` execution logic inside a `try/catch` block.
- Added a success `Get.snackbar` to explicitly confirm to the user when the sharing process completes successfully.
- Added an error `Get.snackbar` to gracefully catch exceptions and inform the user if the network call fails (e.g., "Failed to share. Please check your connection.").

## Fixes #943 

## Checklist
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing