### PR TITLE
fix: wrap hover_preset_button in Obx for reactive theme updates

### DIFF
--- a/lib/app/utils/hover_preset_button.dart
+++ b/lib/app/utils/hover_preset_button.dart
@@ -11,7 +11,7 @@ Widget hoverPresetButton(BuildContext context, String label, Duration duration) 
   final double width = MediaQuery.of(context).size.width;
   final double height = MediaQuery.of(context).size.height;
 
-  return ElevatedButton(
+  return Obx (() => ElevatedButton(
     onPressed: () {
       timerController.remainingTime.value = duration;
       timerController.createTimer();
@@ -42,5 +42,5 @@ Widget hoverPresetButton(BuildContext context, String label, Duration duration) 
         fontWeight: FontWeight.bold,
       ),
     ),
-  );
+  ));
 }


### PR DESCRIPTION
### Description
This PR addresses a UI state management leak in `hover_preset_button.dart`. Previously, the button's background color relied on a reactive GetX variable (`themeController.primaryColor.value`) but was not wrapped in an `Obx` observer. This caused the button to get "stuck" on the previous theme's color palette when a user switched between Light Mode and Dark Mode.

### Proposed Changes
- Wrapped the returned `ElevatedButton` inside `hoverPresetButton` with an `Obx(() => ...)` stream observer.
- The button now properly listens to `themeController` state changes and reactively updates its UI the instant the theme is toggled.

## Fixes #945 

## Checklist
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing